### PR TITLE
RadioGroup.get_value() fix

### DIFF
--- a/supervisely/app/widgets/radio_group/template.html
+++ b/supervisely/app/widgets/radio_group/template.html
@@ -7,7 +7,7 @@
         v-model="state.{{{widget.widget_id}}}.value"
         v-for="item in data.{{{widget.widget_id}}}.items"
         :key="item.value"
-        :label="item.label"
+        :label="item.value"
         {% if widget._size is not none %}
         :size="data.{{{widget.widget_id}}}.size"
         {% endif %}    


### PR DESCRIPTION
**RadioGroup.get_value()** returns _label_ if it was specified (not value).

Changed template.html to fix it:
```:label="item.value"```