### PR TITLE
Fix usage of slashes in image names.

### DIFF
--- a/supervisely/project/project.py
+++ b/supervisely/project/project.py
@@ -544,6 +544,7 @@ class Dataset(KeyObject):
         if ann_path is None:
             raise RuntimeError("Item {} not found in the project.".format(item_name))
 
+        ann_path = ann_path.strip("/")
         return os.path.join(self.ann_dir, ann_path)
 
     def get_img_info_path(self, img_name: str) -> str:
@@ -970,7 +971,9 @@ class Dataset(KeyObject):
             return
 
         self._check_add_item_name(item_name)
+        item_name = item_name.strip("/")
         dst_img_path = os.path.join(self.item_dir, item_name)
+        os.makedirs(os.path.dirname(dst_img_path), exist_ok=True)
         with open(dst_img_path, "wb") as fout:
             fout.write(item_raw_bytes)
         self._validate_added_item_or_die(dst_img_path)
@@ -1143,6 +1146,7 @@ class Dataset(KeyObject):
         if type(ann) is not dict:
             raise TypeError("Ann should be a dict, not a {}".format(type(ann)))
         dst_ann_path = self.get_ann_path(item_name)
+        os.makedirs(os.path.dirname(dst_ann_path), exist_ok=True)
         dump_json_file(ann, dst_ann_path, indent=4)
 
     def get_item_paths(self, item_name: str) -> ItemPaths:


### PR DESCRIPTION
We made a habit of using directories for hierarchy in storing our data. This hierarchy is propagated to our image names in Supervisely. So for example we would have an image in `s3://bucket/foo/bar/baz.png` for some project `foo/bar` and the corresponding name in Supervisely is `/foo/bar/baz.png`. This makes it easier to track back where an image came from.

However Supervisely does not support downloading datasets with such images. There are two problems:

1. `os.path.join('/foo', '/bar') == '/bar'`, which can be fixed by stripping the starting `/`.
2. The code assumes the corresponding directory exists, but if there's slashes in the name then these are new directories, which are not created. This PR adds a call to create the required directories.