### PR TITLE
Handle non-string input in sly.volume.is_valid_ext(ext: str)

### DIFF
--- a/supervisely/volume/volume.py
+++ b/supervisely/volume/volume.py
@@ -78,6 +78,9 @@ def is_valid_ext(ext: str) -> bool:
         sly.volume.is_valid_ext(".mp4") # False
     """
 
+    if type(ext) is not str:
+        return False
+
     return ext.lower() in ALLOWED_VOLUME_EXTENSIONS
 
 


### PR DESCRIPTION
`sly.volume.has_valid_ext` returns  `is_valid_ext(get_extension(path))`:
1. `get_extension` -> `str` or **`None`**
2. `is_valid_ext` utilizes the `str.lower()` method (fails if `None` is provided).

added argument type checking