### PR TITLE
Add tqdm dependency.

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,6 +2,7 @@
 requires = [
     "requests",
     "setuptools>=42",
-    "wheel"
+    "wheel",
+    "tqdm"
 ]
 build-backend = "setuptools.build_meta"


### PR DESCRIPTION
Seeing as `SlyTqdm` is imported when importing `supervisely`, it seems fitting to list `tqdm` as a dependency as it is not built-in module for python.