### PR TITLE
New Import: Group 2D DICOM, meta from 3D DICOM. Graph shape for videos. Handling corner cases. New method api.image.upload_medical_images()

### DIFF
--- a/supervisely/api/image_api.py
+++ b/supervisely/api/image_api.py
@@ -8,6 +8,8 @@ import io
 import json
 import re
 import urllib.parse
+from collections import defaultdict
+from pathlib import Path
 from time import sleep
 from typing import (
     Any,
@@ -22,6 +24,7 @@ from typing import (
     Tuple,
     Union,
 )
+from uuid import uuid4
 
 import numpy as np
 from requests_toolbelt import MultipartDecoder, MultipartEncoder
@@ -45,6 +48,7 @@ from supervisely.api.module_api import (
 )
 from supervisely.imaging import image as sly_image
 from supervisely.io.fs import (
+    clean_dir,
     ensure_base_path,
     get_file_ext,
     get_file_hash,
@@ -53,6 +57,7 @@ from supervisely.io.fs import (
     list_files,
     list_files_recursively,
 )
+from supervisely.project.project_meta import ProjectMeta
 from supervisely.project.project_type import (
     _MULTISPECTRAL_TAG_NAME,
     _MULTIVIEW_TAG_NAME,
@@ -2689,7 +2694,7 @@ class ImageApi(RemoveableBulkModuleApi):
         :type group_name: str
         :param paths: List of paths to images.
         :type paths: List[str]
-        :param metas: List of image metas (optional)
+        :param metas: List of dictionaries which adds a customizable meta for every image provided in `paths` parameter.
         :type metas: Optional[List[Dict]]
         :param progress_cb: Function for tracking upload progress.
         :type progress_cb: Optional[Union[tqdm, Callable]]
@@ -2726,9 +2731,9 @@ class ImageApi(RemoveableBulkModuleApi):
         group_tag = Tag(meta=group_tag_meta, value=group_name)
 
         for path in paths:
-            if get_file_ext(path) not in sly_image.SUPPORTED_IMG_EXTS:
+            if get_file_ext(path).lower() not in sly_image.SUPPORTED_IMG_EXTS:
                 raise RuntimeError(
-                    f"Image {path} has unsupported extension. Supported extensions: {sly_image.SUPPORTED_IMG_EXTS}"
+                    f"Image {path!r} has unsupported extension. Supported extensions: {sly_image.SUPPORTED_IMG_EXTS}"
                 )
 
         names = [get_file_name(path) for path in paths]
@@ -2749,6 +2754,139 @@ class ImageApi(RemoveableBulkModuleApi):
             dataset_id, filters=[{"field": "id", "operator": "in", "value": image_ids}]
         )
         return uploaded_image_infos
+
+    def upload_medical_images(
+        self,
+        dataset_id: int,
+        paths: List[str],
+        group_tag_name: Optional[str] = None,
+        metas: Optional[List[Dict]] = None,
+        progress_cb: Optional[Union[tqdm, Callable]] = None,
+    ) -> List[ImageInfo]:
+        """
+        Upload medical 2D images (DICOM & NiFTi) to Supervisely and group them by specified or default tag.
+
+        :param dataset_id: Dataset ID in Supervisely.
+        :type dataset_id: int
+        :param paths: List of paths to images.
+        :type paths: List[str]
+        :param group_tag_name: Group name. All images will be assigned by tag with this group name. If `group_tag_name` is None, the images will be grouped by one of the default tags.
+        :type group_tag_name: str, optional
+        :param metas: List of dictionaries which adds a customizable meta for every image provided in `paths` parameter.
+        :type metas: List[Dict], optional
+        :param progress_cb: Function for tracking upload progress.
+        :type progress_cb: tqdm or callable, optional
+
+        :return: List of uploaded images infos.
+        :rtype: List[ImageInfo]
+
+        :raises Exception: If tag does not exist in project or tag is not of type ANY_STRING
+        :raises Exception: If length of `metas` is not equal to the length of `paths`.
+
+        :Usage example:
+
+         .. code-block:: python
+
+            import os
+            from dotenv import load_dotenv
+            from tqdm import tqdm
+
+            import supervisely as sly
+
+            # Load secrets and create API object from .env file (recommended)
+            # Learn more here: https://developer.supervisely.com/getting-started/basics-of-authentication
+            if sly.is_development():
+               load_dotenv(os.path.expanduser("~/supervisely.env"))
+
+            api = sly.Api.from_env()
+
+            dataset_id = 123456
+            paths = ['path/to/medical_01.dcm', 'path/to/medical_02.dcm']
+            metas = [{'meta':'01'}, {'meta':'02'}]
+            group_tag_name = 'StudyInstanceUID'
+
+            pbar = tqdm(desc="Uploading images", total=len(paths))
+            image_infos = api.image.upload_medical_images(dataset_id, paths, group_tag_name, metas)
+
+        """
+
+        if metas is None:
+            _metas = [dict() for _ in paths]
+        else:
+            if len(metas) != len(paths):
+                raise ValueError("Length of 'metas' is not equal to the length of 'paths'.")
+            _metas = metas.copy()
+
+        dataset = self._api.dataset.get_info_by_id(dataset_id, raise_error=True)
+        meta_json = self._api.project.get_meta(dataset.project_id)
+        project_meta = ProjectMeta.from_json(meta_json)
+
+        import nrrd
+
+        from supervisely.convert.image.medical2d.medical2d_helper import (
+            convert_dcm_to_nrrd,
+        )
+
+        image_paths = []
+        image_names = []
+        anns = []
+
+        converted_dir_name = uuid4().hex
+        converted_dir = Path("/tmp/") / converted_dir_name
+
+        group_tag_counter = defaultdict(int)
+        for path, image_meta in zip(paths, _metas):
+            try:
+                nrrd_paths, nrrd_names, group_tags, dcm_meta = convert_dcm_to_nrrd(
+                    image_path=path,
+                    converted_dir=converted_dir.as_posix(),
+                    group_tag_name=group_tag_name,
+                )
+                image_meta.update(dcm_meta)
+                image_paths.extend(nrrd_paths)
+                image_names.extend(nrrd_names)
+
+                for nrrd_path in nrrd_paths:
+                    tags = []
+                    for tag in group_tags:
+                        tag_meta = project_meta.get_tag_meta(tag["name"])
+                        if tag_meta is None:
+                            tag_meta = TagMeta(tag["name"], TagValueType.ANY_STRING)
+                            project_meta = project_meta.add_tag_meta(tag_meta)
+                        tag = Tag(meta=tag_meta, value=tag["value"])
+                        tags.append(tag)
+                    img_size = nrrd.read_header(nrrd_path)["sizes"].tolist()[::-1]
+                    ann = Annotation(img_size=img_size, img_tags=tags)
+                    anns.append(ann)
+
+                for tag in group_tags:
+                    group_tag_counter[tag["name"]] += 1
+            except Exception as e:
+                logger.warning(f"File '{path}' will be skipped due to: {str(e)}")
+                continue
+
+        image_infos = self.upload_paths(
+            dataset_id=dataset_id,
+            names=image_names,
+            paths=image_paths,
+            progress_cb=progress_cb,
+            metas=_metas,
+        )
+        image_ids = [image_info.id for image_info in image_infos]
+
+        # Update the project metadata and enable image grouping
+        self._api.project.update_meta(id=dataset.project_id, meta=project_meta.to_json())
+        if len(group_tag_counter) > 0:
+            max_used_tag_name = max(group_tag_counter, key=group_tag_counter.get)
+            if group_tag_name not in group_tag_counter:
+                group_tag_name = max_used_tag_name
+            self._api.project.images_grouping(
+                id=dataset.project_id, enable=True, tag_name=group_tag_name
+            )
+        self._api.annotation.upload_anns(image_ids, anns)
+        clean_dir(converted_dir.as_posix())
+
+        return image_infos
 
     def get_free_names(self, dataset_id: int, names: List[str]) -> List[str]:
         """

--- a/supervisely/api/image_api.py
+++ b/supervisely/api/image_api.py
@@ -2842,7 +2842,7 @@ class ImageApi(RemoveableBulkModuleApi):
                     converted_dir=converted_dir.as_posix(),
                     group_tag_name=group_tag_name,
                 )
-                image_meta.update(dcm_meta)
+                image_meta.update(dcm_meta) # TODO: check update order
                 image_paths.extend(nrrd_paths)
                 image_names.extend(nrrd_names)
 
@@ -2853,6 +2853,8 @@ class ImageApi(RemoveableBulkModuleApi):
                         if tag_meta is None:
                             tag_meta = TagMeta(tag["name"], TagValueType.ANY_STRING)
                             project_meta = project_meta.add_tag_meta(tag_meta)
+                        elif tag_meta.value_type != TagValueType.ANY_STRING:
+                            raise ValueError(f"Tag '{tag['name']}' is not of type ANY_STRING.")
                         tag = Tag(meta=tag_meta, value=tag["value"])
                         tags.append(tag)
                     img_size = nrrd.read_header(nrrd_path)["sizes"].tolist()[::-1]

--- a/supervisely/api/image_api.py
+++ b/supervisely/api/image_api.py
@@ -2764,7 +2764,7 @@ class ImageApi(RemoveableBulkModuleApi):
         progress_cb: Optional[Union[tqdm, Callable]] = None,
     ) -> List[ImageInfo]:
         """
-        Upload medical 2D images (DICOM & NiFTi) to Supervisely and group them by specified or default tag.
+        Upload medical 2D images (DICOM) to Supervisely and group them by specified or default tag.
 
         :param dataset_id: Dataset ID in Supervisely.
         :type dataset_id: int

--- a/supervisely/convert/base_converter.py
+++ b/supervisely/convert/base_converter.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import os
 from typing import List, Tuple, Union
 
@@ -8,16 +10,14 @@ except ImportError:
 
 from tqdm import tqdm
 
-from supervisely import (
-    Annotation,
-    Api,
-    Progress,
-    ProjectMeta,
-    TagValueType,
-    is_production,
-    logger,
-)
+from supervisely._utils import is_production
+from supervisely.annotation.annotation import Annotation
+from supervisely.annotation.tag_meta import TagValueType
+from supervisely.api.api import Api
 from supervisely.io.fs import JUNK_FILES, get_file_ext, get_file_name_with_ext
+from supervisely.project.project_meta import ProjectMeta
+from supervisely.sly_logger import logger
+from supervisely.task.progress import Progress
 
 
 class AvailableImageConverters:
@@ -240,7 +240,7 @@ class BaseConverter:
                     only_modality_items = False
                     if ext.lower() in self.unsupported_exts:
                         unsupported_exts.add(ext)
-                    
+
             if self.items_count == 0:
                 if unsupported_exts:
                     raise RuntimeError(
@@ -254,7 +254,7 @@ class BaseConverter:
                 )
             if not only_modality_items:
                 logger.warn(
-                    "Annotations not found. " # pylint: disable=no-member
+                    "Annotations not found. "  # pylint: disable=no-member
                     f"Uploading {self.modality} without annotations. "
                     "If you need assistance to upload data with annotations, please contact our support team."
                 )

--- a/supervisely/convert/base_converter.py
+++ b/supervisely/convert/base_converter.py
@@ -323,7 +323,7 @@ class BaseConverter:
                 meta1 = meta1.add_tag_meta(new_tag)
 
         # update project meta
-        api.project.update_meta(dataset.project_id, meta1)
+        meta1 = api.project.update_meta(dataset.project_id, meta1)
 
         return meta1, renamed_classes, renamed_tags
 

--- a/supervisely/convert/converter.py
+++ b/supervisely/convert/converter.py
@@ -7,7 +7,8 @@ try:
 except ImportError:
     from typing_extensions import Literal
 
-from supervisely import Api, is_production, logger, Progress, ProjectType
+from supervisely._utils import is_production
+from supervisely.api.api import Api
 from supervisely.app import get_data_dir
 from supervisely.convert.image.csv.csv_converter import CSVConverter
 from supervisely.convert.image.image_converter import ImageConverter
@@ -27,6 +28,9 @@ from supervisely.io.fs import (
     silent_remove,
     unpack_archive,
 )
+from supervisely.project.project_type import ProjectType
+from supervisely.sly_logger import logger
+from supervisely.task.progress import Progress
 
 
 class ImportManager:
@@ -57,7 +61,7 @@ class ImportManager:
         self._input_data = self._prepare_input_data(input_data)
         self._unpack_archives(self._input_data)
         remove_junk_from_dir(self._input_data)
-    
+
         self._modality = project_type
         self._converter = self.get_converter()
         if isinstance(self._converter, CSVConverter):
@@ -176,10 +180,7 @@ class ImportManager:
             progress_cb = progress.iters_done_report
         else:
             progress = tqdm(
-                total=total,
-                desc=message,
-                unit="B" if is_size else "it",
-                unit_scale=is_size
+                total=total, desc=message, unit="B" if is_size else "it", unit_scale=is_size
             )
             progress_cb = progress.update
         return progress, progress_cb

--- a/supervisely/convert/image/image_converter.py
+++ b/supervisely/convert/image/image_converter.py
@@ -16,6 +16,7 @@ from supervisely import (
     logger,
 )
 from supervisely.convert.base_converter import BaseConverter
+from supervisely.api.api import ApiContext
 from supervisely.imaging.image import SUPPORTED_IMG_EXTS, is_valid_ext
 from supervisely.io.fs import get_file_ext, get_file_name
 from supervisely.io.json import load_json_file
@@ -124,6 +125,8 @@ class ImageConverter(BaseConverter):
         log_progress=True,
     ) -> None:
         """Upload converted data to Supervisely"""
+        dataset_info = api.dataset.get_info_by_id(dataset_id)
+        project_id = dataset_info.project_id
 
         meta, renamed_classes, renamed_tags = self.merge_metas_with_conflicts(api, dataset_id)
 
@@ -153,10 +156,13 @@ class ImageConverter(BaseConverter):
                 if ann is not None:
                     anns.append(ann)
 
-            img_infos = api.image.upload_paths(dataset_id, item_names, item_paths, metas=item_metas)
-            img_ids = [img_info.id for img_info in img_infos]
-            if len(anns) == len(img_ids):
-                api.annotation.upload_anns(img_ids, anns)
+            with ApiContext(
+                api=api, project_id=project_id, dataset_id=dataset_id, project_meta=meta
+            ):
+                img_infos = api.image.upload_paths(dataset_id, item_names, item_paths, metas=item_metas)
+                img_ids = [img_info.id for img_info in img_infos]
+                if len(anns) == len(img_ids):
+                    api.annotation.upload_anns(img_ids, anns)
 
             if log_progress:
                 progress_cb(len(batch))

--- a/supervisely/convert/image/medical2d/medical2d_converter.py
+++ b/supervisely/convert/image/medical2d/medical2d_converter.py
@@ -74,12 +74,11 @@ class Medical2DImageConverter(ImageConverter):
             item = self.Item(item_path=path)
             img_size = nrrd.read_header(path)["sizes"].tolist()[::-1] # pylint: disable=no-member
             item.set_shape(img_size)
-            if group_tag in group_tags:
-                self._group_tag_names[group_tag["name"]] += 1
-            if len(group_tags) > 0:
+            if group_tags is not None:
+                for group_tag in group_tags:
+                    self._group_tag_names[group_tag["name"]] += 1
                 item.ann_data = group_tags
-            if len(dcm_metas) > 0:
-                item.dcm_mets = dcm_metas
+            item.set_meta_data(dcm_metas if dcm_metas is not None else {})
             self._items.append(item)
 
         self._meta = meta
@@ -152,7 +151,7 @@ class Medical2DImageConverter(ImageConverter):
             for batch in batched(self._items, batch_size):
                 paths = [item.path for item in batch]
                 anns = [self.to_supervisely(item, meta, renamed_classes, renamed_tags) for item in batch]
-                img_metas = [item.meta for item in batch]
+                img_metas = [item.meta or {} for item in batch]
                 names = []
                 for item in batch:
                     item.name = f"{get_file_name(item.path)}{get_file_ext(item.path).lower()}"

--- a/supervisely/convert/image/medical2d/medical2d_converter.py
+++ b/supervisely/convert/image/medical2d/medical2d_converter.py
@@ -40,7 +40,7 @@ class Medical2DImageConverter(ImageConverter):
         mkdir(converted_dir, remove_content_if_exists=True)
         meta = ProjectMeta()
 
-        nrrd = {}
+        nrrds_dict = {}
         for root, _, files in os.walk(self._input_data):
             if converted_dir_name in root:
                 continue
@@ -59,22 +59,22 @@ class Medical2DImageConverter(ImageConverter):
                                 meta = meta.add_tag_meta(tag_meta)
                             group_tag = Tag(tag_meta, tag_value)
                         for path, name in zip(paths, names):
-                            nrrd[name] = (path, group_tag)
+                            nrrds_dict[name] = (path, group_tag)
                 elif ext == ".nrrd":
                     if helper.check_nrrd(path):  # is nrrd
                         paths, names = helper.slice_nrrd_file(path, converted_dir)
                         for path, name in zip(paths, names):
-                            nrrd[name] = (path, None)
+                            nrrds_dict[name] = (path, None)
                 elif mime == "application/gzip" or mime == "application/octet-stream":
                     if is_nifti_file(path):  # is nifti
                         paths, names = helper.slice_nifti_file(path, converted_dir)
                         for path, name in zip(paths, names):
-                            nrrd[name] = (path, None)
+                            nrrds_dict[name] = (path, None)
 
         self._items = []
-        for name, (path, group_tag) in nrrd.items():
+        for name, (path, group_tag) in nrrds_dict.items():
             item = self.Item(item_path=path)
-            img_size = nrrd.read_header(path)["sizes"].tolist()[::-1]
+            img_size = nrrd.read_header(path)["sizes"].tolist()[::-1] # pylint: disable=no-member
             item.set_shape(img_size)
             if group_tag is not None:
                 self._group_tag_names[group_tag.name] += 1

--- a/supervisely/convert/image/medical2d/medical2d_converter.py
+++ b/supervisely/convert/image/medical2d/medical2d_converter.py
@@ -122,13 +122,12 @@ class Medical2DImageConverter(ImageConverter):
         """Upload converted data to Supervisely"""
 
         if len(self._group_tag_names) > 0:
-            group_tag_name = next(iter(self._group_tag_names))
             logger.debug("Group tags detected")
+            group_tag_name = next(iter(self._group_tag_names))
             if len(self._group_tag_names) > 1:
                 group_tag_name = max(self._group_tag_names, key=self._group_tag_names.get)
                 logger.warn(
                     f"Multiple group tags found: {', '.join(self._group_tag_names.keys())}."
-                    f"Will use: {group_tag_name}."
                     "Some images will be hidden in the grouped view if they don't have the corresponding group tag."
                 )
             meta, renamed_classes, renamed_tags = self.merge_metas_with_conflicts(api, dataset_id)

--- a/supervisely/convert/image/medical2d/medical2d_converter.py
+++ b/supervisely/convert/image/medical2d/medical2d_converter.py
@@ -132,7 +132,7 @@ class Medical2DImageConverter(ImageConverter):
             if len(self._group_tag_names) > 1:
                 group_tag_name = max(self._group_tag_names, key=self._group_tag_names.get)
                 logger.warn(
-                    f"Multiple group tags found: {', '.join(self._group_tag_names.keys())}."
+                    f"Multiple metadata fields found: {', '.join(self._group_tag_names.keys())}..."
                     "Some images will be hidden in the grouped view if they don't have the corresponding group tag."
                 )
             meta, renamed_classes, renamed_tags = self.merge_metas_with_conflicts(api, dataset_id)

--- a/supervisely/convert/image/medical2d/medical2d_converter.py
+++ b/supervisely/convert/image/medical2d/medical2d_converter.py
@@ -105,12 +105,14 @@ class Medical2DImageConverter(ImageConverter):
     ) -> Annotation:
         ann = Annotation(item.shape)
         if item.ann_data is not None:
