### PR TITLE
Widget ClassesTable - change icon for polygon shapes and fix disable attribute

### DIFF
--- a/supervisely/app/widgets/classes_table/classes_table.py
+++ b/supervisely/app/widgets/classes_table/classes_table.py
@@ -51,7 +51,7 @@ class ClassesTable(Widget):
         self._global_checkbox = False
         self._checkboxes = []
         self._selectable = selectable
-        self._disabled = disabled
+        self._selection_disabled = disabled
         self._loading = False
         self._allowed_types = allowed_types if allowed_types is not None else []
         if project_id is not None:
@@ -240,7 +240,7 @@ class ClassesTable(Widget):
             "table_data": self._table_data,
             "columns": self._columns,
             "loading": self._loading,
-            "disabled": self._disabled,
+            "disabled": self._selection_disabled,
             "selectable": self._selectable,
         }
 

--- a/supervisely/app/widgets/classes_table/template.html
+++ b/supervisely/app/widgets/classes_table/template.html
@@ -57,16 +57,27 @@
           ></el-checkbox>
         </td>
         <td v-for="col in row">
-          <span v-if="col.name === 'CLASS'">
-            <i class="zmdi zmdi-circle ml5 mr5" :style="{color: col.color}"></i>
-          </span>
-          <span v-if="col.name === 'SHAPE'">
+          <div class="fflex">
+            <span v-if="col.name === 'CLASS'">
+                <i class="zmdi zmdi-circle ml5 mr5" :style="{color: col.color}"></i>
+            </span>
+            <svg
+                v-if="col.name === 'SHAPE' & col.data === 'polygon'"
+                style="margin-right: 5px"
+                xmlns="http://www.w3.org/2000/svg"
+                xmlns:xlink="http://www.w3.org/1999/xlink"
+                version="1.1"
+                width="9.75" height="13" viewBox="0 0 24 24" fill=""
+            >
+                <path d="M2,2V8H4.28L5.57,16H4V22H10V20.06L15,20.05V22H21V16H19.17L20,9H22V3H16V6.53L14.8,8H9.59L8,5.82V2M4,4H6V6H4M18,5H20V7H18M6.31,8H7.11L9,10.59V14H15V10.91L16.57,9H18L17.16,16H15V18.06H10V16H7.6M11,10H13V12H11M6,18H8V20H6M17,18H19V20H17"></path>
+            </svg>
             <i
-              :class="col.icon"
-              style="margin-right: 5px"
+                v-if="col.name === 'SHAPE' & col.data !== 'polygon'"
+                :class="col.icon"
+                style="margin-right: 5px"
             ></i>
-          </span>
-          {{ col.data }}
+            <span>{{ col.data }}</span>
+          </div>
         </td>
       </tr>
     </tbody>


### PR DESCRIPTION
replaced the icon with SVG used in labeling tool.


before:
<img width="1126" alt="image" src="https://github.com/supervisely/supervisely/assets/79905215/f0a96ae7-ffb3-456f-939f-124b064fb31b">

after:
<img width="504" alt="image" src="https://github.com/supervisely/supervisely/assets/79905215/9a2e012c-a2b8-4dfd-a706-0f88f5a205e4">



