### PR TITLE
Update RAM usage in tracking interface

### DIFF
--- a/supervisely/nn/inference/tracking/tracker_interface.py
+++ b/supervisely/nn/inference/tracking/tracker_interface.py
@@ -154,14 +154,11 @@ class TrackerInterface:
             self._hot_cache[frame_index] = self.api.video.frame.download_np(
                 self.video_id, frame_index
             )
+            return self._hot_cache[frame_index]
         else:
-            frame = self._local_cache_loader(
+            return self._local_cache_loader(
                 self.api, self.video_id, frame_index
             )
-            if self.load_all_frames:
-                self._hot_cache[frame_index] = frame
-            return frame
-        return self._hot_cache[frame_index]
 
     def _load_frames(self):
         rgbs = []

--- a/supervisely/nn/inference/tracking/tracker_interface.py
+++ b/supervisely/nn/inference/tracking/tracker_interface.py
@@ -155,9 +155,12 @@ class TrackerInterface:
                 self.video_id, frame_index
             )
         else:
-            self._hot_cache[frame_index] = self._local_cache_loader(
+            frame = self._local_cache_loader(
                 self.api, self.video_id, frame_index
             )
+            if self.load_all_frames:
+                self._hot_cache[frame_index] = frame
+            return frame
         return self._hot_cache[frame_index]
 
     def _load_frames(self):


### PR DESCRIPTION
disable saving frames in hot_cache (RAM) in TrackerInterface
- if smart caching is used (`frame_loader=self.download_frame`)
- if `load_all_frames is False`