### PR TITLE
fix upload_volume_project

### DIFF
--- a/supervisely/project/volume_project.py
+++ b/supervisely/project/volume_project.py
@@ -371,7 +371,7 @@ def download_volume_project(
 
 
 def upload_volume_project(dir, api: Api, workspace_id, project_name=None, log_progress=True):
-    project_fs = VolumeProject.read_single(dir)
+    project_fs = VolumeProject(dir, OpenMode.READ)
     if project_name is None:
         project_name = project_fs.name
 


### PR DESCRIPTION
[Import Volumes in Supervisely format](https://dev.supervise.ly/ecosystem/apps/import-volumes-with-anns) не импортит проекты, т.к. ищет meta.json внутри датасета, а не внутри проекта.