### PR TITLE
Offline session dump fix

### DIFF
--- a/supervisely/api/file_api.py
+++ b/supervisely/api/file_api.py
@@ -807,8 +807,6 @@ class FileApi(ModuleApiBase):
             return open(path, "rb")
 
         content_dict = []
-        log_data = []
-        total = 0
         for idx, (src, dst) in enumerate(zip(src_paths, dst_paths)):
             name = get_file_name_with_ext(dst)
             content_dict.append((ApiField.NAME, name))
@@ -826,12 +824,6 @@ class FileApi(ModuleApiBase):
                     ),
                 )
             )
-            size = os.path.getsize(src) / 1024
-            log_data.append({ApiField.NAME: name, ApiField.PATH: dst_dir, "size": f"{size:.3f} KB"})
-            total += size
-
-        logger.debug("Uploading files:", extra={"files_data": log_data, "total": f"{total:.3f} KB"})
-
         encoder = MultipartEncoder(fields=content_dict)
 
         # progress = None
@@ -1349,8 +1341,7 @@ class FileApi(ModuleApiBase):
         else:
             res_remote_dir = remote_dir
 
-        local_files = sorted(list_files_recursively(local_dir))
-        assert len(local_files) == len(set(local_files)), "Duplicate files in the directory"
+        local_files = list_files_recursively(local_dir)
         remote_files = []
         dir_parts = local_dir.strip("/").split("/")
         for file in local_files:

--- a/supervisely/api/file_api.py
+++ b/supervisely/api/file_api.py
@@ -807,6 +807,8 @@ class FileApi(ModuleApiBase):
             return open(path, "rb")
 
         content_dict = []
+        log_data = []
+        total = 0
         for idx, (src, dst) in enumerate(zip(src_paths, dst_paths)):
             name = get_file_name_with_ext(dst)
             content_dict.append((ApiField.NAME, name))
@@ -824,6 +826,12 @@ class FileApi(ModuleApiBase):
                     ),
                 )
             )
+            size = os.path.getsize(src) / 1024
+            log_data.append({ApiField.NAME: name, ApiField.PATH: dst_dir, "size": f"{size:.3f} KB"})
+            total += size
+
+        logger.debug("Uploading files:", extra={"files_data": log_data, "total": f"{total:.3f} KB"})
+
         encoder = MultipartEncoder(fields=content_dict)
 
         # progress = None
@@ -1341,7 +1349,8 @@ class FileApi(ModuleApiBase):
         else:
             res_remote_dir = remote_dir
 
-        local_files = list_files_recursively(local_dir)
+        local_files = sorted(list_files_recursively(local_dir))
+        assert len(local_files) == len(set(local_files)), "Duplicate files in the directory"
         remote_files = []
         dir_parts = local_dir.strip("/").split("/")
         for file in local_files:

--- a/supervisely/app/fastapi/offline.py
+++ b/supervisely/app/fastapi/offline.py
@@ -144,10 +144,10 @@ def dump_files_to_supervisely(app: FastAPI, template_response):
 
 def _upload_offline_session():
     global _pending_offline_session
-    sly.logger.info(f"Start dumping app UI for offline mode")
     if _pending_offline_session is not None:
         app, template_response = _pending_offline_session
         _pending_offline_session = None
+        sly.logger.info(f"Start dumping app UI for offline mode")
         dump_files_to_supervisely(app, template_response)
     if _pending_offline_session is not None:
         _upload_offline_session()

--- a/supervisely/app/fastapi/offline.py
+++ b/supervisely/app/fastapi/offline.py
@@ -15,6 +15,9 @@ from starlette.templating import _TemplateResponse
 
 import supervisely as sly
 
+_offline_session_uploader = None
+_pending_offline_session = None
+
 
 def get_static_paths_by_mounted_object(mount) -> list:
     StaticPath = namedtuple("StaticPath", ["local_path", "url_path"])
@@ -150,22 +153,39 @@ def dump_files_to_supervisely(app: FastAPI, template_response):
         os.environ["_SUPERVISELY_OFFLINE_FILES_UPLOADED"] = "False"
 
 
+def _upload_offline_session():
+    global _pending_offline_session
+    sly.logger.info(f"Start dumping app UI for offline mode")
+    if _pending_offline_session is not None:
+        app, template_response = _pending_offline_session
+        _pending_offline_session = None
+        dump_files_to_supervisely(app, template_response)
+    if _pending_offline_session is not None:
+        _upload_offline_session()
+
+
 def available_after_shutdown(app: FastAPI):
     def func_layer_wrapper(f):
         @functools.wraps(f)
         def wrapper(*args, **kwargs):
+            global _offline_session_uploader
+            global _pending_offline_session
             template_response = f(*args, **kwargs)
             sly.logger.debug(f"response type: {type(template_response)}")
             if not isinstance(template_response, _TemplateResponse):
                 return template_response
             try:
                 if sly.utils.is_production():
-                    sly.logger.info(f"Start dumping app UI for offline mode")
-                    threading.Thread(
-                        target=functools.partial(dump_files_to_supervisely, app, template_response),
-                        daemon=False,
-                    ).start()
-
+                    _pending_offline_session = (app, template_response)
+                    if (
+                        _offline_session_uploader is None
+                        or not _offline_session_uploader.is_alive()
+                    ):
+                        _offline_session_uploader = threading.Thread(
+                            target=_upload_offline_session,
+                            daemon=False,
+                        )
+                        _offline_session_uploader.start()
             except Exception as ex:
                 traceback.print_exc()
                 sly.logger.warning(f"Cannot dump files for offline usage, reason: {ex}")

--- a/supervisely/app/fastapi/offline.py
+++ b/supervisely/app/fastapi/offline.py
@@ -84,7 +84,7 @@ def get_offline_session_files_path(task_id) -> pathlib.Path:
     return pathlib.Path("/", "offline-sessions", str(task_id), "app-template")
 
 
-def upload_to_supervisely(static_dir_path: pathlib.Path):
+def upload_to_supervisely(static_dir_path):
     api_token = sly.env.spawn_api_token(raise_not_found=False) or sly.env.api_token()
     # spawn_api_token - is a token of user, that spawned application.
     # api_token - is a token of user for which application was spawned.
@@ -98,17 +98,6 @@ def upload_to_supervisely(static_dir_path: pathlib.Path):
     task_id = sly.env.task_id(raise_not_found=False)
     task_id = 0000 if task_id is None else task_id
     remote_dir = get_offline_session_files_path(task_id)
-
-    def _iter_dir(path: pathlib.Path):
-        for sub in path.iterdir():
-            if sub.is_dir():
-                yield from _iter_dir(sub)
-            else:
-                yield sub
-
-    sly.logger.debug("Static dir to dump:")
-    for p in _iter_dir(static_dir_path):
-        sly.logger.debug(f"{p.as_posix()}")
 
     res_remote_dir: str = api.file.upload_directory(
         team_id=team_id,
@@ -171,7 +160,6 @@ def available_after_shutdown(app: FastAPI):
             global _offline_session_uploader
             global _pending_offline_session
             template_response = f(*args, **kwargs)
-            sly.logger.debug(f"response type: {type(template_response)}")
             if not isinstance(template_response, _TemplateResponse):
                 return template_response
             try:


### PR DESCRIPTION
When reloading dynamic widget fast, there was an error uploading offline session files.
This PR fixes it by uploading offline session files consequently