### PR TITLE
Upgrade JS bundle to 2.1.79. Fixes for import PCDe and FileStorageUpload widget

### DIFF
--- a/supervisely/app/fastapi/templating.py
+++ b/supervisely/app/fastapi/templating.py
@@ -11,7 +11,7 @@ from supervisely.app.singleton import Singleton
 from supervisely.app.widgets_context import JinjaWidgets
 
 # https://github.com/supervisely/js-bundle
-js_bundle_version = "2.1.77"
+js_bundle_version = "2.1.79"
 
 # https://github.com/supervisely-ecosystem/supervisely-app-frontend-js
 js_frontend_version = "v0.0.50"

--- a/supervisely/app/widgets/file_storage_upload/file_storage_upload.py
+++ b/supervisely/app/widgets/file_storage_upload/file_storage_upload.py
@@ -28,7 +28,8 @@ class FileStorageUpload(Widget):
 
     def _get_path(self, path: str):
         if self._change_name_if_conflict is True:
-            path = f"/{path}" if not path.startswith("/") else path
+            if "://" not in path:
+                path = f"/{path}" if not path.startswith("/") else path
             return self._api.file.get_free_dir_name(self._team_id, path)
         return path
 

--- a/supervisely/convert/base_converter.py
+++ b/supervisely/convert/base_converter.py
@@ -11,11 +11,11 @@ from tqdm import tqdm
 from supervisely import (
     Annotation,
     Api,
-    logger,
-    is_production,
     Progress,
     ProjectMeta,
     TagValueType,
+    is_production,
+    logger,
 )
 from supervisely.io.fs import JUNK_FILES, get_file_ext, get_file_name_with_ext
 
@@ -65,7 +65,7 @@ class BaseConverter:
             custom_data: dict = {},
         ):
             self._path: str = item_path
-            self._name : str = None
+            self._name: str = None
             self._ann_data: Union[str, dict] = ann_data
             self._shape: Union[Tuple, List] = shape
             self._custom_data: dict = custom_data
@@ -85,6 +85,7 @@ class BaseConverter:
         @path.setter
         def path(self, path: str) -> None:
             self._path = path
+
         @property
         def ann_data(self) -> Union[str, dict]:
             return self._ann_data
@@ -220,7 +221,7 @@ class BaseConverter:
         progress_cb(1)
 
         if len(found_formats) == 0:
-            logger.warn("Not found any valid annotation formats. Only items will be processed")
+            logger.info("Not found any valid annotation formats. Only items will be processed")
             for root, _, files in os.walk(self._input_data):
                 for file in files:
                     full_path = os.path.join(root, file)
@@ -290,7 +291,6 @@ class BaseConverter:
                 new_tag = new_tag.clone(name=new_name)
                 meta1 = meta1.add_tag_meta(new_tag)
 
-
         # update project meta
         api.project.update_meta(dataset.project_id, meta1)
 
@@ -307,10 +307,7 @@ class BaseConverter:
             progress_cb = progress.iters_done_report
         else:
             progress = tqdm(
-                total=total,
-                desc=message,
-                unit="B" if is_size else "it",
-                unit_scale=is_size
+                total=total, desc=message, unit="B" if is_size else "it", unit_scale=is_size
             )
             progress_cb = progress.update
         return progress, progress_cb

--- a/supervisely/convert/pointcloud_episodes/pointcloud_episodes_converter.py
+++ b/supervisely/convert/pointcloud_episodes/pointcloud_episodes_converter.py
@@ -1,7 +1,5 @@
 from typing import List, Optional
 
-from tqdm import tqdm
-
 from supervisely import (
     Api,
     PointcloudEpisodeAnnotation,
@@ -15,6 +13,7 @@ from supervisely.api.module_api import ApiField
 from supervisely.convert.base_converter import BaseConverter
 from supervisely.io.json import load_json_file
 from supervisely.pointcloud.pointcloud import ALLOWED_POINTCLOUD_EXTENSIONS
+from tqdm import tqdm
 
 
 class PointcloudEpisodeConverter(BaseConverter):
@@ -87,9 +86,13 @@ class PointcloudEpisodeConverter(BaseConverter):
     ):
         """Upload converted data to Supervisely"""
 
-        meta, renamed_classes, renamed_tags = self.merge_metas_with_conflicts(api, dataset_id)
+        meta, renamed_classes, renamed_tags = self.merge_metas_with_conflicts(
+            api, dataset_id
+        )
 
