### PR TITLE
Fix deprecated skvideo in sly.video.get_image_size_and_frames_count(path)

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -37,7 +37,6 @@ INSTALL_REQUIRES = [
     "stringcase>=1.2.0, <2.0.0",
     "python-magic>=0.4.25, <1.0.0",
     "trimesh>=3.11.2, <4.0.0",
-    "scikit-video>=1.1.11, <2.0.0",
     "uvicorn[standard]>=0.18.2, <1.0.0",
     "pydantic>=1.7.4, <2.0.0",
     "anyio>=3.7.1,<4.0.0",  # TODO: remove after upgrade fastapi version up to 0.103.1
@@ -156,7 +155,6 @@ setup(
             "matplotlib>=3.3.2, <4.0.0",
             "pascal-voc-writer>=0.1.4, <1.0.0",
             "scipy>=1.5.2, <2.0.0",
-            "sk-video>=1.1.10, <2.0.0",
             "pandas>=1.1.3, <1.4.0",
             "ruamel.yaml==0.17.21",
         ],


### PR DESCRIPTION
- Change deprecated `skvideo` to `cv2` in `sly.video.get_image_size_and_frames_count(path)` to get frames count and frame size 
- Fix reading video meta using `ffprobe` (add `pts_time` property)
- Check timecodes are not `None`