### PR TITLE
hotfix ImportError: cannot import name 'appengine' from 'urllib3.contrib' 

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -60,6 +60,7 @@ INSTALL_REQUIRES = [
     "click",
     "imutils==0.5.4",
     "aiocache==0.12.0",
+    "urllib3==1.26.15",
 ]
 
 ALT_INSTALL_REQUIRES = {
@@ -89,7 +90,8 @@ def check_alternative_installation(install_require, alternative_install_requires
 def get_install_requirements(main_requires, alternative_requires):
     """Iterates over all install requires
     If an install require has an alternative option, check if this option is installed
-    If that is the case, replace the install require by the alternative to not install dual package"""
+    If that is the case, replace the install require by the alternative to not install dual package
+    """
     install_requires = []
     for main_require in main_requires:
         if main_require in alternative_requires:


### PR DESCRIPTION
`The cause is that the latest version of requests does not support urllib3 2.0.0. This is fixed in kfp-2.0.0b16 ([see PR with the change](https://github.com/kubeflow/pipelines/pull/9323)), so you can either upgrade to that, or create a new image that downgrades urllib.`

- зафискировал на `urllib3==1.26.15`
- мб потом стоит проверить, пофиксили ли проблему на третьей стороне и будет иметь смысл расфиксировать?


Источник: https://stackoverflow.com/questions/76175487/sudden-importerror-cannot-import-name-appengine-from-requests-packages-urlli