### PR TITLE
Fix bugs when reading a local project / dataset. New arg in sly.fs. subdirs_tree

### DIFF
--- a/supervisely/io/fs.py
+++ b/supervisely/io/fs.py
@@ -501,7 +501,7 @@ def get_subdirs_tree(dir_path: str) -> Dict[str, Union[str, Dict]]:
 def subdirs_tree(
         dir_path: str,
         ignore: Optional[List[str]] = None,
-        ignore_included: Optional[List[str]] = None,
+        ignore_content: Optional[List[str]] = None,
 ) -> Generator[str, None, None]:
     """Generator that yields directories in the directory tree,
     starting from the level below the root directory and then going down the tree.
@@ -514,21 +514,21 @@ def subdirs_tree(
         subdirectories of ignored directories. It will only ignore paths which end with
         the specified directory names.
     :type ignore: List[str]
-    :param ignore_included: List of directories which subdirectories should be ignored too.
-    :type ignore_included: List[str]
+    :param ignore_content: List of directories which subdirectories should be ignored.
+    :type ignore_content: List[str]
     :returns: Generator that yields directories in the directory tree.
     :rtype: Generator[str, None, None]
     """
     tree = get_subdirs_tree(dir_path)
     ignore = ignore or []
-    ignore_included = ignore_included or []
+    ignore_content = ignore_content or []
 
     def _subdirs_tree(tree, path=""):
         for key, value in tree.items():
             new_path = os.path.join(path, key) if path else key
             if not any(new_path.endswith(i) for i in ignore):
                 yield new_path
-            elif any(new_path.endswith(i) for i in ignore_included):
+            if any(new_path.endswith(i) for i in ignore_content):
                 continue
             if value:
                 yield from _subdirs_tree(value, new_path)

--- a/supervisely/io/fs.py
+++ b/supervisely/io/fs.py
@@ -498,7 +498,11 @@ def get_subdirs_tree(dir_path: str) -> Dict[str, Union[str, Dict]]:
     return tree
 
 
-def subdirs_tree(dir_path: str, ignore: Optional[List[str]] = None) -> Generator[str, None, None]:
+def subdirs_tree(
+        dir_path: str,
+        ignore: Optional[List[str]] = None,
+        ignore_included: Optional[List[str]] = None,
+) -> Generator[str, None, None]:
     """Generator that yields directories in the directory tree,
     starting from the level below the root directory and then going down the tree.
     If ignore is specified, it will ignore paths which end with the specified directory names.
@@ -510,17 +514,22 @@ def subdirs_tree(dir_path: str, ignore: Optional[List[str]] = None) -> Generator
         subdirectories of ignored directories. It will only ignore paths which end with
         the specified directory names.
     :type ignore: List[str]
+    :param ignore_included: List of directories which subdirectories should be ignored too.
+    :type ignore_included: List[str]
     :returns: Generator that yields directories in the directory tree.
     :rtype: Generator[str, None, None]
     """
     tree = get_subdirs_tree(dir_path)
     ignore = ignore or []
+    ignore_included = ignore_included or []
 
     def _subdirs_tree(tree, path=""):
         for key, value in tree.items():
             new_path = os.path.join(path, key) if path else key
             if not any(new_path.endswith(i) for i in ignore):
                 yield new_path
+            elif any(new_path.endswith(i) for i in ignore_included):
+                continue
             if value:
                 yield from _subdirs_tree(value, new_path)
 

--- a/supervisely/project/project.py
+++ b/supervisely/project/project.py
@@ -167,9 +167,16 @@ class Dataset(KeyObject):
         self._item_to_ann = {}  # item file name -> annotation file name
 
         parts = directory.split(os.path.sep)
-        project_dir = parts[0]
-        full_ds_name = os.path.join(*[p for p in parts[1:] if p != self.datasets_dir_name])
-        short_ds_name = os.path.basename(directory)
+        if self.datasets_dir_name not in parts:
+            project_dir, ds_name = os.path.split(directory.rstrip("/"))
+            full_ds_name = short_ds_name = ds_name
+        else:
+            nested_ds_dir_index = parts.index(self.datasets_dir_name)
+            ds_dir_index = nested_ds_dir_index - 1
+
+            project_dir = os.path.join(*parts[: ds_dir_index])
+            full_ds_name = os.path.join(*[p for p in parts[ds_dir_index :] if p != self.datasets_dir_name])
+            short_ds_name = os.path.basename(directory)
 
         self._project_dir = project_dir
         self._name = full_ds_name

--- a/supervisely/project/project.py
+++ b/supervisely/project/project.py
@@ -1729,7 +1729,6 @@ class Project:
         possible_datasets = subdirs_tree(self.directory, self.dataset_class.ignorable_dirs(), ignore_included)
 
         for ds_name in possible_datasets:
-            logger.debug(f"Reading dataset {ds_name}")
             parents = ds_name.split(os.path.sep)
             parents = [p for p in parents if p != self.dataset_class.datasets_dir()]
             if len(parents) > 1:

--- a/supervisely/project/project.py
+++ b/supervisely/project/project.py
@@ -1729,6 +1729,7 @@ class Project:
         possible_datasets = subdirs_tree(self.directory, self.dataset_class.ignorable_dirs(), ignore_included)
 
         for ds_name in possible_datasets:
+            logger.debug(f"Reading dataset {ds_name}")
             parents = ds_name.split(os.path.sep)
             parents = [p for p in parents if p != self.dataset_class.datasets_dir()]
             if len(parents) > 1:

--- a/supervisely/project/project.py
+++ b/supervisely/project/project.py
@@ -1723,10 +1723,13 @@ class Project:
     def _read(self):
         meta_json = load_json_file(self._get_project_meta_path())
         self._meta = ProjectMeta.from_json(meta_json)
-        ignore_included = self.dataset_class.ignorable_dirs()
-        ignore_included.pop(ignore_included.index(self.dataset_class.datasets_dir()))
 
-        possible_datasets = subdirs_tree(self.directory, self.dataset_class.ignorable_dirs(), ignore_included)
+        ignore_dirs = self.dataset_class.ignorable_dirs() # dir names that can not be datasets
+
+        ignore_content_dirs = ignore_dirs.copy() # dir names which can not contain datasets
+        ignore_content_dirs.pop(ignore_content_dirs.index(self.dataset_class.datasets_dir()))
+
+        possible_datasets = subdirs_tree(self.directory, ignore_dirs, ignore_content_dirs)
 
         for ds_name in possible_datasets:
             parents = ds_name.split(os.path.sep)


### PR DESCRIPTION
- new argument in `sly.fs.subdirs_tree` to ignore subdirs of the specified dirs
- fix: using `dataset_class` instead of `Dataset` (videos, volumes, pointclouds, episodes projects)
- fix: get the correct `project_dir` and dataset names in dataset class initialization