### PR TITLE
Update PIL version to 7.0

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -31,7 +31,7 @@ setup(
         "opencv-python>=3.4.1,<4.0.0",
         "pascal-voc-writer>=0.1.4",
         "PTable>=0.9.2",
-        "pillow>=5.1.0,<6.0.0",
+        "pillow>=7.0.0,<8.0",
         "protobuf>=3.7.1",
         # Higher python-json-logger versions are incompatible with
         # simplejson somehow, so for now prevent higher versions from


### PR DESCRIPTION
There is no reason to use old PIL version.
I've checked backward incompatible changes for:
- v6: https://pillow.readthedocs.io/en/stable/releasenotes/6.0.0.html#backwards-incompatible-changes
- v7: https://pillow.readthedocs.io/en/stable/releasenotes/7.0.0.html#backwards-incompatible-changes

Nothing was used in the code.