### PR TITLE
api.project.remove_permanently and api.dataset.remove_permanently add batch and progress_cb args

### DIFF
--- a/supervisely/api/dataset_api.py
+++ b/supervisely/api/dataset_api.py
@@ -526,7 +526,9 @@ class DatasetApi(UpdateableModule, RemoveableModuleApi):
             res = res._replace(items_count=res.images_count)
         return DatasetInfo(**res._asdict())
 
-    def remove_permanently(self, ids: Union[int, List]) -> dict:
+    def remove_permanently(
+        self, ids: Union[int, List], batch_size: int = 50, progress_cb=None
+    ) -> List[dict]:
         """
         Delete permanently datasets with given IDs from the Supervisely server.
 
@@ -535,15 +537,31 @@ class DatasetApi(UpdateableModule, RemoveableModuleApi):
 
         :param ids: IDs of datasets in Supervisely.
         :type ids: Union[int, List]
-        :return: Response content in JSON format
-        :rtype: dict
+        :param batch_size: The number of entities that will be deleted by a single API call. This value must be in the range 1-50 inclusive, if you set a value out of range it will automatically adjust to the boundary values.
+        :type batch_size: int, optional
+        :param progress_cb: Function for control delete progress.
+        :type progress_cb: Callable, optional
+        :return: A list of response content in JSON format for each API call.
+        :rtype: List[dict]
         """
+        if batch_size > 50:
+            batch_size = 50
+        elif batch_size < 1:
+            batch_size = 1
+
         if isinstance(ids, int):
             datasets = [{ApiField.ID: ids}]
         else:
             datasets = [{ApiField.ID: id} for id in ids]
