### PR TITLE
Fix PointcloudEpisodeAnnotation: return empty collection if frame not found in annotations

### DIFF
--- a/supervisely/pointcloud_annotation/pointcloud_episode_annotation.py
+++ b/supervisely/pointcloud_annotation/pointcloud_episode_annotation.py
@@ -135,6 +135,12 @@ class PointcloudEpisodeAnnotation:
 
         frame = self._frames.get(frame_index, None)
         if frame is None:
+            # if frame_index < self.frames_count:
+            #     return PointcloudEpisodeTagCollection([])
+            # else:
+            #     raise ValueError(f"No frame with index {frame_index} in annotation.")
+            # NOTE: The above code is commented out because the value of `frame_index` can be greater
+            # than `frames_count` in the episode annotation if some frames are removed from the episode.
             return PointcloudEpisodeTagCollection([])
         tags = []
         for tag in self._tags:
@@ -195,6 +201,12 @@ class PointcloudEpisodeAnnotation:
 
         frame = self._frames.get(frame_index, None)
         if frame is None:
+            # if frame_index < self.frames_count:
+            #     return PointcloudEpisodeObjectCollection([])
+            # else:
+            #     raise ValueError(f"No frame with index {frame_index} in annotation.")
+            # NOTE: The above code is commented out because the value of `frame_index` can be greater
+            # than `frames_count` in the episode annotation if some frames are removed from the episode.
             return PointcloudEpisodeObjectCollection([])
         frame_objects = {}
         for fig in frame.figures:
@@ -238,6 +250,12 @@ class PointcloudEpisodeAnnotation:
 
         frame = self._frames.get(frame_index, None)
         if frame is None:
+            # if frame_index < self.frames_count:
+            #     return []
+            # else:
+            #     raise ValueError(f"No frame with index {frame_index} in annotation.")
+            # NOTE: The above code is commented out because the value of `frame_index` can be greater
+            # than `frames_count` in the episode annotation if some frames are removed from the episode.
             return []
         return frame.figures
 

--- a/supervisely/pointcloud_annotation/pointcloud_episode_annotation.py
+++ b/supervisely/pointcloud_annotation/pointcloud_episode_annotation.py
@@ -135,10 +135,7 @@ class PointcloudEpisodeAnnotation:
 
         frame = self._frames.get(frame_index, None)
         if frame is None:
-            if frame_index < self.frames_count:
-                return PointcloudEpisodeTagCollection([])
-            else:
-                raise ValueError(f"No frame with index {frame_index} in annotation.")
+            return PointcloudEpisodeTagCollection([])
         tags = []
         for tag in self._tags:
             if frame_index >= tag.frame_range[0] and frame_index <= tag.frame_range[1]:
@@ -198,10 +195,7 @@ class PointcloudEpisodeAnnotation:
 
         frame = self._frames.get(frame_index, None)
         if frame is None:
-            if frame_index < self.frames_count:
-                return PointcloudEpisodeObjectCollection([])
-            else:
-                raise ValueError(f"No frame with index {frame_index} in annotation.")
+            return PointcloudEpisodeObjectCollection([])
         frame_objects = {}
         for fig in frame.figures:
             if fig.parent_object.key() not in frame_objects.keys():
@@ -244,10 +238,7 @@ class PointcloudEpisodeAnnotation:
 
         frame = self._frames.get(frame_index, None)
         if frame is None:
-            if frame_index < self.frames_count:
-                return []
-            else:
-                raise ValueError(f"No frame with index {frame_index} in annotation.")
+            return []
         return frame.figures
 
     def to_json(self, key_id_map: KeyIdMap = None) -> Dict:


### PR DESCRIPTION
When removing some frames from an episode, `frame_index` can be greater than `frames_count` (will raise the `ValueError No frame with index XX in annotation` exception )

```python
# example:
ann: sly.PointcloudEpisodeAnnotation 
# frames_count == 10, some frame has frame_index == 15

# before fix:
ann.get_figures_on_frame(frame_index)  # ValueError
ann.get_tags_on_frame(frame_index)  # ValueError
ann.get_objects_on_frame(frame_index) #  ValueError
```