### PR TITLE
Logging project reader exception

### DIFF
--- a/supervisely/project/project.py
+++ b/supervisely/project/project.py
@@ -859,7 +859,7 @@ def read_single_project(dir, project_class=Project):
         project_fs = project_class(dir, OpenMode.READ)
         return project_fs
     except Exception as e:
-        pass
+        logger.warning("While opening project exception has occurred", exc_info=1)
 
     projects_in_dir = get_subdirs(dir)
     if len(projects_in_dir) != 1:


### PR DESCRIPTION
in previous version this method skip real traceback and misled user by second exception on row 874