### PR TITLE
fix upload_bulk (os.path.sep) -> "/"

### DIFF
--- a/supervisely/api/file_api.py
+++ b/supervisely/api/file_api.py
@@ -566,8 +566,8 @@ class FileApi(ModuleApiBase):
             name = get_file_name_with_ext(dst)
             content_dict.append((ApiField.NAME, name))
             dst_dir = os.path.dirname(dst)
-            if not dst_dir.endswith(os.path.sep):
-                dst_dir += os.path.sep
+            if not dst_dir.endswith("/"):
+                dst_dir += "/"
             content_dict.append((ApiField.PATH, dst_dir))
             content_dict.append(
                 (


### PR DESCRIPTION
The "upload" api request is handled by the remote server, that is a Unix, i suppose. So we can use a hardcoded "/" separator and don't care about the local OS.