### PR TITLE
Added list of excluded directories in enable_hot_reload_on_debug()

### DIFF
--- a/supervisely/app/fastapi/subapp.py
+++ b/supervisely/app/fastapi/subapp.py
@@ -120,8 +120,14 @@ def enable_hot_reload_on_debug(app: FastAPI):
         print("Can not detect debug mode, no sys.gettrace")
     elif gettrace():
         import arel
+        
+        # List of directories to exclude from the hot reload.
+        exclude = [".venv", ".git", "tmp"]
 
-        hot_reload = arel.HotReload(paths=[arel.Path(".")])
+        hot_reload = arel.HotReload(
+            paths=[arel.Path(path) for path in os.listdir() if path not in exclude]
+        )
+
         app.add_websocket_route("/hot-reload", route=hot_reload, name="hot-reload")
         app.add_event_handler("startup", hot_reload.startup)
         app.add_event_handler("shutdown", hot_reload.shutdown)


### PR DESCRIPTION
Right now enable_hot_reload_on_debug() function uses:
`hot_reload = arel.HotReload(paths=[arel.Path(".")])`
which in some cases leads to the infinite reload loop like this:
```
Detected file added at '.venv/bin/python', '.venv/bin/python3.10', '.venv/bin/python3'. Triggering reload...
Detected file added at '.venv/bin/python', '.venv/bin/python3.10', '.venv/bin/python3'. Triggering reload...
Detected file added at '.venv/bin/python', '.venv/bin/python3.10', '.venv/bin/python3'. Triggering reload...
```

I think we should add a list of excluded directories, which won't be scanned for changes.
Now it has the following just for example:
`exclude = [".venv", ".git", "tmp"]`

