### PR TITLE
Removed raw video data parameter for API request

### DIFF
--- a/supervisely/api/video/video_api.py
+++ b/supervisely/api/video/video_api.py
@@ -522,7 +522,6 @@ class VideoApi(RemoveableBulkModuleApi):
                         ApiField.DATASET_ID: dataset_id,
                         ApiField.FILTER: filters,
                         ApiField.FIELDS: fields,
-                        ApiField.RAW_VIDEO_META: True,
                     },
                 )
             )


### PR DESCRIPTION
Reason: [SDK: frames_to_timecodes is None if RAW_VIDEO_META is True](https://github.com/supervisely/issues/issues/4154)