### PR TITLE
Detailed error messages for load_json_file()

### DIFF
--- a/supervisely/io/json.py
+++ b/supervisely/io/json.py
@@ -118,7 +118,7 @@ def load_json_file(filename: str) -> Dict:
     """
     if os.path.isdir(filename):
         raise FileNotFoundError(f"The path {filename} is a directory, not a file.")
-    if not os.path.isfile(filename):
+    elif not os.path.isfile(filename):
         raise FileNotFoundError(f"File with path {filename} was not found.")
     try:
         with open(filename, encoding="utf-8") as fin:

--- a/supervisely/io/json.py
+++ b/supervisely/io/json.py
@@ -27,7 +27,7 @@ def load_json_file(filename: str) -> Dict:
 
     :param filename: Target file path.
     :type filename: str
-    :raises FileNotFoundError: If path is a directory, not a file.
+    :raises IsADirectoryError: If given filename is a directory, not a file.
     :raises FileNotFoundError: If file with given filename was not found.
     :raises RuntimeError: If can not decode json file.
     :returns: Json format as a dict
@@ -117,7 +117,7 @@ def load_json_file(filename: str) -> Dict:
         # }
     """
     if os.path.isdir(filename):
-        raise FileNotFoundError(f"The path {filename} is a directory, not a file.")
+        raise IsADirectoryError(f"The path {filename} is a directory, not a file.")
     elif not os.path.isfile(filename):
         raise FileNotFoundError(f"File with path {filename} was not found.")
     try:

--- a/supervisely/io/json.py
+++ b/supervisely/io/json.py
@@ -27,6 +27,7 @@ def load_json_file(filename: str) -> Dict:
 
     :param filename: Target file path.
     :type filename: str
+    :raises FileNotFoundError: If path is a directory, not a file.
     :raises FileNotFoundError: If file with given filename was not found.
     :raises RuntimeError: If can not decode json file.
     :returns: Json format as a dict
@@ -115,6 +116,8 @@ def load_json_file(filename: str) -> Dict:
         #     ]
         # }
     """
+    if os.path.isdir(filename):
+        raise FileNotFoundError(f"The path {filename} is a directory, not a file.")
     if not os.path.isfile(filename):
         raise FileNotFoundError(f"File with path {filename} was not found.")
     try:


### PR DESCRIPTION
- If path is a directory, not a file
- If file from path does not exists
- For JSON decode errors: file path, line, column and position numbers, error message and document.

Error example:
```sh
RuntimeError: Can not decode json file with path /Users/iwatkot/Downloads/10903_test 3/ds0/annotation.json: Invalid control character at at line number: 1, column: 3, position: 2. Document: "{
    "description": "",
    "key": "233ed5ab8d7d4349bad8a5a30513519d",
    "tags": [],
    "objects": [],
    "framesCount": 20,
    "frames": []
}
```