### PR TITLE
Shifting to ImageProxy for resizing and compressing images

### DIFF
--- a/supervisely/_utils.py
+++ b/supervisely/_utils.py
@@ -226,10 +226,6 @@ def compress_image_url(
     :return: Full URL to a compressed image.
     :rtype: str
     """
-    logger.warning(
-        "compress_image_url is deprecated. Use resize_image_url instead. "
-        "NOTE: compress_image_url returning INCORRECT RESULTS already."
-    )
     if width is None:
         width = ""
     if height is None:

--- a/supervisely/_utils.py
+++ b/supervisely/_utils.py
@@ -288,13 +288,16 @@ def resize_image_url(
     # original url example: https://app.supervisely.com/h5un6l2bnaz1vj8a9qgms4-public/images/original/2/X/Re/<image_name>.jpg
     # resized url example:  https://app.supervisely.com/previews/q/ext:jpeg/resize:fill:300:0:0/q:70/plain/h5un6l2bnaz1vj8a9qgms4-public/images/original/2/X/Re/<image_name>.jpg
     # to add: previews/q/ext:jpeg/resize:fill:300:0:0/q:70/plain/
+    try:
+        parsed_url = urllib.parse.urlparse(full_storage_url)
+        server_address = f"{parsed_url.scheme}://{parsed_url.netloc}"
 
-    parsed_url = urllib.parse.urlparse(full_storage_url)
-    server_address = f"{parsed_url.scheme}://{parsed_url.netloc}"
-
-    resize_string = f"previews/q/ext:{ext}/resize:{method}:{width}:{height}:0/q:{quality}/plain"
-    url = full_storage_url.replace(server_address, f"{server_address}/{resize_string}")
-    return url
+        resize_string = f"previews/q/ext:{ext}/resize:{method}:{width}:{height}:0/q:{quality}/plain"
+        url = full_storage_url.replace(server_address, f"{server_address}/{resize_string}")
+        return url
+    except Exception as e:
+        logger.debug(f"Failed to resize image with url: {full_storage_url}: {e}")
+        return full_storage_url
 
 
 def get_preview_link(title="preview"):

--- a/supervisely/_utils.py
+++ b/supervisely/_utils.py
@@ -244,11 +244,13 @@ def resize_image_url(
     full_storage_url: str,
     ext: Literal["jpeg", "png"] = "jpeg",
     method: Literal["fit", "fill", "fill-down", "force", "auto"] = "auto",
-    width: int = 256,
+    width: int = 0,
     height: int = 0,
     quality: int = 70,
 ) -> str:
     """Returns a URL to a resized image with given parameters.
+    Default sizes are 0, which means that the image will not be resized,
+    just compressed if the extension is jpeg to the given quality.
     Learn more about resize parameters `here <https://docs.imgproxy.net/usage/processing#resize>`_.
 
     :param full_storage_url: Full Image storage URL, can be obtained from ImageInfo.

--- a/supervisely/_utils.py
+++ b/supervisely/_utils.py
@@ -292,7 +292,7 @@ def resize_image_url(
         url = full_storage_url.replace(server_address, f"{server_address}/{resize_string}")
         return url
     except Exception as e:
-        logger.debug(f"Failed to resize image with url: {full_storage_url}: {e}")
+        logger.debug(f"Failed to resize image with url: {full_storage_url}: {repr(e)}")
         return full_storage_url
 
 

--- a/supervisely/api/image_api.py
+++ b/supervisely/api/image_api.py
@@ -33,6 +33,7 @@ from supervisely._utils import (
     generate_free_name,
     get_bytes_hash,
     is_development,
+    resize_image_url,
 )
 from supervisely.annotation.annotation import Annotation
 from supervisely.annotation.tag import Tag
@@ -155,11 +156,7 @@ class ImageInfo(NamedTuple):
         :return: Image preview URL.
         :rtype: :class:`str`
         """
-        res = self.full_storage_url
-        if is_development():
-            res = abs_url(res)
-        res = compress_image_url(url=res)
-        return res
+        return resize_image_url(self.full_storage_url)
 
 
 class ImageApi(RemoveableBulkModuleApi):

--- a/supervisely/api/image_api.py
+++ b/supervisely/api/image_api.py
@@ -28,12 +28,9 @@ from requests_toolbelt import MultipartDecoder, MultipartEncoder
 from tqdm import tqdm
 
 from supervisely._utils import (
-    abs_url,
     batched,
-    compress_image_url,
     generate_free_name,
     get_bytes_hash,
-    is_development,
     resize_image_url,
 )
 from supervisely.annotation.annotation import Annotation

--- a/supervisely/api/image_api.py
+++ b/supervisely/api/image_api.py
@@ -16,6 +16,7 @@ from typing import (
     Generator,
     Iterator,
     List,
+    Literal,
     NamedTuple,
     Optional,
     Tuple,
@@ -2361,9 +2362,12 @@ class ImageApi(RemoveableBulkModuleApi):
         width: Optional[int] = None,
         height: Optional[int] = None,
         quality: Optional[int] = 70,
+        ext: Literal["jpeg", "png"] = "jpeg",
+        method: Literal["fit", "fill", "fill-down", "force", "auto"] = "auto",
     ) -> str:
         """
         Previews Image with the given resolution parameters.
+        Learn more about resize parameters `here <https://docs.imgproxy.net/usage/processing#resize>`_.
 
         :param url: Full Image storage URL.
         :type url: str
@@ -2373,6 +2377,10 @@ class ImageApi(RemoveableBulkModuleApi):
         :type height: int
         :param quality: Preview Image quality.
         :type quality: int
+        :param ext: Preview Image extension, available values: "jpeg", "png".
+        :type ext: str, optional
+        :param method: Preview Image resize method, available values: "fit", "fill", "fill-down", "force", "auto".
+        :type method: str, optional
         :return: New URL with resized Image
         :rtype: :class:`str`
         :Usage example:
@@ -2389,16 +2397,7 @@ class ImageApi(RemoveableBulkModuleApi):
             img_info = api.image.get_info_by_id(image_id)
             img_preview_url = api.image.preview_url(img_info.full_storage_url, width=512, height=256)
         """
-        # @TODO: if both width and height are defined, and they are not proportioned to original image resolution,
-        # then images will be croped from center
-        if width is None:
-            width = ""
-        if height is None:
-            height = ""
-        return url.replace(
-            "/image-converter",
-            f"/previews/{width}x{height},jpeg,q{quality}/image-converter",
-        )
+        return resize_image_url(url, ext, method, width, height, quality)
 
     def update_meta(self, id: int, meta: Dict) -> Dict:
         """


### PR DESCRIPTION
Works for:

- preview_url property of ImageInfo objects
- api.image.preview_url() method