### PR TITLE
Improve exception handler decorator. Upgrade js_bundle_version to 2.1.73

### DIFF
--- a/supervisely/app/fastapi/templating.py
+++ b/supervisely/app/fastapi/templating.py
@@ -9,7 +9,7 @@ from supervisely.app.singleton import Singleton
 from supervisely.app.widgets_context import JinjaWidgets
 
 # https://github.com/supervisely/js-bundle
-js_bundle_version = "2.1.71"
+js_bundle_version = "2.1.73"
 
 # https://github.com/supervisely-ecosystem/supervisely-app-frontend-js
 js_frontend_version = "0.0.48"


### PR DESCRIPTION
1. Upgraded `js_bundle_version = 2.1.73` (fixed `<sly-editor>` and `<sly-file-storage-upload>` widgets)

2. Added `has_ui` argument in the `handle_exceptions` decorator to preserve exception type (instead of `DialogWindowError`) in the apps that do not have UI
    
    now it can be used in the following ways:
    
    a. with argument
    ```python
    @sly.handle_exceptions(has_ui=False)
        def my_func():
            # Some code that may raise an exception.
    ```
    b. without argument
    ```python
    @sly.handle_exceptions # equal to @sly.handle_exceptions(has_ui=True)
        def my_func():
            # Some code that may raise an exception.
    ```