+            tags = []
             for tag in item.ann_data:
                 tag_name = renamed_tags.get(tag["name"], tag["name"])
                 tag_meta = meta.get_tag_meta(tag_name)
                 if tag_meta is not None:
                     group_tag = Tag(tag_meta, tag["value"])
-                    ann = ann.add_tags(group_tag)
+                    tags.append(group_tag)
+            ann = ann.add_tags(tags)
         return ann
 
     def upload_dataset(

--- a/supervisely/convert/image/medical2d/medical2d_converter.py
+++ b/supervisely/convert/image/medical2d/medical2d_converter.py
@@ -112,7 +112,7 @@ class Medical2DImageConverter(ImageConverter):
                 tag_name = renamed_tags.get(tag["name"], tag["name"])
                 tag_meta = meta.get_tag_meta(tag_name)
                 if tag_meta is not None:
-                    group_tag = Tag(tag_meta, tag["value"])
+                    group_tag = Tag(tag_meta, str(tag["value"]))
                     tags.append(group_tag)
             ann = ann.add_tags(tags)
         return ann

--- a/supervisely/convert/image/medical2d/medical2d_helper.py
+++ b/supervisely/convert/image/medical2d/medical2d_helper.py
@@ -12,17 +12,6 @@ from supervisely import image, logger, volume
 from supervisely.io.fs import get_file_ext, get_file_name, get_file_name_with_ext, mkdir
 
 
-DICOM_GROUP_TAGS = [
-    "StudyInstanceUID",
-    "StudyID",
-    "SeriesInstanceUID",
-    "TreatmentSessionUID",
-    "Manufacturer",
-    "ManufacturerModelName",
-    "Modality",
-]
-
-
 def slice_nifti_file(nii_file_path: str, converted_dir: str) -> Tuple[List[str], List[str]]:
     """Slices file into 2D slices if it is 3D.
     Returns image paths and image names.
@@ -130,20 +119,6 @@ def convert_dcm_to_nrrd(image_path: str, converted_dir: str) -> Tuple[List[str],
     mkdir(curr_convert_dir)
 
     dcm = pydicom.read_file(image_path)
-
-    group_tag = None
-    for tag_name in DICOM_GROUP_TAGS:
-        if hasattr(dcm, tag_name):
-            group_tag_value = str(dcm[tag_name].value)
-            if group_tag_value in ["", None]:
-                logger.warn(f"Tag [{tag_name}] has empty value. Skipping tag.")
-                continue
-            if len(group_tag_value) > 255:
-                logger.warn(f"Tag [{tag_name}] has too long value. Skipping tag.")
-                continue
-            group_tag = {"name": tag_name, "value": group_tag_value}
-            break
-
     pixel_data_list = [dcm.pixel_array]
     if len(dcm.pixel_array.shape) == 3:
         if dcm.pixel_array.shape[0] == 1 and not hasattr(dcm, "NumberOfFrames"):
@@ -187,7 +162,7 @@ def convert_dcm_to_nrrd(image_path: str, converted_dir: str) -> Tuple[List[str],
         nrrd.write(save_path, pixel_data, header)
         save_paths.append(save_path)
         image_names.append(image_name)
-    return save_paths, image_names, group_tag
+    return save_paths, image_names
 
 
 def slice_nrrd_file(nrrd_file_path: str, output_dir: str) -> Tuple[List[str], List[str]]:

--- a/supervisely/convert/image/medical2d/medical2d_helper.py
+++ b/supervisely/convert/image/medical2d/medical2d_helper.py
@@ -1,6 +1,8 @@
 import os
+import re
+from os.path import basename, dirname, exists, join, normpath, pardir
 from pathlib import Path
-from typing import Dict, List, Tuple, Optional
+from typing import Dict, List, Optional, Tuple
 
 import nrrd
 import numpy as np
@@ -9,7 +11,24 @@ from pydicom import FileDataset
 from tqdm import tqdm
 
 from supervisely import image, logger, volume
-from supervisely.io.fs import get_file_ext, get_file_name, get_file_name_with_ext, mkdir
+from supervisely.annotation.tag import Tag
+from supervisely.io.fs import (
+    dir_exists,
+    get_file_ext,
+    get_file_name,
+    get_file_name_with_ext,
+    mkdir,
+)
+
+_MEDICAL_DEFAULT_GROUP_TAG_NAMES = [
+    "StudyInstanceUID",
+    "StudyID",
+    "SeriesInstanceUID",
+    "TreatmentSessionUID",
+    "Manufacturer",
+    "ManufacturerModelName",
+    "Modality",
+]
 
 
 def slice_nifti_file(nii_file_path: str, converted_dir: str) -> Tuple[List[str], List[str]]:
@@ -58,7 +77,7 @@ def is_dicom_file(path: str) -> bool:
         pydicom.read_file(str(Path(path).resolve()), stop_before_pixels=True)
         result = True
     except Exception as ex:
-        logger.warn("'{}' appears not to be a DICOM file\n({})".format(path, ex))
+        logger.warning("'{}' appears not to be a DICOM file\n({})".format(path, ex))
         result = False
     return result
 
@@ -112,39 +131,33 @@ def create_pixel_data_set(dcm: FileDataset, frame_axis: int) -> Tuple[List[np.nd
     return list_of_images, frame_axis
 
 
-def convert_dcm_to_nrrd(image_path: str, converted_dir: str, group_tag_name: Optional[list] = None) -> Tuple[List[str], List[str], List[dict], dict]:
+def convert_dcm_to_nrrd(
+    image_path: str, converted_dir: str, group_tag_name: Optional[list] = None
+) -> Tuple[List[str], List[str], List[dict], dict]:
     """Converts DICOM data to nrrd format and returns image paths and image names"""
+    logger.info(f"Starting {get_file_name_with_ext(image_path)!r}...")
+
     original_name = get_file_name_with_ext(image_path)
+    if not dir_exists(converted_dir):
+        mkdir(converted_dir)
     curr_convert_dir = os.path.join(converted_dir, original_name)
     mkdir(curr_convert_dir)
 
     dcm = pydicom.read_file(image_path)
-    pixel_data_list = [dcm.pixel_array]
-    if len(dcm.pixel_array.shape) == 3:
-        if dcm.pixel_array.shape[0] == 1 and not hasattr(dcm, "NumberOfFrames"):
-            frames = 1
-            pixel_data_list = [
-                dcm.pixel_array.reshape((dcm.pixel_array.shape[1], dcm.pixel_array.shape[2]))
-            ]
-            header = create_nrrd_header_from_dcm(image_path)
-        else:
-            try:
-                frames = int(dcm.NumberOfFrames)
-            except AttributeError as e:
-                if str(e) == "'FileDataset' object has no attribute 'NumberOfFrames'":
-                    e.args = ("can't get 'NumberOfFrames' from dcm meta.",)
-                    raise e
-            frame_axis = find_frame_axis(dcm.pixel_array, frames)
-            pixel_data_list, frame_axis = create_pixel_data_set(dcm, frame_axis)
-            header = create_nrrd_header_from_dcm(image_path, frame_axis)
-    elif len(dcm.pixel_array.shape) == 2:
-        frames = 1
-        header = create_nrrd_header_from_dcm(image_path)
-    else:
-        raise NotImplementedError(
-            f"this type of dcm data is not supported, pixel_array.shape = {len(dcm.pixel_array.shape)}"
-        )
+    dcm_meta = get_dcm_meta(dcm)
 
+    if group_tag_name is None:
+        group_tag_names = _MEDICAL_DEFAULT_GROUP_TAG_NAMES
+    else:
+        group_tag_names = [group_tag_name] + _MEDICAL_DEFAULT_GROUP_TAG_NAMES
+
+    is_group_tag_exists = next((name for name in group_tag_names if name in dcm), None) is not None
+    if not is_group_tag_exists:
+        logger.warning(f"Not found group tags in DICOM file.")
+
+    header, frames, frame_axis, pixel_data_list = get_nrrd_data(image_path, dcm)
+
+    group_tags = []
     save_paths = []
     image_names = []
     frames_list = [f"{i:0{len(str(frames))}d}" for i in range(1, frames + 1)]
@@ -162,7 +175,15 @@ def convert_dcm_to_nrrd(image_path: str, converted_dir: str, group_tag_name: Opt
         nrrd.write(save_path, pixel_data, header)
         save_paths.append(save_path)
         image_names.append(image_name)
-    return save_paths, image_names
+
+    for tag_name in group_tag_names:
+        if dcm.get(tag_name) is not None:
+            group_tag_value = dcm[tag_name].value
+            group_tags.append({"name": tag_name, "value": group_tag_value})
+        elif group_tag_name is not None and tag_name == group_tag_name:
+            logger.warning(f"Couldn't find key {group_tag_name!r} in file's metadata.")
+
+    return save_paths, image_names, group_tags, dcm_meta
 
 
 def slice_nrrd_file(nrrd_file_path: str, output_dir: str) -> Tuple[List[str], List[str]]:
@@ -229,3 +250,73 @@ def slice_nrrd_file(nrrd_file_path: str, output_dir: str) -> Tuple[List[str], Li
         output_paths.append(nrrd_file_path)
         output_names.append(get_file_name_with_ext(nrrd_file_path))
     return output_paths, output_names
+
+
+def get_dcm_meta(dcm: FileDataset) -> List[Tag]:
+    """Create tags from DICOM metadata."""
+
+    filtered_tags = []
+
+    DCM_TAGS = list(dcm.keys())
+    empty_tags, too_long_tags = [], []
+    for dcm_tag in DCM_TAGS:
+        try:
+            curr_tag = dcm[dcm_tag]
+            dcm_tag_name = str(curr_tag.name)
+            dcm_tag_value = str(curr_tag.value)
+            if dcm_tag_value in ["", None]:
+                empty_tags.append(dcm_tag_name)
+                continue
+            if len(dcm_tag_value) > 255:
+                too_long_tags.append(dcm_tag_name)
+                continue
+            filtered_tags.append((dcm_tag_name, dcm_tag_value))
+        except KeyError:
+            dcm_filename = get_file_name_with_ext(dcm.filename)
+            logger.warning(f"Couldn't find key '{dcm_tag}' in file's metadata: '{dcm_filename}'")
+            continue
+
+    if len(empty_tags) > 0:
+        logger.warning(f"{len(dcm_tag_name)} tags have empty value. Skipped tags: {empty_tags}.")
+    if len(too_long_tags) > 0:
+        logger.warning(
+            f"{len(too_long_tags)} tags have too long value (> 255 symbols). Skipped tags: {too_long_tags}."
+        )
+
+    dcm_tags_dict = {}
+    for dcm_tag_name, dcm_tag_value in filtered_tags:
+        dcm_tags_dict[dcm_tag_name] = dcm_tag_value
+    return dcm_tags_dict
+
+
+def get_nrrd_data(image_path: str, dcm: FileDataset):
+
+    frame_axis = 2
+    pixel_data_list = [dcm.pixel_array]
+
+    if len(dcm.pixel_array.shape) == 3:
+        if dcm.pixel_array.shape[0] == 1 and not hasattr(dcm, "NumberOfFrames"):
+            frames = 1
+            pixel_data_list = [
+                dcm.pixel_array.reshape((dcm.pixel_array.shape[1], dcm.pixel_array.shape[2]))
+            ]
+            header = create_nrrd_header_from_dcm(image_path, frame_axis)
+        else:
+            try:
+                frames = int(dcm.NumberOfFrames)
+            except AttributeError as e:
+                if str(e) == "'FileDataset' object has no attribute 'NumberOfFrames'":
+                    e.args = ("can't get 'NumberOfFrames' from dcm meta.",)
+                    raise e
+            frame_axis = find_frame_axis(dcm.pixel_array, frames)
+            pixel_data_list, frame_axis = create_pixel_data_set(dcm, frame_axis)
+            header = create_nrrd_header_from_dcm(image_path, frame_axis)
+    elif len(dcm.pixel_array.shape) == 2:
+        frames = 1
+        header = create_nrrd_header_from_dcm(image_path, frame_axis)
+    else:
+        raise RuntimeError(
+            f"This type of dcm data is not supported, pixel_array.shape = {len(dcm.pixel_array.shape)}"
+        )
+
+    return header, frames, frame_axis, pixel_data_list

--- a/supervisely/convert/image/medical2d/medical2d_helper.py
+++ b/supervisely/convert/image/medical2d/medical2d_helper.py
@@ -269,7 +269,7 @@ def get_dcm_meta(dcm: FileDataset) -> List[Tag]:
             curr_tag = dcm[dcm_tag]
             dcm_tag_name = str(curr_tag.name)
             dcm_tag_value = str(curr_tag.value)
-            if dcm_tag_name in _anonymize_tags:
+            if dcm_tag_name in _anonymize_tags + ["Patient's Name"]:
                 dcm_tag_value = "anonymized"
             if dcm_tag_value in ["", None]:
                 empty_tags.append(dcm_tag_name)

--- a/supervisely/convert/image/medical2d/medical2d_helper.py
+++ b/supervisely/convert/image/medical2d/medical2d_helper.py
@@ -12,6 +12,17 @@ from supervisely import image, logger, volume
 from supervisely.io.fs import get_file_ext, get_file_name, get_file_name_with_ext, mkdir
 
 
+DICOM_GROUP_TAGS = [
+    "StudyInstanceUID",
+    "StudyID",
+    "SeriesInstanceUID",
+    "TreatmentSessionUID",
+    "Manufacturer",
+    "ManufacturerModelName",
+    "Modality",
+]
+
+
 def slice_nifti_file(nii_file_path: str, converted_dir: str) -> Tuple[List[str], List[str]]:
     """Slices file into 2D slices if it is 3D.
     Returns image paths and image names.
@@ -119,6 +130,21 @@ def convert_dcm_to_nrrd(image_path: str, converted_dir: str) -> Tuple[List[str],
     mkdir(curr_convert_dir)
 
     dcm = pydicom.read_file(image_path)
+
+    group_tag = None
+    for tag_name in DICOM_GROUP_TAGS:
+        if hasattr(dcm, tag_name):
+            group_tag_value = str(dcm[tag_name].value)
+            if group_tag_value in ["", None]:
+                logger.warn(f"Tag [{tag_name}] has empty value. Skipping tag.")
+                continue
+            if len(group_tag_value) > 255:
+                logger.warn(f"Tag [{tag_name}] has too long value. Skipping tag.")
+                continue
+            group_tag = {"name": tag_name, "value": group_tag_value}
+            logger.info(f"Will use [{group_tag}] as group tag.")
+            break
+
     pixel_data_list = [dcm.pixel_array]
     if len(dcm.pixel_array.shape) == 3:
         if dcm.pixel_array.shape[0] == 1 and not hasattr(dcm, "NumberOfFrames"):
@@ -162,7 +188,7 @@ def convert_dcm_to_nrrd(image_path: str, converted_dir: str) -> Tuple[List[str],
         nrrd.write(save_path, pixel_data, header)
         save_paths.append(save_path)
         image_names.append(image_name)
-    return save_paths, image_names
+    return save_paths, image_names, group_tag
 
 
 def slice_nrrd_file(nrrd_file_path: str, output_dir: str) -> Tuple[List[str], List[str]]:

--- a/supervisely/convert/image/medical2d/medical2d_helper.py
+++ b/supervisely/convert/image/medical2d/medical2d_helper.py
@@ -135,8 +135,6 @@ def convert_dcm_to_nrrd(
     image_path: str, converted_dir: str, group_tag_name: Optional[list] = None
 ) -> Tuple[List[str], List[str], List[dict], dict]:
     """Converts DICOM data to nrrd format and returns image paths and image names"""
-    logger.info(f"Starting {get_file_name_with_ext(image_path)!r}...")
-
     original_name = get_file_name_with_ext(image_path)
     if not dir_exists(converted_dir):
         mkdir(converted_dir)
@@ -258,6 +256,7 @@ def get_dcm_meta(dcm: FileDataset) -> List[Tag]:
     filtered_tags = []
 
     DCM_TAGS = list(dcm.keys())
+    filename = get_file_name_with_ext(dcm.filename)
     empty_tags, too_long_tags = [], []
     for dcm_tag in DCM_TAGS:
         try:
@@ -277,10 +276,10 @@ def get_dcm_meta(dcm: FileDataset) -> List[Tag]:
             continue
 
     if len(empty_tags) > 0:
-        logger.warning(f"{len(dcm_tag_name)} tags have empty value. Skipped tags: {empty_tags}.")
+        logger.warning(f"{filename}: {len(dcm_tag_name)} tags have empty value. Skipped tags: {empty_tags}.")
     if len(too_long_tags) > 0:
         logger.warning(
-            f"{len(too_long_tags)} tags have too long value (> 255 symbols). Skipped tags: {too_long_tags}."
+            f"{filename}: {len(too_long_tags)} tags have too long value (> 255 symbols). Skipped tags: {too_long_tags}."
         )
 
     dcm_tags_dict = {}

--- a/supervisely/convert/image/medical2d/medical2d_helper.py
+++ b/supervisely/convert/image/medical2d/medical2d_helper.py
@@ -269,7 +269,7 @@ def get_dcm_meta(dcm: FileDataset) -> List[Tag]:
             curr_tag = dcm[dcm_tag]
             dcm_tag_name = str(curr_tag.name)
             dcm_tag_value = str(curr_tag.value)
-            if dcm_tag_name in _anonymize_tags + ["Patient's Name"]:
+            if dcm_tag_name in ["Patient's Name", "Patient ID"] + _anonymize_tags:
                 dcm_tag_value = "anonymized"
             if dcm_tag_value in ["", None]:
                 empty_tags.append(dcm_tag_name)

--- a/supervisely/convert/image/medical2d/medical2d_helper.py
+++ b/supervisely/convert/image/medical2d/medical2d_helper.py
@@ -1,6 +1,6 @@
 import os
 from pathlib import Path
-from typing import Dict, List, Tuple
+from typing import Dict, List, Tuple, Optional
 
 import nrrd
 import numpy as np
@@ -112,7 +112,7 @@ def create_pixel_data_set(dcm: FileDataset, frame_axis: int) -> Tuple[List[np.nd
     return list_of_images, frame_axis
 
 
-def convert_dcm_to_nrrd(image_path: str, converted_dir: str) -> Tuple[List[str], List[str], Dict[str, str]]:
+def convert_dcm_to_nrrd(image_path: str, converted_dir: str, group_tag_name: Optional[list] = None) -> Tuple[List[str], List[str], List[dict], dict]:
     """Converts DICOM data to nrrd format and returns image paths and image names"""
     original_name = get_file_name_with_ext(image_path)
     curr_convert_dir = os.path.join(converted_dir, original_name)

--- a/supervisely/convert/image/medical2d/medical2d_helper.py
+++ b/supervisely/convert/image/medical2d/medical2d_helper.py
@@ -123,7 +123,7 @@ def create_pixel_data_set(dcm: FileDataset, frame_axis: int) -> Tuple[List[np.nd
     return list_of_images, frame_axis
 
 
-def convert_dcm_to_nrrd(image_path: str, converted_dir: str) -> Tuple[List[str], List[str]]:
+def convert_dcm_to_nrrd(image_path: str, converted_dir: str) -> Tuple[List[str], List[str], Dict[str, str]]:
     """Converts DICOM data to nrrd format and returns image paths and image names"""
     original_name = get_file_name_with_ext(image_path)
     curr_convert_dir = os.path.join(converted_dir, original_name)
@@ -142,7 +142,6 @@ def convert_dcm_to_nrrd(image_path: str, converted_dir: str) -> Tuple[List[str],
                 logger.warn(f"Tag [{tag_name}] has too long value. Skipping tag.")
                 continue
             group_tag = {"name": tag_name, "value": group_tag_value}
-            logger.info(f"Will use [{group_tag}] as group tag.")
             break
 
     pixel_data_list = [dcm.pixel_array]

--- a/supervisely/convert/image/medical2d/medical2d_helper.py
+++ b/supervisely/convert/image/medical2d/medical2d_helper.py
@@ -177,7 +177,8 @@ def convert_dcm_to_nrrd(
     for tag_name in group_tag_names:
         if dcm.get(tag_name) is not None:
             group_tag_value = dcm[tag_name].value
-            group_tags.append({"name": tag_name, "value": group_tag_value})
+            if group_tag_value is not None and group_tag_value != "":
+                group_tags.append({"name": tag_name, "value": group_tag_value})
         elif group_tag_name is not None and tag_name == group_tag_name:
             logger.warning(f"Couldn't find key {group_tag_name!r} in file's metadata.")
 

--- a/supervisely/convert/image/multispectral/multispectral_converter.py
+++ b/supervisely/convert/image/multispectral/multispectral_converter.py
@@ -6,7 +6,8 @@ import cv2
 import nrrd
 import numpy as np
 
-from supervisely import Api, is_development, logger, ProjectMeta
+from supervisely import is_development, logger, ProjectMeta
+from supervisely.api.api import Api, ApiContext
 from supervisely.convert.base_converter import AvailableImageConverters
 from supervisely.convert.image.image_converter import ImageConverter
 from supervisely.imaging.image import is_valid_ext
@@ -78,7 +79,11 @@ class MultiSpectralImageConverter(ImageConverter):
     ) -> None:
         """Upload converted data to Supervisely"""
         dataset = api.dataset.get_info_by_id(dataset_id)
-        api.project.set_multispectral_settings(dataset.project_id)
+        project_id = dataset.project_id
+        api.project.set_multispectral_settings(project_id)
+
+        meta_json = api.project.get_meta(project_id)
+        meta = ProjectMeta.from_json(meta_json)
 
         items_count = sum(len(group.split) + len(group.upload) for group in self._group_map.values())
         if log_progress:
@@ -99,7 +104,11 @@ class MultiSpectralImageConverter(ImageConverter):
                 images.append(os.path.join(group_path, image_to_upload))
             for image_to_split in images_to_split:
                 channels.extend(self._get_image_channels(os.path.join(group_path, image_to_split)))
-            api.image.upload_multispectral(dataset.id, group_name, channels, images, progress_cb)
+
+            with ApiContext(
+                api=api, project_id=project_id, dataset_id=dataset_id, project_meta=meta
+            ):
+                api.image.upload_multispectral(dataset.id, group_name, channels, images, progress_cb)
 
         if log_progress:
             if is_development():

--- a/supervisely/convert/image/sly/sly_image_converter.py
+++ b/supervisely/convert/image/sly/sly_image_converter.py
@@ -180,19 +180,20 @@ class SLYImageConverter(ImageConverter):
 
             meta = ProjectMeta()
             dataset_dirs = [d for d in dirs_filter(input_data, _check_function)]
-            for dataset_dir in dataset_dirs:
-                dataset_ds = Dataset(dataset_dir, OpenMode.READ)
-                for name in dataset_ds.get_items_names():
-                    img_path, ann_path = dataset_ds.get_item_paths(name)
-                    meta_path = dataset_ds.get_item_meta_path(name)
-                    item = self.Item(img_path)
-                    if file_exists(ann_path):
-                        if self.validate_ann_file(ann_path, meta):
-                            item.ann_data = ann_path
-                        meta = self.generate_meta_from_annotation(ann_path, meta)
-                    if file_exists(meta_path):
-                        item.set_meta_data(meta_path)
-                    self._items.append(item)
+            if len(dataset_dirs) > 1:
+                for dataset_dir in dataset_dirs:
+                    dataset_ds = Dataset(dataset_dir, OpenMode.READ)
+                    for name in dataset_ds.get_items_names():
+                        img_path, ann_path = dataset_ds.get_item_paths(name)
+                        meta_path = dataset_ds.get_item_meta_path(name)
+                        item = self.Item(img_path)
+                        if file_exists(ann_path):
+                            if self.validate_ann_file(ann_path, meta):
+                                item.ann_data = ann_path
+                            meta = self.generate_meta_from_annotation(ann_path, meta)
+                        if file_exists(meta_path):
+                            item.set_meta_data(meta_path)
+                        self._items.append(item)
             if self.items_count > 0:
                 self._meta = meta
                 return True

--- a/supervisely/convert/image/sly/sly_image_helper.py
+++ b/supervisely/convert/image/sly/sly_image_helper.py
@@ -80,6 +80,7 @@ def create_classes_from_annotation(object: dict, meta: ProjectMeta) -> ProjectMe
     class_name = object["classTitle"]
     geometry_type = object["geometryType"]
     # @TODO: add better check for geometry type, add
+    obj_class = None
     if geometry_type == Bitmap.geometry_name():
         obj_class = ObjClass(name=class_name, geometry_type=Bitmap)
     elif geometry_type == Rectangle.geometry_name():

--- a/supervisely/convert/image/sly/sly_image_helper.py
+++ b/supervisely/convert/image/sly/sly_image_helper.py
@@ -16,17 +16,25 @@ from supervisely import (
 )
 from supervisely.io.json import load_json_file
 from supervisely.geometry.graph import KeypointsTemplate
+from supervisely.annotation.label import LabelJsonFields
+from supervisely.annotation.tag import TagJsonFields
 
 SLY_IMAGE_ANN_KEYS = ["objects", "tags", "size"]
+SLY_OBJECT_KEYS = [LabelJsonFields.OBJ_CLASS_NAME, LabelJsonFields.TAGS, "geometryType"]  #, LabelJsonFields.GEOMETRY_TYPE] TODO: add geometry type
+SLY_TAG_KEYS = [TagJsonFields.TAG_NAME, TagJsonFields.VALUE]
 
-
+# Check the annotation format documentation at
 def get_meta_from_annotation(ann_path: str, meta: ProjectMeta) -> ProjectMeta:
     ann_json = load_json_file(ann_path)
     if "annotation" in ann_json:
         ann_json = ann_json["annotation"]
 
     if not all(key in ann_json for key in SLY_IMAGE_ANN_KEYS):
-        logger.warn(f"Annotation file {ann_path} is not in Supervisely format")
+        logger.warn(
+            f"Annotation file {ann_path} is not in Supervisely format. Skipping. "
+            "Check the annotation format documentation at: "
+            "https://docs.supervisely.com/customization-and-integration/00_ann_format_navi/05_supervisely_format_images"
+        )
         return meta
 
     for object in ann_json["objects"]:
@@ -38,8 +46,15 @@ def get_meta_from_annotation(ann_path: str, meta: ProjectMeta) -> ProjectMeta:
 
 def create_tags_from_annotation(tags: List[dict], meta: ProjectMeta) -> ProjectMeta:
     for tag in tags:
-        tag_name = tag["name"]
-        tag_value = tag["value"]
+        if not all(key in tag for key in SLY_TAG_KEYS):
+            logger.warn(
+                f"Tag in annotation file is not in Supervisely format. "
+                "Read more about the Supervisely JSON format of tags in the documentation at: "
+                "https://docs.supervisely.com/customization-and-integration/00_ann_format_navi/03_supervisely_format_tags"
+            )
+            continue
+        tag_name = tag[TagJsonFields.TAG_NAME]
+        tag_value = tag[TagJsonFields.VALUE]
         if tag_value is None:
             tag_meta = TagMeta(tag_name, TagValueType.NONE)
         elif isinstance(tag_value, int) or isinstance(tag_value, float):
@@ -55,6 +70,13 @@ def create_tags_from_annotation(tags: List[dict], meta: ProjectMeta) -> ProjectM
 
 
 def create_classes_from_annotation(object: dict, meta: ProjectMeta) -> ProjectMeta:
+    if not all(key in object for key in SLY_OBJECT_KEYS):
+        logger.warn(
+            f"Object in annotation file is not in Supervisely format: {object}. "
+            "Read more about the Supervisely JSON format of objects in the documentation at: "
+            "https://docs.supervisely.com/customization-and-integration/00_ann_format_navi/04_supervisely_format_objects"
+        )
+        return meta
     class_name = object["classTitle"]
     geometry_type = object["geometryType"]
     # @TODO: add better check for geometry type, add

--- a/supervisely/convert/video/sly/sly_video_helper.py
+++ b/supervisely/convert/video/sly/sly_video_helper.py
@@ -3,6 +3,7 @@ from typing import List
 from supervisely import (
     AnyGeometry,
     Bitmap,
+    GraphNodes,
     ObjClass,
     Point,
     Polygon,
@@ -13,9 +14,17 @@ from supervisely import (
     TagValueType,
     logger,
 )
+from supervisely.geometry.graph import KeypointsTemplate
 from supervisely.io.json import load_json_file
+from supervisely.annotation.label import LabelJsonFields
+from supervisely.annotation.tag import TagJsonFields
+from supervisely.video_annotation.constants import FIGURES, INDEX, KEY, IMG_SIZE, OBJECT_KEY, OBJECTS, FRAMES_COUNT, TAGS, FRAMES
 
-SLY_ANN_KEYS = ["size", "framesCount", "frames", "objects", "tags"]
+SLY_ANN_KEYS = [IMG_SIZE, FRAMES_COUNT, FRAMES, OBJECTS, TAGS]
+SLY_VIDEO_OBJECT_KEYS = [LabelJsonFields.OBJ_CLASS_NAME, LabelJsonFields.TAGS, KEY]
+SLY_TAG_KEYS = [TagJsonFields.TAG_NAME, TagJsonFields.VALUE]
+SLY_FRAME_KEYS = [FIGURES, INDEX]
+SLY_FIGURE_KEYS = [KEY, OBJECT_KEY, "geometryType"]  #, LabelJsonFields.GEOMETRY_TYPE] TODO: add geometry type
 
 
 def get_meta_from_annotation(ann_path: str, meta: ProjectMeta) -> ProjectMeta:
@@ -23,23 +32,41 @@ def get_meta_from_annotation(ann_path: str, meta: ProjectMeta) -> ProjectMeta:
     if "annotation" in ann_json:
         ann_json = ann_json["annotation"]
     if not all(key in ann_json for key in SLY_ANN_KEYS):
-        logger.warn(f"VideoAnnotation file {ann_path} is not in Supervisely format")
+        logger.warn(
+            f"VideoAnnotation file {ann_path} is not in Supervisely format. "
+            "Check the annotation format documentation at: "
+            "https://docs.supervisely.com/customization-and-integration/00_ann_format_navi/06_supervisely_format_videos"
+        )
         return meta
 
     object_key_to_name = {}
-    for object in ann_json["objects"]:
-        meta = create_tags_from_annotation(meta, object["tags"])
-        object_key_to_name[object["key"]] = object["classTitle"]
-    for frame in ann_json["frames"]:
+    for object in ann_json[OBJECTS]:
+        if not all(key in object for key in SLY_VIDEO_OBJECT_KEYS):
+            logger.warn(
+                f"Object in annotation file is not in Supervisely format: {object}. "
+                "Read more about the Supervisely JSON format of objects in the documentation at: "
+                "https://docs.supervisely.com/customization-and-integration/00_ann_format_navi/06_supervisely_format_videos"
+            )
+            continue
+        meta = create_tags_from_annotation(meta, object[TAGS])
+        object_key_to_name[object[KEY]] = object[LabelJsonFields.OBJ_CLASS_NAME]
+    for frame in ann_json[FRAMES]:
+        if not all(key in frame for key in SLY_FRAME_KEYS):
+            logger.warn(
+                f"Frame in annotation file is not in Supervisely format: {frame}."
+                "Read more about the Supervisely JSON format of frames in the documentation at: "
+                "https://docs.supervisely.com/customization-and-integration/00_ann_format_navi/06_supervisely_format_videos"
+            )
+            continue
         meta = create_classes_from_annotation(frame, meta, object_key_to_name)
-    meta = create_tags_from_annotation(meta, ann_json["tags"])
+    meta = create_tags_from_annotation(meta, ann_json[TAGS])
     return meta
 
 
 def create_tags_from_annotation(meta: ProjectMeta, tags: List[dict]) -> ProjectMeta:
     for tag in tags:
-        tag_name = tag["name"]
-        tag_value = tag.get("value")
+        tag_name = tag[TagJsonFields.TAG_NAME]
+        tag_value = tag.get(TagJsonFields.VALUE)
         if tag_value is None:
             tag_meta = TagMeta(tag_name, TagValueType.NONE)
         elif isinstance(tag_value, int) or isinstance(tag_value, float):
@@ -57,8 +84,15 @@ def create_tags_from_annotation(meta: ProjectMeta, tags: List[dict]) -> ProjectM
 def create_classes_from_annotation(
     frame: dict, meta: ProjectMeta, object_key_to_name: dict
 ) -> ProjectMeta:
-    for fig in frame["figures"]:
-        obj_key = fig.get("objectKey")
+    for fig in frame[FIGURES]:
+        if not all(key in fig for key in SLY_FIGURE_KEYS):
+            logger.warn(
+                f"Figure in annotation file is not in Supervisely format: {fig}. "
+                "Read more about the Supervisely JSON format of figures in the documentation at: "
+                "https://docs.supervisely.com/customization-and-integration/00_ann_format_navi/06_supervisely_format_videos"
+            )
+            continue
+        obj_key = fig.get(OBJECT_KEY)
         if obj_key is None:
             continue
         class_name = object_key_to_name[obj_key]
@@ -73,12 +107,23 @@ def create_classes_from_annotation(
             obj_class = ObjClass(name=class_name, geometry_type=Polygon)
         elif geometry_type == Polyline.geometry_name():
             obj_class = ObjClass(name=class_name, geometry_type=Polyline)
+        elif geometry_type == GraphNodes.geometry_name():
+            if not all(key in fig for key in ["geometry", "geometryType"]):
+                continue
+            geometry = fig["geometry"]
+            if "nodes" not in geometry:
+                continue
+            template = KeypointsTemplate()
+            for uuid, node in geometry["nodes"].items():
+                if "loc" not in node or len(node["loc"]) != 2:
+                    continue
+                template.add_point(label=uuid, row=node["loc"][0], col=node["loc"][1])
+            obj_class = ObjClass(name=class_name, geometry_type=GraphNodes, geometry_config=template)
 
-        # @TODO: add better check for geometry type, add
-        # elif geometry_type == GraphNodes.geometry_name():
-        #     geometry_config = None
-        #     obj_class = ObjClass(name=class_name, geometry_type=GraphNodes)
         existing_class = meta.get_obj_class(class_name)
+        if obj_class is None:
+            logger.warn(f"Object class {class_name} is not in Supervisely format.")
+            continue
         if existing_class is None:
             meta = meta.add_obj_class(obj_class)
         else:
@@ -90,11 +135,14 @@ def create_classes_from_annotation(
 
 def rename_in_json(ann_json, renamed_classes=None, renamed_tags=None):
     if renamed_classes:
-        for obj in ann_json["objects"]:
-            obj["classTitle"] = renamed_classes.get(obj["classTitle"], obj["classTitle"])
-            for tag in obj["tags"]:
-                tag["name"] = renamed_tags.get(tag["name"], tag["name"])
+        for obj in ann_json[OBJECTS]:
+            obj_cls_name = obj[LabelJsonFields.OBJ_CLASS_NAME]
+            obj[LabelJsonFields.OBJ_CLASS_NAME] = renamed_classes.get(obj_cls_name, obj_cls_name)
+            for tag in obj[TAGS]:
+                tag_name = tag[TagJsonFields.TAG_NAME]
+                tag[TagJsonFields.TAG_NAME] = renamed_tags.get(tag_name, tag_name)
     if renamed_tags:
-        for tag in ann_json["tags"]:
-            tag["name"] = renamed_tags.get(tag["name"], tag["name"])
+        for tag in ann_json[TAGS]:
+            tag_name = tag[TagJsonFields.TAG_NAME]
+            tag[TagJsonFields.TAG_NAME] = renamed_tags.get(tag_name, tag_name)
     return ann_json

--- a/supervisely/convert/video/sly/sly_video_helper.py
+++ b/supervisely/convert/video/sly/sly_video_helper.py
@@ -97,6 +97,7 @@ def create_classes_from_annotation(
             continue
         class_name = object_key_to_name[obj_key]
         geometry_type = fig["geometryType"]
+        obj_class = None
         if geometry_type == Bitmap.geometry_name():
             obj_class = ObjClass(name=class_name, geometry_type=Bitmap)
         elif geometry_type == Rectangle.geometry_name():

--- a/supervisely/convert/volume/dicom/dicom_converter.py
+++ b/supervisely/convert/volume/dicom/dicom_converter.py
@@ -1,13 +1,38 @@
 from typing import List
 
-import supervisely.convert.volume.dicom.dicom_helper as dicom_helper
-from supervisely import ProjectMeta, VolumeAnnotation
+from supervisely.api.api import Api
+from supervisely import generate_free_name, logger, ProjectMeta
 from supervisely.convert.base_converter import AvailableVolumeConverters
 from supervisely.convert.volume.volume_converter import VolumeConverter
-from supervisely.volume.volume import inspect_dicom_series
+from supervisely.volume.volume import inspect_dicom_series, get_extension, read_dicom_serie_volume
 
 
 class DICOMConverter(VolumeConverter):
+    class Item(VolumeConverter.Item):
+        """Item class for DICOM series."""
+        def __init__(self, serie_id: str, item_paths: List[str], volume_meta: dict):
+            item_path = item_paths[0] if len(item_paths) > 0 else None
+            super().__init__(item_path, volume_meta=volume_meta)
+
+            self._serie_id: str = serie_id
+            self._item_paths: List[str] = item_paths
+
+        @property
+        def item_paths(self) -> List[str]:
+            return self._item_paths
+
+        @item_paths.setter
+        def item_paths(self, paths: List[str]) -> None:
+            self._item_paths = paths
+
+        @property
+        def serie_id(self) -> str:
+            return self._serie_id
+
+        @serie_id.setter
+        def serie_id(self, serie_id: str) -> None:
+            self._serie_id = serie_id
+
     def __init__(self, input_data: str, labeling_interface: str):
         self._input_data: str = input_data
         self._items: List[VolumeConverter.Item] = []
@@ -32,19 +57,43 @@ class DICOMConverter(VolumeConverter):
         # create Items
         self._items = []
         for dicom_id, dicom_paths in series_infos.items():
-            item_path, volume_meta = dicom_helper.dcm_to_nrrd(dicom_id, dicom_paths)
-            item = self.Item(item_path, volume_meta=volume_meta)
+            if len(dicom_paths) == 0:
+                logger.warn(f"Empty serie {dicom_id}, serie will be skipped")
+                continue
+            item_path = dicom_paths[0]
+            if get_extension(path=item_path) is None:
+                logger.warn(
+                    f"Can not recognize file extension {item_path}, serie will be skipped"
+                )
+                continue
+            _, meta = read_dicom_serie_volume(dicom_paths, anonymize=True)
+            item = self.Item(serie_id=dicom_id, item_paths=dicom_paths, volume_meta=meta)
             self._items.append(item)
         self._meta = ProjectMeta()
 
-        return len(series_infos) > 0
+        return self.items_count > 0
 
-    def to_supervisely(
+    def upload_dataset(
         self,
-        item: VolumeConverter.Item,
-        meta: ProjectMeta = None,
-        renamed_classes: dict = None,
-        renamed_tags: dict = None,
-    ) -> VolumeAnnotation:
-        """Convert to Supervisely format."""
-        return None
+        api: Api,
+        dataset_id: int,
+        batch_size: int = 1,
+        log_progress=True,
+    ):
+        existing_names = set([vol.name for vol in api.volume.get_list(dataset_id)])
+
+        for item in self._items:
+            serie_id, serie_paths = item.serie_id, item.item_paths
+            volume_name = f"{serie_id}.nrrd"
+            volume_name = generate_free_name(
+                existing_names, volume_name, with_ext=True, extend_used_names=True
+            )
+            api.volume.upload_dicom_serie_paths(
+                dataset_id=dataset_id,
+                name=volume_name,
+                paths=serie_paths,
+                log_progress=log_progress,
+                anonymize=True,
+            )
+
+        logger.info(f"Dataset ID:{dataset_id} has been successfully uploaded.")


### PR DESCRIPTION
- new method `api.image.upload_medical_images()` to upload 2D DICOM images in groups
- Add grouping functionality for 2D DICOM images
- Preserve metadata for 3D DICOM volumes
- Implement GraphNode shape in SLY video converter
- Address corner cases in SLY image converter
- used sly.ApiContext to improve annotations uploading performance 