### PR TITLE
Finding and checking directories with specific filename (marker)

### DIFF
--- a/supervisely/io/fs.py
+++ b/supervisely/io/fs.py
@@ -947,7 +947,7 @@ def parse_agent_id_and_path(remote_path: str) -> int:
     return agent_id, path_in_agent_folder
 
 
-def markered_dirs(
+def dirs_with_marker(
     input_path: str,
     markers: Union[str, List[str]],
     check_function: Callable = None,
@@ -989,7 +989,7 @@ def markered_dirs(
             test_file_path = os.path.join(dir_path, 'test.txt')
             return os.path.exists(test_file_path)
 
-        for directory in sly.fs.markered_dirs(input_path, markers, check_function, ignore_case=True):
+        for directory in sly.fs.dirs_with_marker(input_path, markers, check_function, ignore_case=True):
             # Now you can be sure that the directory contains the markers and meets the requirements.
             # Do something with it.
             print(directory)


### PR DESCRIPTION
Added dirs_with_markers() - generator function that yields paths to directories that contain files with specific names (markers).
The markers can be specified as a single string or a list of strings.
If the check_function is specified, the markered directory will be yielded only if the check_function returns True.
If ignore_case is True, then the case of the marker names will be ignored.

```python
        import supervisely as sly

        input_path = '/home/admin/work/projects/examples'

        # You can pass a string if you have only one marker.
        # markers = 'config.json'

        # Or a list of strings if you have several markers.
        # There's no need to pass one marker in different cases, you can use ignore_case=True for this.
        markers = ['config.json', 'config.yaml']


        # Check function is optional, if you don't need the directories to meet any requirements,
        # you can omit it.

        def check_function(dir_path):
            test_file_path = os.path.join(dir_path, 'test.txt')
            return os.path.exists(test_file_path)

        for directory in sly.fs.dirs_with_marker(input_path, markers, check_function, ignore_case=True):
            # Now you can be sure that the directory contains the markers and meets the requirements.
            # Do something with it.
            print(directory)
```