-        existing_names = set([pcde.name for pcde in api.pointcloud_episode.get_list(dataset_id)])
+        existing_names = set(
+            [pcde.name for pcde in api.pointcloud_episode.get_list(dataset_id)]
+        )
 
         if log_progress:
             progress, progress_cb = self.get_progress(
@@ -128,42 +131,55 @@ class PointcloudEpisodeConverter(BaseConverter):
                 item_metas.append({"frame": item._frame_number})
                 rimg_infos = []
                 camera_names = []
-                img_paths, rimg_ann_paths = list(zip(*item._related_images))
-                rimg_hashes = api.pointcloud_episode.upload_related_images(img_paths)
-                for img_ind, (img_hash, rimg_ann_path) in enumerate(
-                    zip(rimg_hashes, rimg_ann_paths)
-                ):
-                    meta_json = load_json_file(rimg_ann_path)
-                    try:
-                        if ApiField.META not in meta_json:
-                            raise ValueError("Related image meta not found in json file.")
-                        if ApiField.NAME not in meta_json:
-                            raise ValueError("Related image name not found in json file.")
-                        if "deviceId" not in meta_json[ApiField.META].keys():
-                            camera_names.append(f"CAM_{str(img_ind).zfill(2)}")
-                        else:
-                            camera_names.append(meta_json[ApiField.META]["deviceId"])
-                        rimg_infos.append(
-                            {
-                                ApiField.ENTITY_ID: pcd_id,
-                                ApiField.NAME: meta_json[ApiField.NAME],
-                                ApiField.HASH: img_hash,
-                                ApiField.META: meta_json[ApiField.META],
-                            }
-                        )
-                        api.pointcloud.add_related_images(rimg_infos, camera_names)
-                    except Exception as e:
-                        logger.warn(
-                            f"Failed to upload related image or add it to pointcloud episo: {repr(e)}"
-                        )
-                        continue
+                if len(item._related_images) > 0:
+                    img_paths, rimg_ann_paths = list(zip(*item._related_images))
+                    rimg_hashes = api.pointcloud_episode.upload_related_images(
+                        img_paths
+                    )
+                    for img_ind, (img_hash, rimg_ann_path) in enumerate(
+                        zip(rimg_hashes, rimg_ann_paths)
+                    ):
+                        meta_json = load_json_file(rimg_ann_path)
+                        try:
+                            if ApiField.META not in meta_json:
+                                raise ValueError(
+                                    "Related image meta not found in json file."
+                                )
+                            if ApiField.NAME not in meta_json:
+                                raise ValueError(
+                                    "Related image name not found in json file."
+                                )
+                            if "deviceId" not in meta_json[ApiField.META].keys():
+                                camera_names.append(f"CAM_{str(img_ind).zfill(2)}")
+                            else:
+                                camera_names.append(
+                                    meta_json[ApiField.META]["deviceId"]
+                                )
+                            rimg_infos.append(
+                                {
+                                    ApiField.ENTITY_ID: pcd_id,
+                                    ApiField.NAME: meta_json[ApiField.NAME],
+                                    ApiField.HASH: img_hash,
+                                    ApiField.META: meta_json[ApiField.META],
+                                }
+                            )
+                            api.pointcloud.add_related_images(rimg_infos, camera_names)
+                        except Exception as e:
+                            logger.warn(
+                                f"Failed to upload related image or add it to pointcloud episo: {repr(e)}"
+                            )
+                            continue
 
             if log_progress:
                 progress_cb(len(batch))
 
         if self.items_count > 0:
-            ann = self.to_supervisely(self._items[0], meta, renamed_classes, renamed_tags)
-            api.pointcloud_episode.annotation.append(dataset_id, ann, frame_to_pointcloud_ids)
+            ann = self.to_supervisely(
+                self._items[0], meta, renamed_classes, renamed_tags
+            )
+            api.pointcloud_episode.annotation.append(
+                dataset_id, ann, frame_to_pointcloud_ids
+            )
 
         if log_progress:
             if is_development():


### PR DESCRIPTION
* Add warning if frames mapping file not found for PCDe import.
* Add support for uploading PCDe without rimgs.
* Set log level to info for data without annotation format.
* Upgrade JS bundle to "2.1.79".
* Fix get_path method in FileStorageUpload widget