### PR TITLE
PointcloudEpisodeAnnotationAPI - fixed indexes of frames in api.pointcloud_episode.annotation.append

### DIFF
--- a/supervisely/api/pointcloud/pointcloud_episode_annotation_api.py
+++ b/supervisely/api/pointcloud/pointcloud_episode_annotation_api.py
@@ -154,13 +154,13 @@ class PointcloudEpisodeAnnotationAPI(EntityAnnotationAPI):
 
         figures = []
         pointcloud_ids = []
-        for i, frame in enumerate(ann.frames):
+        for frame in ann.frames:
             for fig in frame.figures:
-                if frame_to_pointcloud_ids.get(i) is None:  # skip unmapped frames
+                if frame_to_pointcloud_ids.get(frame.index) is None:  # skip unmapped frames
                     continue
 
                 figures.append(fig)
-                pointcloud_ids.append(frame_to_pointcloud_ids[i])
+                pointcloud_ids.append(frame_to_pointcloud_ids[frame.index])
 
         if len(pointcloud_ids) == 0:
             return


### PR DESCRIPTION
Fixed incorrect uploading of figures (starting from the first frame of episodes even if they were supposed to be, for example, on frames 5 and 6).

After the fix, they will be uploaded to the correct frames (in this case – on 5 and 6 frames instead of 1 and 2 frames).