### PR TITLE
Limit task by workspace

### DIFF
--- a/supervisely/__init__.py
+++ b/supervisely/__init__.py
@@ -306,4 +306,4 @@ except Exception as e:
 # If new changes in Supervisely Python SDK require upgrade of the Supervisely instance
 # set a new value for the environment variable MINIMUM_INSTANCE_VERSION_FOR_SDK, otherwise
 # users can face compatibility issues, if the instance version is lower than the SDK version.
-os.environ["MINIMUM_INSTANCE_VERSION_FOR_SDK"] = "6.9.13"
+os.environ["MINIMUM_INSTANCE_VERSION_FOR_SDK"] = "6.9.18"

--- a/supervisely/api/module_api.py
+++ b/supervisely/api/module_api.py
@@ -526,6 +526,10 @@ class ApiField:
     """"""
     IMPORT_SETTINGS = "importSettings"
     """"""
+    ADVANCED_SETTINGS = "advancedSettings"
+    """"""
+    LIMIT_BY_WORKSPACE = "limitByWorkspace"
+    """"""
 
 
 def _get_single_item(items):

--- a/supervisely/api/task_api.py
+++ b/supervisely/api/task_api.py
@@ -504,6 +504,7 @@ class TaskApi(ModuleApiBase, ModuleWithStatus):
         proxy_keep_url: Optional[bool] = False,
         module_id: Optional[int] = None,
         redirect_requests: Optional[Dict[str, int]] = {},
+        limit_by_workspace: bool = False,
     ) -> Dict[str, Any]:
         """Starts the application task on the agent.
 
@@ -537,6 +538,9 @@ class TaskApi(ModuleApiBase, ModuleWithStatus):
         :type module_id: int, optional
         :param redirect_requests: For internal usage only in Develop and Debug mode.
         :type redirect_requests: Dict[str, int], optional
+        :param limit_by_workspace: If set to True tasks will be only visible inside of the workspace
+            with specified workspace_id.
+        :type limit_by_workspace: bool, optional
         :return: Task information in JSON format.
         :rtype: Dict[str, Any]
 
@@ -571,6 +575,10 @@ class TaskApi(ModuleApiBase, ModuleWithStatus):
         if app_id is None and module_id is None:
             raise ValueError("One of the arguments (app_id or module_id) have to be defined")
 
+        advanced_settings = {
+            ApiField.LIMIT_BY_WORKSPACE: limit_by_workspace,
+        }
+
         data = {
             ApiField.AGENT_ID: agent_id,
             # "nodeId": agent_id,
@@ -584,6 +592,7 @@ class TaskApi(ModuleApiBase, ModuleWithStatus):
             ApiField.TASK_NAME: task_name,
             ApiField.RESTART_POLICY: restart_policy,
             ApiField.PROXY_KEEP_URL: proxy_keep_url,
+            ApiField.ADVANCED_SETTINGS: advanced_settings,
         }
         if len(redirect_requests) > 0:
             data[ApiField.REDIRECT_REQUESTS] = redirect_requests


### PR DESCRIPTION
Tasks can be limited to be visible only in the specified workspace.

```python
import supervisely as sly

api = sly.Api.from_env()

agent_id = 469
module_id = 54

task_info = api.task.start(
    agent_id=agent_id,
    module_id=module_id,
    workspace_id=workspace_id,
    limit_by_workspace=True,
)
```