-        response = self._api.post("datasets.remove.permanently", {ApiField.DATASETS: datasets})
-        return response.json()
+
+        batches = [datasets[i : i + batch_size] for i in range(0, len(datasets), batch_size)]
+        responses = []
+        for batch in batches:
+            response = self._api.post("datasets.remove.permanently", {ApiField.DATASETS: batch})
+            if progress_cb is not None:
+                progress_cb(len(batch))
+            responses.append(response.json())
+        return responses
 
     def get_list_all(
         self,

--- a/tests/test_api_dataset_remove_permanently.py
+++ b/tests/test_api_dataset_remove_permanently.py
@@ -87,7 +87,7 @@ class TestRemoveDatasetPermanently(unittest.TestCase):
         mock_callback.assert_called_with(len(dataset_ids))
 
     def test_multiple_responses(self):
-        # Testing deletion of multiple datasets by a list of IDs in bathc size of 1
+        # Testing deletion of multiple datasets by a list of IDs in batch size of 1
         multiple_ids = self.create_test_datasets(3)
         response = self.dataset_instance.remove_permanently(multiple_ids, 1)
         # Checking for a responses

--- a/tests/test_api_dataset_remove_permanently.py
+++ b/tests/test_api_dataset_remove_permanently.py
@@ -15,7 +15,7 @@ class TestRemoveDatasetPermanently(unittest.TestCase):
         with patch("builtins.input", return_value="user_input_value"):
             project = cls.api.project.create(
                 workspace_id=int(workspace_id),
-                name="unit tests remove_permanently",
+                name="[UT] Dataset remove permanently",
                 change_name_if_conflict=True,
             )
         cls.project_id = project.id
@@ -35,7 +35,7 @@ class TestRemoveDatasetPermanently(unittest.TestCase):
         for i in range(count):
             created_dataset = self.dataset_instance.create(
                 self.project_id,
-                name=f"unit tests remove_permanently {i+1}",
+                name=f"[UT] Dataset remove permanently {i+1}",
                 change_name_if_conflict=True,
             )
             created_dataset_ids.append(created_dataset.id)

--- a/tests/test_api_dataset_remove_permanently.py
+++ b/tests/test_api_dataset_remove_permanently.py
@@ -51,6 +51,9 @@ class TestRemoveDatasetPermanently(unittest.TestCase):
         self.assertEqual(len(response), 1)
         # Verifying the response for a single dataset deletion
         self.assertIn("success", response[0])
+        # Verifying the dataset is really deleted
+        dataset_info = self.api.dataset.get_info_by_id(single_id)
+        self.assertIsNone(dataset_info)
 
     def test_multiple_ids_deletion(self):
         # Testing deletion of multiple datasets by a list of IDs

--- a/tests/test_api_dataset_remove_permanently.py
+++ b/tests/test_api_dataset_remove_permanently.py
@@ -1,0 +1,99 @@
+import unittest
+from unittest.mock import Mock, patch
+
+from supervisely.api.api import Api
+
+
+class TestRemoveDatasetPermanently(unittest.TestCase):
+    project_id = None
+    api = None
+
+    @classmethod
+    def setUpClass(cls):
+        cls.api = Api.from_env()
+        workspace_id = input("Enter workspace ID for tests here >> ")
+        with patch("builtins.input", return_value="user_input_value"):
+            project = cls.api.project.create(
+                workspace_id=int(workspace_id),
+                name="unit tests remove_permanently",
+                change_name_if_conflict=True,
+            )
+        cls.project_id = project.id
+
+    @classmethod
+    def tearDownClass(cls):
+        cls.api.project.remove(cls.project_id)
+
+    def setUp(self):
+        self.dataset_instance = self.api.dataset
+
+    def create_test_datasets(self, count):
+        """
+        Create test datasets for testing 'remove_permanently'.
+        """
+        created_dataset_ids = []
+        for i in range(count):
+            created_dataset = self.dataset_instance.create(
+                self.project_id,
+                name=f"unit tests remove_permanently {i+1}",
+                change_name_if_conflict=True,
+            )
+            created_dataset_ids.append(created_dataset.id)
+        return created_dataset_ids
+
+    def test_single_id_deletion(self):
+        # Testing deletion of a single dataset by ID
+        created_dataset_ids = self.create_test_datasets(1)
+        single_id = created_dataset_ids[0]
+        response = self.dataset_instance.remove_permanently(single_id)
+        # Checking for a response
+        self.assertIsInstance(response, list)
+        self.assertEqual(len(response), 1)
+        # Verifying the response for a single dataset deletion
+        self.assertIn("success", response[0])
+
+    def test_multiple_ids_deletion(self):
+        # Testing deletion of multiple datasets by a list of IDs
+        multiple_ids = self.create_test_datasets(3)
+        response = self.dataset_instance.remove_permanently(multiple_ids)
+        # Checking for a response
+        self.assertIsInstance(response, list)
+        self.assertEqual(len(response), 1)
+        # Verifying the response for multiple datasets deletion
+        for resp in response:
+            self.assertIn("success", resp)
+
+    def test_batch_size_adjustment(self):
+        # Testing batch size adjustment
+        batch_size = 60
+        created_dataset_ids = self.create_test_datasets(1)
+        single_id = created_dataset_ids[0]
+        response = self.dataset_instance.remove_permanently(single_id, batch_size=batch_size)
+        # Checking for a response
+        self.assertIsInstance(response, list)
+        self.assertEqual(len(response), 1)
+        # Verifying that the batch size was correctly adjusted
+        self.assertLessEqual(len(response[0]), 50)
+
+    def test_progress_callback(self):
+        # Testing the progress callback
+        mock_callback = Mock()
+        dataset_ids = self.create_test_datasets(5)
+        self.dataset_instance.remove_permanently(dataset_ids, progress_cb=mock_callback)
+        # Verifying the callback invocation for each dataset
+        mock_callback.assert_called_with(len(dataset_ids))
+
+    def test_multiple_responses(self):
+        # Testing deletion of multiple datasets by a list of IDs in bathc size of 1
+        multiple_ids = self.create_test_datasets(3)
+        response = self.dataset_instance.remove_permanently(multiple_ids, 1)
+        # Checking for a responses
+        self.assertIsInstance(response, list)
+        self.assertEqual(len(response), len(multiple_ids))
+        # Verifying the response for multiple datasets deletion
+        for resp in response:
+            self.assertIn("success", resp)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_api_project_archive.py
+++ b/tests/test_api_project_archive.py
@@ -1,0 +1,96 @@
+import unittest
+from unittest.mock import Mock, patch
+
+from supervisely.api.api import Api
+
+
+class TestArchiveProject(unittest.TestCase):
+    workspace_id = None
+    api = None
+
+    @classmethod
+    def setUpClass(cls):
+        cls.api = Api.from_env()
+        workspace_id = input("Enter workspace ID for tests here >> ")
+        with patch("builtins.input", return_value="user_input_value"):
+            cls.workspace_id = int(workspace_id)
+
+    def tearDown(self):
+        self.api.project.remove_batch(self.project_ids)
+
+    def setUp(self):
+        self.project_instance = self.api.project
+        self.url = "https://www.dropbox.com/"
+        self.project_ids = []
+
+    def create_test_projects(self, count):
+        """
+        Create test projects for testing 'remove_permanently'.
+        """
+        created_project_ids = []
+        for i in range(count):
+            created_project = self.project_instance.create(
+                self.workspace_id,
+                name=f"[UT] Archived project {i+1}",
+                change_name_if_conflict=True,
+            )
+            created_project_ids.append(created_project.id)
+        return created_project_ids
+
+    def test_single_id_archiving(self):
+        # Testing archiving of a single project
+        created_project_ids = self.create_test_projects(1)
+        single_id = created_project_ids[0]
+        self.project_instance.archive(single_id, self.url, self.url)
+        # Verifying the project is archived
+        project_info = self.api.project.get_info_by_id(single_id)
+        self.assertIsNotNone(project_info)
+        self.assertIsNotNone(project_info.backup_archive)
+        self.assertIsNotNone(project_info.backup_archive.get("url"))
+        self.assertIsNotNone(project_info.backup_archive.get("annotationsUrl"))
+        self.assertIsInstance(project_info.backup_archive.get("url"), str)
+        self.assertIsInstance(project_info.backup_archive.get("annotationsUrl"), str)
+        self.project_ids.append(single_id)
+
+    def test_single_id_archiving_files_url(self):
+        # Testing archiving of a single project only with files URL
+        created_project_ids = self.create_test_projects(1)
+        single_id = created_project_ids[0]
+        self.project_instance.archive(single_id, self.url)
+        # Verifying the project is archived
+        project_info = self.api.project.get_info_by_id(single_id)
+        self.assertIsNotNone(project_info)
+        self.assertIsNotNone(project_info.backup_archive)
+        self.assertIsNotNone(project_info.backup_archive.get("url"))
+        self.assertIsInstance(project_info.backup_archive.get("url"), str)
+        self.assertIsNone(project_info.backup_archive.get("annotationsUrl"))
+        self.project_ids.append(single_id)
+
+    def test_single_id_archiving_ann_url(self):
+        # Testing archiving of a single project only with annotations URL
+        created_project_ids = self.create_test_projects(1)
+        single_id = created_project_ids[0]
+        self.assertRaises(
+            TypeError, lambda: self.project_instance.archive(single_id, ann_archive_url=self.url)
+        )
+        self.project_ids.append(single_id)
+
+    def test_multiple_ids_archiving(self):
+        # Testing archiving of multiple projects
+        multiple_ids = self.create_test_projects(3)
+        multiple_urls = [self.url for _ in range(3)]
+        self.project_instance.archive_batch(multiple_ids, multiple_urls, multiple_urls)
+        # Verifying the projects are archived
+        for id in multiple_ids:
+            project_info = self.api.project.get_info_by_id(id)
+            self.assertIsNotNone(project_info)
+            self.assertIsNotNone(project_info.backup_archive)
+            self.assertIsNotNone(project_info.backup_archive.get("url"))
+            self.assertIsNotNone(project_info.backup_archive.get("annotationsUrl"))
+            self.assertIsInstance(project_info.backup_archive.get("url"), str)
+            self.assertIsInstance(project_info.backup_archive.get("annotationsUrl"), str)
+            self.project_ids.append(id)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_api_project_remove_permanently.py
+++ b/tests/test_api_project_remove_permanently.py
@@ -1,0 +1,90 @@
+import unittest
+from unittest.mock import Mock, patch
+
+from supervisely.api.api import Api
+
+
+class TestRemoveProjectPermanently(unittest.TestCase):
+    workspace_id = None
+    api = None
+
+    @classmethod
+    def setUpClass(cls):
+        cls.api = Api.from_env()
+        workspace_id = input("Enter workspace ID for tests here >> ")
+        with patch("builtins.input", return_value="user_input_value"):
+            cls.workspace_id = int(workspace_id)
+
+    def setUp(self):
+        self.project_instance = self.api.project
+
+    def create_test_projects(self, count):
+        """
+        Create test projects for testing 'remove_permanently'.
+        """
+        created_project_ids = []
+        for i in range(count):
+            created_project = self.project_instance.create(
+                self.workspace_id,
+                name=f"unit tests remove_permanently {i+1}",
+                change_name_if_conflict=True,
+            )
+            created_project_ids.append(created_project.id)
+        return created_project_ids
+
+    def test_single_id_deletion(self):
+        # Testing deletion of a single project by ID
+        created_project_ids = self.create_test_projects(1)
+        single_id = created_project_ids[0]
+        response = self.project_instance.remove_permanently(single_id)
+        # Checking for a response
+        self.assertIsInstance(response, list)
+        self.assertEqual(len(response), 1)
+        # Verifying the response for a single project deletion
+        self.assertIn("success", response[0])
+
+    def test_multiple_ids_deletion(self):
+        # Testing deletion of multiple projects by a list of IDs
+        multiple_ids = self.create_test_projects(3)
+        response = self.project_instance.remove_permanently(multiple_ids)
+        # Checking for a response
+        self.assertIsInstance(response, list)
+        self.assertEqual(len(response), 1)
+        # Verifying the response for multiple projects deletion
+        for resp in response:
+            self.assertIn("success", resp)
+
+    def test_batch_size_adjustment(self):
+        # Testing batch size adjustment
+        batch_size = 60
+        created_project_ids = self.create_test_projects(1)
+        single_id = created_project_ids[0]
+        response = self.project_instance.remove_permanently(single_id, batch_size=batch_size)
+        # Checking for a response
+        self.assertIsInstance(response, list)
+        self.assertEqual(len(response), 1)
+        # Verifying that the batch size was correctly adjusted
+        self.assertLessEqual(len(response[0]), 50)
+
+    def test_progress_callback(self):
+        # Testing the progress callback
+        mock_callback = Mock()
+        project_ids = self.create_test_projects(5)
+        self.project_instance.remove_permanently(project_ids, progress_cb=mock_callback)
+        # Verifying the callback invocation for each project
+        mock_callback.assert_called_with(len(project_ids))
+
+    def test_multiple_responses(self):
+        # Testing deletion of multiple projects by a list of IDs in bathc size of 1
+        multiple_ids = self.create_test_projects(3)
+        response = self.project_instance.remove_permanently(multiple_ids, 1)
+        # Checking for a responses
+        self.assertIsInstance(response, list)
+        self.assertEqual(len(response), len(multiple_ids))
+        # Verifying the response for multiple projects deletion
+        for resp in response:
+            self.assertIn("success", resp)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_api_project_remove_permanently.py
+++ b/tests/test_api_project_remove_permanently.py
@@ -42,6 +42,9 @@ class TestRemoveProjectPermanently(unittest.TestCase):
         self.assertEqual(len(response), 1)
         # Verifying the response for a single project deletion
         self.assertIn("success", response[0])
+        # Verifying the project is really deleted
+        project_info = self.api.project.get_info_by_id(single_id)
+        self.assertIsNone(project_info)
 
     def test_multiple_ids_deletion(self):
         # Testing deletion of multiple projects by a list of IDs

--- a/tests/test_api_project_remove_permanently.py
+++ b/tests/test_api_project_remove_permanently.py
@@ -78,7 +78,7 @@ class TestRemoveProjectPermanently(unittest.TestCase):
         mock_callback.assert_called_with(len(project_ids))
 
     def test_multiple_responses(self):
-        # Testing deletion of multiple projects by a list of IDs in bathc size of 1
+        # Testing deletion of multiple projects by a list of IDs in batch size of 1
         multiple_ids = self.create_test_projects(3)
         response = self.project_instance.remove_permanently(multiple_ids, 1)
         # Checking for a responses

--- a/tests/test_api_project_remove_permanently.py
+++ b/tests/test_api_project_remove_permanently.py
@@ -26,7 +26,7 @@ class TestRemoveProjectPermanently(unittest.TestCase):
         for i in range(count):
             created_project = self.project_instance.create(
                 self.workspace_id,
-                name=f"unit tests remove_permanently {i+1}",
+                name=f"[UT] Project remove permanently {i+1}",
                 change_name_if_conflict=True,
             )
             created_project_ids.append(created_project.id)


### PR DESCRIPTION
 - update methods to delete in batches with max allowed size of 50 (by default)
 - add unit tests for:
     - `api.project.remove_permanently`
     - `api.dataset.remove_permanently`
     - `api.project.archive`