### PR TITLE
Added setuptools dependency for support Python 3.12.2

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -65,7 +65,7 @@ INSTALL_REQUIRES = [
     "cacheout==0.14.1",
     "jsonschema>=2.6.0,<=4.20.0",
     "pyjwt>=2.1.0,<3.0.0",
-    "setuptools"
+    "setuptools<=65.5.0"
 ]
 
 ALT_INSTALL_REQUIRES = {

--- a/setup.py
+++ b/setup.py
@@ -65,6 +65,7 @@ INSTALL_REQUIRES = [
     "cacheout==0.14.1",
     "jsonschema>=2.6.0,<=4.20.0",
     "pyjwt>=2.1.0,<3.0.0",
+    "setuptools"
 ]
 
 ALT_INSTALL_REQUIRES = {


### PR DESCRIPTION
Issue on the Python 3.12.2: 
```python
supervisely/init.py", line 3, in
import pkg_resources # isort: skip
^^^^^^^^^^^^^^^^^^^^
ModuleNotFoundError: No module named 'pkg_resources'
```
Related: https://github.com/supervisely/issues/issues/4497