### PR TITLE
Bugfix in Transfer widget

### DIFF
--- a/supervisely/app/widgets/transfer/transfer.py
+++ b/supervisely/app/widgets/transfer/transfer.py
@@ -139,7 +139,7 @@ class Transfer(Widget):
                  right_checked: Optional[List[str]] = None):    
         
         self._changes_handled = False
-        self._items = None
+        self._items = []
         self._transferred_items = []
         
         if items:
@@ -237,9 +237,9 @@ class Transfer(Widget):
         """
 
         res = {
-            "items": None,
+            "items": [],
         }
-        if self._items is not None:
+        if self._items:
             res["items"] = [item.to_json() for item in self._items]
 
         return res

--- a/supervisely/app/widgets/transfer/transfer.py
+++ b/supervisely/app/widgets/transfer/transfer.py
@@ -345,8 +345,11 @@ class Transfer(Widget):
 
             # As you can see, the list of items was replaced with the new one.
         """
-
-        self._items = self.__checked_items(items)
+        
+        if items:
+            self._items = self.__checked_items(items)
+        else:
+            self._items = []
 
         self.update_data()
         DataJson().send_changes()


### PR DESCRIPTION
Changed None value to [] for widget items, because the widget may disappear if the items data was None.