### PR TITLE
HTML tags fix in ShowDialog

### DIFF
--- a/supervisely/app/fastapi/dialog_window.html
+++ b/supervisely/app/fastapi/dialog_window.html
@@ -26,15 +26,9 @@
     ></i>
 
     <span
-      style="
-        min-height: 35px;
-        display: flex;
-        align-items: center;
-        word-break: break-word;
-      "
-    >
-      {{ data.slyAppDialogMessage }}
-    </span>
+      style="min-height: 35px; align-items: center; word-break: break-word"
+      v-html="data.slyAppDialogMessage"
+    ></span>
   </div>
 
   <div slot="footer">


### PR DESCRIPTION
sly.app.show_dialog() will render HTML tags in the widget.

