### PR TITLE
ImageRegionSelect point size fix

### DIFF
--- a/supervisely/app/widgets/image_region_selector/script.js
+++ b/supervisely/app/widgets/image_region_selector/script.js
@@ -160,7 +160,7 @@ Vue.component('smarttool-editor', {
       const viewBox = getViewBox(this.bboxEl.bbox());
       this.sceneEl.viewbox(viewBox)
       this.backgroundEl = this.sceneEl.image(this.imageUrl).loaded(() => {
-        this.pointSize = POINT_SIZE * (viewBox.w / this.container.width.baseVal.value);
+        this.pointSize = POINT_SIZE * (getViewBox(this.bboxEl.bbox()).w / this.container.width.baseVal.value);
         this.initPoints();
       });
       this.group.add(


### PR DESCRIPTION
Point sizes in the ImageRegionSelector widget have wrong calculations after changing images in the widget.
This fix will solve the issue.