### PR TITLE
remove stl and update geometries upload

### DIFF
--- a/supervisely/api/entity_annotation/entity_annotation_api.py
+++ b/supervisely/api/entity_annotation/entity_annotation_api.py
@@ -5,9 +5,6 @@ from tqdm import tqdm
 from typing import List, Dict, Union, Optional, Callable
 from supervisely._utils import batched
 from supervisely.api.module_api import ApiField, ModuleApi
-from supervisely.api.volume.volume_figure_api import VolumeFigureApi
-from supervisely.api.volume.volume_tag_api import VolumeTagApi
-from supervisely.api.volume.volume_object_api import VolumeObjectApi
 from supervisely.video_annotation.key_id_map import KeyIdMap
 
 
@@ -47,9 +44,9 @@ class EntityAnnotationAPI(ModuleApi):
 
     def _append(
         self,
-        tag_api: VolumeTagApi,
-        object_api: VolumeObjectApi,
-        figure_api: VolumeFigureApi,
+        tag_api,
+        object_api,
+        figure_api,
         project_id,
         dataset_id,
         entity_id,
@@ -69,9 +66,7 @@ class EntityAnnotationAPI(ModuleApi):
         for fig_batch in batched(figures, batch_size=1000):
             figure_api.append_bulk(entity_id, fig_batch, key_id_map)
             if progress_cb is not None:
-                if hasattr(progress_cb, "update") and callable(
-                    getattr(progress_cb, "update")
-                ):
+                if hasattr(progress_cb, "update") and callable(getattr(progress_cb, "update")):
                     progress_cb.update(len(fig_batch))
                 else:
                     progress_cb(len(fig_batch))

--- a/supervisely/api/entity_annotation/entity_annotation_api.py
+++ b/supervisely/api/entity_annotation/entity_annotation_api.py
@@ -5,6 +5,9 @@ from tqdm import tqdm
 from typing import List, Dict, Union, Optional, Callable
 from supervisely._utils import batched
 from supervisely.api.module_api import ApiField, ModuleApi
+from supervisely.api.volume.volume_figure_api import VolumeFigureApi
+from supervisely.api.volume.volume_tag_api import VolumeTagApi
+from supervisely.api.volume.volume_object_api import VolumeObjectApi
 from supervisely.video_annotation.key_id_map import KeyIdMap
 
 
@@ -44,9 +47,9 @@ class EntityAnnotationAPI(ModuleApi):
 
     def _append(
         self,
-        tag_api,
-        object_api,
-        figure_api,
+        tag_api: VolumeTagApi,
+        object_api: VolumeObjectApi,
+        figure_api: VolumeFigureApi,
         project_id,
         dataset_id,
         entity_id,
@@ -66,7 +69,9 @@ class EntityAnnotationAPI(ModuleApi):
         for fig_batch in batched(figures, batch_size=1000):
             figure_api.append_bulk(entity_id, fig_batch, key_id_map)
             if progress_cb is not None:
-                if hasattr(progress_cb, "update") and callable(getattr(progress_cb, "update")):
+                if hasattr(progress_cb, "update") and callable(
+                    getattr(progress_cb, "update")
+                ):
                     progress_cb.update(len(fig_batch))
                 else:
                     progress_cb(len(fig_batch))

--- a/supervisely/api/volume/volume_annotation_api.py
+++ b/supervisely/api/volume/volume_annotation_api.py
@@ -51,7 +51,7 @@ class VolumeAnnotationAPI(EntityAnnotationAPI):
     _method_download_bulk = "volumes.annotations.bulk.info"
     _entity_ids_str = ApiField.VOLUME_IDS
 
-    def download(self, volume_id: int):
+    def download(self, volume_id: int) -> Dict:
         """
         Download information about VolumeAnnotation by volume ID from API.
         :param volume_id: Volume ID in Supervisely.

--- a/supervisely/api/volume/volume_annotation_api.py
+++ b/supervisely/api/volume/volume_annotation_api.py
@@ -118,7 +118,8 @@ class VolumeAnnotationAPI(EntityAnnotationAPI):
 
         :param dataset_id: int
         :param entity_ids: list of integers
-        :return: 
+        :return: Information about VolumeAnnotations in json format
+        :rtype: :class:`dict`
         """
         response = self._api.post(
             self._method_download_bulk,
@@ -211,7 +212,7 @@ class VolumeAnnotationAPI(EntityAnnotationAPI):
         :type ann_paths: List[str]
         :param project_meta: Input :class:`ProjectMeta<supervisely.project.project_meta.ProjectMeta>` for VolumeAnnotations.
         :type project_meta: ProjectMeta
-        :param progress_cb: Function for tracking download progress.
+        :param progress_cb: Function for tracking upload progress.
         :type progress_cb: tqdm or callable, optional
         :return: None
         :rtype: :class:`NoneType`

--- a/supervisely/api/volume/volume_annotation_api.py
+++ b/supervisely/api/volume/volume_annotation_api.py
@@ -114,11 +114,11 @@ class VolumeAnnotationAPI(EntityAnnotationAPI):
 
     def download_bulk(self, dataset_id: int, entity_ids: List[int]) -> Dict:
         """
-        Download a list of content (annotations with given ids from dataset with given id).
+        Download annotations for entities with given ids from dataset.
 
         :param dataset_id: int
         :param entity_ids: list of integers
-        :return: list of content(annotations with given ids from dataset with given id), received after execution post request
+        :return: 
         """
         response = self._api.post(
             self._method_download_bulk,
@@ -140,7 +140,6 @@ class VolumeAnnotationAPI(EntityAnnotationAPI):
                 nrrd_geometry = nrrd_geometries.get(spatial_figure.get("id"))
                 with tempfile.NamedTemporaryFile(delete=True) as temp_file:
                     temp_file.write(nrrd_geometry)
-                    file_path = temp_file.name
                     data_array, _ = nrrd.read(temp_file.name)
                 data_array = sly.Mask3D.data_2_base64(data_array)
                 spatial_figure["geometry"] = {

--- a/supervisely/api/volume/volume_figure_api.py
+++ b/supervisely/api/volume/volume_figure_api.py
@@ -102,11 +102,11 @@ class VolumeFigureApi(FigureApi):
         Add VolumeFigures to given Volume by ID.
 
         :param volume_id: Volume ID in Supervisely.
-        :type volume_id: int
-        :param key_id_map: KeyIdMap object.
-        :type key_id_map: KeyIdMap
+        :type volume_id: int        
         :param figures: List of VolumeFigure objects.
         :type figures: List[VolumeFigure]
+        :param key_id_map: KeyIdMap object.
+        :type key_id_map: KeyIdMap
         :return: None
         :rtype: :class:`NoneType`
         :Usage example:
@@ -114,6 +114,7 @@ class VolumeFigureApi(FigureApi):
          .. code-block:: python
 
             import supervisely as sly
+            import numpy as np
 
             from supervisely.volume_annotation.plane import Plane
 
@@ -134,11 +135,13 @@ class VolumeFigureApi(FigureApi):
             volume_obj_collection = vol_ann.objects.to_json()
             vol_obj = sly.VolumeObject.from_json(volume_obj_collection[1], project_meta)
 
+            geometry = sly.Mask3D(np.zeros(3, 3, 3). dtype=np.bool_)  
+            
             figure = sly.VolumeFigure(
                 vol_obj,
-                sly.Rectangle(20, 20, 129, 200),
-                sly.Plane.AXIAL,
-                45,
+                geometry,
+                None,
+                None,
             )
 
             api.volume.figure.append_bulk(volume_id, [figure], key_id_map)
@@ -217,15 +220,17 @@ class VolumeFigureApi(FigureApi):
             project_meta_json = api.project.get_meta(project_id)
             project_meta = sly.ProjectMeta.from_json(project_meta_json)
 
-            vol_ann_json = api.volume.annotation.download(volume_id)
-            id_to_paths = {}
+            vol_ann_json = api.volume.annotation.download(volume_id)            
             vol_ann = sly.VolumeAnnotation.from_json(vol_ann_json, project_meta, key_id_map)
 
+            ids = []
+            paths = []
+            
             for sp_figure in vol_ann.spatial_figures:
                 figure_id = key_id_map.get_figure_id(sp_figure.key())
-                id_to_paths[figure_id] = f"{STORAGE_DIR}/{figure_id}.nrrd"
-            if id_to_paths:
-                api.volume.figure.download_sf_geometries(*zip(*id_to_paths.items()))
+                ids.append(figure_id)
+                paths.appen(f"{STORAGE_DIR}/{figure_id}.nrrd")                        
+            api.volume.figure.download_sf_geometries(ids, paths)
         """
 
         if not ids:

--- a/supervisely/geometry/mask_3d.py
+++ b/supervisely/geometry/mask_3d.py
@@ -53,7 +53,9 @@ class PointVolume(JsonSerializable):
         loc = sly.PointVolume(x, y, z)
     """
 
-    def __init__(self, x: Union[int, float], y: Union[int, float], z: Union[int, float]):
+    def __init__(
+        self, x: Union[int, float], y: Union[int, float], z: Union[int, float]
+    ):
         self._x = round(unwrap_if_numpy(x))
         self._y = round(unwrap_if_numpy(y))
         self._z = round(unwrap_if_numpy(z))
@@ -359,7 +361,9 @@ class Mask3D(Geometry):
         json_root_key = cls._impl_json_class_name()
         if json_root_key not in json_data:
             raise ValueError(
-                "Data must contain {} field to create Mask3D object.".format(json_root_key)
+                "Data must contain {} field to create Mask3D object.".format(
+                    json_root_key
+                )
             )
 
         if DATA not in json_data[json_root_key]:
@@ -387,9 +391,7 @@ class Mask3D(Geometry):
         if SPACE_ORIGIN in json_data[json_root_key]:
             x, y, z = json_data[json_root_key][SPACE_ORIGIN]
             instance._space_origin = PointVolume(x=x, y=y, z=z)
-            return instance
-        else:
-            return instance
+        return instance
 
     @classmethod
     def _impl_json_class_name(cls):

--- a/supervisely/io/fs.py
+++ b/supervisely/io/fs.py
@@ -2,7 +2,7 @@
 
 # docs
 from re import L
-from typing import Dict, List, Optional, Callable, Union, Literal, Generator
+from typing import Dict, List, Optional, Callable, Union, Literal, Generator, Any
 
 import os
 import re
@@ -1049,3 +1049,44 @@ def dirs_filter(input_path: str, check_function: Callable) -> Generator[str, Non
         if os.path.isdir(path):
             if check_function(path):
                 yield path
+
+
+def get_nested_dicts_data(data_dict: Dict, *dict_keys: str) -> Any:
+    """
+    Recursively traverses all keys and returns the value of the last key.
+
+    :param data_dict: dict with nested dicts
+    :type data_dict: dict
+    :return: value of the last key
+    :rtype: Any
+    :Usage example:
+
+     .. code-block:: python
+
+        from supervisely.io.fs import get_nested_dicts_data
+
+        nested_dict = {
+            'first_level': {
+                'second_level': {
+                    'third_level_1': 'You are wrong',
+                    'third_level_2': 'This is the innermost value'
+                }
+            }
+        }
+
+        required_value = get_nested_dicts_data(nested_dict, 'first_level', 'second_level', 'third_level_2')
+        print(required_value)
+
+        Output: 'This is the innermost value'
+
+    """
+    if not dict_keys:
+        return data_dict
+
+    dict_key = dict_keys[0]
+    if data_dict.get(dict_key):
+        return get_nested_dicts_data(data_dict.get(dict_key), *dict_keys[1:])
+    else:
+        raise KeyError(
+            "The key you are searching for is missing or is at a different nesting level"
+        )


### PR DESCRIPTION
**volume_annotation_api.py**
- add `download_bulk() `with geometries injection to export annotation with fully equipped spatial figures
- remove interpolation dir from `upload_paths()`

**volume_figure_api.py**
 - refactor a little `append_bulk()` , just cosmetic changes 
 - rename `download_stl_meshes()` to `download_sf_geometries()`, set "save to file" as option if paths are passed
 - remove `interpolate()`, it doesn't need now
 - remove `upload_stl_meshes()`, it doesn't need now
 - remove `_upload_meshes_batch()`, it's a part of `upload_stl_meshes()`
 - for `_append_bulk_mask3d()` 
     - add geometry uploading to eliminate additional user actions
     - rename variable from  `fake_figures` to `empty_figures` to make it clearer
 - rename `upload_sf_geometry()` to `upload_sf_geometries()` and add possibility to use method for already prepared figures with their UUID keys.

**volume_project.py**
- from `download_volume_project()` remove redundant processings for spatial figures
- remove `load_figure_data()` due to an update to  `download_volume_project()`
- from `upload_volume_project()` remove `interpolation_dirs`
- remove `get_interpolation_dir()` due to an update to `upload_volume_project()`
- remove `get_interpolation_path()` due to an update to `upload_volume_project()`


**mask_3d.py**
- in ` from_json()` remove redundant `return`

**fs.py**
- add `get_nested_dicts_data()` to recursively gather data from the nested dicts

