### PR TITLE
Bytes conversion in Progress widget

### DIFF
--- a/supervisely/app/widgets/sly_tqdm/sly_tqdm.py
+++ b/supervisely/app/widgets/sly_tqdm/sly_tqdm.py
@@ -59,24 +59,17 @@ class _slyProgressBarIO:
 
         self.progress["n"] = self._n
 
-        if self.unit_scale:
-            current = self.bytes_to_unit(self._n)
-            total = self.bytes_to_unit(self.total)
-
-        else:
-            current = self._n
-            total = self.total
-
         extra = {
             "event_type": EventType.PROGRESS,
             "subtask": self.progress.get("message", None),
-            "current": current,
-            "total": total,
         }
 
-        # if self.unit != "it":
-        #     extra["current_label"] = self.unit
-        #     extra["total_label"] = self.unit
+        if self.unit_scale and self.unit != "it":
+            extra["current_label"] = f"{self.bytes_to_unit(self._n)} {self.unit}"
+            extra["total_label"] = f"{self.bytes_to_unit(self.total)} {self.unit}"
+        else:
+            extra["current"] = self._n
+            extra["total"] = self.total
 
         gettrace = getattr(sys, "gettrace", None)
         in_debug_mode = gettrace is not None and gettrace()

--- a/supervisely/app/widgets/sly_tqdm/sly_tqdm.py
+++ b/supervisely/app/widgets/sly_tqdm/sly_tqdm.py
@@ -62,14 +62,13 @@ class _slyProgressBarIO:
         extra = {
             "event_type": EventType.PROGRESS,
             "subtask": self.progress.get("message", None),
+            "current": self._n,
+            "total": self.total,
         }
 
         if self.unit_scale and self.unit != "it":
             extra["current_label"] = f"{self.bytes_to_unit(self._n)} {self.unit}"
             extra["total_label"] = f"{self.bytes_to_unit(self.total)} {self.unit}"
-        else:
-            extra["current"] = self._n
-            extra["total"] = self.total
 
         gettrace = getattr(sys, "gettrace", None)
         in_debug_mode = gettrace is not None and gettrace()

--- a/supervisely/app/widgets/sly_tqdm/sly_tqdm.py
+++ b/supervisely/app/widgets/sly_tqdm/sly_tqdm.py
@@ -74,9 +74,9 @@ class _slyProgressBarIO:
             "total": total,
         }
 
-        if self.unit != "it":
-            extra["current_label"] = self.unit
-            extra["total_label"] = self.unit
+        # if self.unit != "it":
+        #     extra["current_label"] = self.unit
+        #     extra["total_label"] = self.unit
 
         gettrace = getattr(sys, "gettrace", None)
         in_debug_mode = gettrace is not None and gettrace()

--- a/supervisely/app/widgets/sly_tqdm/sly_tqdm.py
+++ b/supervisely/app/widgets/sly_tqdm/sly_tqdm.py
@@ -75,7 +75,8 @@ class _slyProgressBarIO:
         }
 
         if self.unit != "it":
-            extra["current_label"] = extra["total_label"] = self.unit
+            extra["current_label"] = self.unit
+            extra["total_label"] = self.unit
 
         gettrace = getattr(sys, "gettrace", None)
         in_debug_mode = gettrace is not None and gettrace()

--- a/supervisely/app/widgets/sly_tqdm/sly_tqdm.py
+++ b/supervisely/app/widgets/sly_tqdm/sly_tqdm.py
@@ -5,6 +5,7 @@ import sys
 import weakref
 
 from tqdm import tqdm
+from typing import Union, Any
 
 from supervisely.app.fastapi import run_sync
 from supervisely.app import DataJson
@@ -21,8 +22,11 @@ def extract_by_regexp(regexp, string):
         return ""
 
 
+UNITS = ["B", "KB", "MB", "GB", "TB"]
+
+
 class _slyProgressBarIO:
-    def __init__(self, widget_id, message=None, total=None):
+    def __init__(self, widget_id, message=None, total=None, unit=None, unit_scale=None):
         self.widget_id = widget_id
 
         self.progress = {
@@ -35,6 +39,11 @@ class _slyProgressBarIO:
 
         self.prev_state = self.progress.copy()
         self.total = total
+
+        self.unit_scale = unit_scale
+        self.unit = unit
+        if self.unit_scale and self.unit == "B":
+            self.unit = self.get_unit()
 
         self._n = 0
 
@@ -49,11 +58,20 @@ class _slyProgressBarIO:
             return
 
         self.progress["n"] = self._n
+
+        if self.unit_scale:
+            current = self.bytes_to_unit(self._n)
+            total = self.bytes_to_unit(self.total)
+
+        else:
+            current = self._n
+            total = self.total
+
         extra = {
             "event_type": EventType.PROGRESS,
             "subtask": self.progress.get("message", None),
-            "current": self._n,
-            "total": self.total,
+            "current": current,
+            "total": total,
         }
 
         gettrace = getattr(sys, "gettrace", None)
@@ -98,15 +116,48 @@ class _slyProgressBarIO:
         self.flush(synchronize_changes=False)
         self.print_progress_to_supervisely_tasks_section()
 
+    def get_unit(self) -> str:
+        """Returns the unit of the progress bar according to the total number of bytes.
+
+        :return: unit of the progress bar
+        :rtype: str
+        """
+        total = self.total
+        for unit in UNITS:
+            if total < 1000:
+                return unit
+            total /= 1000
+
+    def bytes_to_unit(self, bytes: int) -> Union[str, Any]:
+        """Returns a human-readable string representation of bytes according to the
+        self.unit.
+
+        :param bytes: number of bytes
+        :type bytes: int
+        :return: human-readable string representation of bytes or passed value if
+            self.unit is not in UNITS or bytes is not int
+        :rtype: Union[str, Any]
+        """
+        if not isinstance(bytes, int) or self.unit not in UNITS:
+            return bytes
+
+        for idx, unit in enumerate(UNITS):
+            if self.unit == unit:
+                return f"{round(bytes / (MULTIPLIER**idx), 2)} {unit}"
+
 
 class CustomTqdm(tqdm):
     def __init__(self, widget_id, message, *args, **kwargs):
         extracted_total = copy.copy(
             tqdm(iterable=kwargs["iterable"], total=kwargs["total"], disable=True).total
         )
+        unit_scale = kwargs.get("unit_scale")
+        unit = kwargs.get("unit")
 
         super().__init__(
-            file=_slyProgressBarIO(widget_id, message, extracted_total), *args, **kwargs
+            file=_slyProgressBarIO(widget_id, message, extracted_total, unit, unit_scale),
+            *args,
+            **kwargs,
         )
 
     def refresh(self, *args, **kwargs):
@@ -222,7 +273,7 @@ class SlyTqdm(Widget):
 
     def get_json_state(self):
         return None
-    
+
     def set_message(self, message):
         self.message = message
         DataJson()[self.widget_id]["message"] = message

--- a/supervisely/app/widgets/sly_tqdm/sly_tqdm.py
+++ b/supervisely/app/widgets/sly_tqdm/sly_tqdm.py
@@ -74,6 +74,9 @@ class _slyProgressBarIO:
             "total": total,
         }
 
+        if self.unit != "it":
+            extra["current_label"] = extra["total_label"] = self.unit
+
         gettrace = getattr(sys, "gettrace", None)
         in_debug_mode = gettrace is not None and gettrace()
 
@@ -128,22 +131,21 @@ class _slyProgressBarIO:
                 return unit
             total /= 1000
 
-    def bytes_to_unit(self, bytes: int) -> Union[str, Any]:
+    def bytes_to_unit(self, bytes: int) -> Union[float, Any]:
         """Returns a human-readable string representation of bytes according to the
         self.unit.
 
         :param bytes: number of bytes
         :type bytes: int
-        :return: human-readable string representation of bytes or passed value if
-            self.unit is not in UNITS or bytes is not int
-        :rtype: Union[str, Any]
+        :return: converted size from bytes to self.unit
+        :rtype: Union[float, Any]
         """
         if not isinstance(bytes, int) or self.unit not in UNITS:
             return bytes
 
         for idx, unit in enumerate(UNITS):
             if self.unit == unit:
-                return f"{round(bytes / (1000**idx), 2)} {unit}"
+                return round(bytes / (1000**idx), 2)
 
 
 class CustomTqdm(tqdm):

--- a/supervisely/app/widgets/sly_tqdm/sly_tqdm.py
+++ b/supervisely/app/widgets/sly_tqdm/sly_tqdm.py
@@ -143,7 +143,7 @@ class _slyProgressBarIO:
 
         for idx, unit in enumerate(UNITS):
             if self.unit == unit:
-                return f"{round(bytes / (MULTIPLIER**idx), 2)} {unit}"
+                return f"{round(bytes / (1000**idx), 2)} {unit}"
 
 
 class CustomTqdm(tqdm):


### PR DESCRIPTION
Converts bytes to MB, GB, etc. if the "B" (bytes) was passed as unit and unit_scale is set to True for convenient display in Workspace Tasks's output.

Usage example:

```python
progress = sly.app.widgets.Progress()
with progress(
            message="Downloading model...",
            total=int(source.headers.get("Content-Length")),
            unit="B",
            unit_scale=True,
        ) as pbar:
```

Result output:

![Kapture 2023-08-17 at 14 29 35](https://github.com/supervisely/supervisely/assets/118521851/590b4aca-4dac-4084-a97b-cd043002de5a)
