### PR TITLE
fix Mask3D array reshape + VolumeAnnotationAPI.upload_paths()

### DIFF
--- a/supervisely/api/volume/volume_annotation_api.py
+++ b/supervisely/api/volume/volume_annotation_api.py
@@ -205,7 +205,7 @@ class VolumeAnnotationAPI(EntityAnnotationAPI):
             self.append(volume_id, ann, key_id_map)
 
             # create empty figures for meshes
-            self._api.volume.figure.append_bulk(volume_id, ann.spatial_figures, key_id_map)
+            # self._api.volume.figure.append_bulk(volume_id, ann.spatial_figures, key_id_map)
             # upload existing interpolations or create on the fly and and add them to empty mesh figures
             self._api.volume.figure.upload_stl_meshes(
                 volume_id, ann.spatial_figures, key_id_map, interpolation_dir

--- a/supervisely/api/volume/volume_annotation_api.py
+++ b/supervisely/api/volume/volume_annotation_api.py
@@ -204,8 +204,6 @@ class VolumeAnnotationAPI(EntityAnnotationAPI):
             ann = VolumeAnnotation.from_json(ann_json, project_meta)
             self.append(volume_id, ann, key_id_map)
 
-            # create empty figures for meshes
-            # self._api.volume.figure.append_bulk(volume_id, ann.spatial_figures, key_id_map)
             # upload existing interpolations or create on the fly and and add them to empty mesh figures
             self._api.volume.figure.upload_stl_meshes(
                 volume_id, ann.spatial_figures, key_id_map, interpolation_dir

--- a/supervisely/geometry/mask_3d.py
+++ b/supervisely/geometry/mask_3d.py
@@ -475,11 +475,11 @@ class Mask3D(Geometry):
         try:
             data = np.frombuffer(data_bytes, dtype=np.uint8).reshape(shape)
         except ValueError:
-            logger.info(
-                "Can't reshape array with dtype=np.uint8, will try to convert from dtype=np.int16"
+            logger.warn(
+                "Can't reshape array with 'dtype=np.uint8'. Will try to automatically convert 'dtype=np.int16' to 'np.uint8' and reshape"
             )
             data = np.frombuffer(data_bytes, dtype=np.int16)
             data = np.clip(data, 0, 1).astype(np.uint8)
             data = data.reshape(shape)
-            logger.info("Converted successfully!")
+            logger.debug("Converted successfully!")
         return data

--- a/supervisely/geometry/mask_3d.py
+++ b/supervisely/geometry/mask_3d.py
@@ -19,6 +19,7 @@ from supervisely.geometry.constants import (
 from supervisely._utils import unwrap_if_numpy
 from supervisely.io.json import JsonSerializable
 from supervisely.io.fs import remove_dir
+from supervisely import logger
 import numpy as np
 import base64
 import gzip
@@ -471,5 +472,14 @@ class Mask3D(Geometry):
         shape_str, data_str = decompressed_string.split("|")
         shape = tuple(int(dim) for dim in shape_str.split(","))
         data_bytes = data_str.encode("utf-8")
-        data = np.frombuffer(data_bytes, dtype=np.uint8).reshape(shape)
+        try:
+            data = np.frombuffer(data_bytes, dtype=np.uint8).reshape(shape)
+        except ValueError:
+            logger.info(
+                "Can't reshape array with dtype=np.uint8, will try to convert from dtype=np.int16"
+            )
+            data = np.frombuffer(data_bytes, dtype=np.int16)
+            data = np.clip(data, 0, 1).astype(np.uint8)
+            data = data.reshape(shape)
+            logger.info("Converted successfully!")
         return data

--- a/supervisely/project/volume_project.py
+++ b/supervisely/project/volume_project.py
@@ -308,7 +308,7 @@ def download_volume_project(
         datasets_infos = api.dataset.get_list(project_id)
 
     for dataset in datasets_infos:
-        dataset_fs = project_fs.create_dataset(dataset.name)
+        dataset_fs: VolumeDataset = project_fs.create_dataset(dataset.name)
         volumes = api.volume.get_list(dataset.id)
 
         ds_progress = None
@@ -375,7 +375,9 @@ def download_volume_project(
     project_fs.set_key_id_map(key_id_map)
 
 
-def load_figure_data(api: Api, volume_file_path: str, spatial_figure: VolumeFigure, key_id_map: KeyIdMap):
+def load_figure_data(
+    api: Api, volume_file_path: str, spatial_figure: VolumeFigure, key_id_map: KeyIdMap
+):
     """
     Load data into figure geometry.
 
@@ -409,6 +411,7 @@ def upload_volume_project(dir, api: Api, workspace_id, project_name=None, log_pr
     api.project.update_meta(project.id, project_fs.meta.to_json())
 
     for dataset_fs in project_fs.datasets:
+        dataset_fs: VolumeDataset
         dataset = api.dataset.create(project.id, dataset_fs.name)
 
         names, item_paths, ann_paths, interpolation_dirs = [], [], [], []


### PR DESCRIPTION
1. **mask_3d**
https://github.com/supervisely/issues/issues/2920
      ```
       File "/usr/local/lib/python3.8/dist-packages/supervisely/geometry/mask_3d.py", line 474, in base64_2_data
            data = np.frombuffer(data_bytes, dtype=np.uint8).reshape(shape)
        ValueError: cannot reshape array of size 168296448 into shape (512,512,321)
      ```
      
      The np.frombuffer doesn't check the dtype, which defaults to `uint8`, but when downloading the geometry it comes in as `int16`.

2. **volume_annotation_api**
    VolumeAnnotationAPI.upload_paths()
    remove (comment) line where creating empty figures, they are already created on this step

3. volume_project
    add type annotation to make it easier to work with the code