### PR TITLE
update urllib3 version requirement to be <2.0.0

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -61,7 +61,7 @@ INSTALL_REQUIRES = [
     "rich",
     "click",
     "imutils==0.5.4",
-    "urllib3>=1.26.15, <=2.1.0",
+    "urllib3>=1.26.15, <2.0.0",
     "cacheout==0.14.1",
     "jsonschema>=2.6.0,<=4.20.0",
     "pyjwt>=2.1.0,<3.0.0",


### PR DESCRIPTION
With urllib3 >= 2.0.0 There is a following error:

```
Traceback (most recent call last):
  File "/usr/local/lib/python3.8/dist-packages/requests_toolbelt/_compat.py", line 48, in <module>
    from requests.packages.urllib3.contrib import appengine as gaecontrib
ImportError: cannot import name 'appengine' from 'requests.packages.urllib3.contrib' (/usr/local/lib/python3.8/dist-packages/urllib3/contrib/__init__.py)
```