### PR TITLE
Fisheye - the new labeling interface. AutoImport search metadata for images.

### DIFF
--- a/supervisely/convert/image/image_converter.py
+++ b/supervisely/convert/image/image_converter.py
@@ -191,8 +191,10 @@ class ImageConverter(BaseConverter):
     def _collect_items_if_format_not_detected(self):
 
         def _is_meta_dir(dirpath: str) -> bool:
-            jsons = list_files(dirpath, valid_extensions=[".json"], ignore_valid_extensions_case=True)
-            return os.path.basename(dirpath).lower() == "meta" and len(jsons) > 0
+            if os.path.basename(dirpath).lower() == "meta":
+                jsons = list_files(dirpath, valid_extensions=[".json"], ignore_valid_extensions_case=True)
+                return len(jsons) > 0
+            return False
 
         meta_dirs = [d for d in dirs_filter(self._input_data, _is_meta_dir)]
         if len(meta_dirs) == 0:

--- a/supervisely/convert/image/sly/sly_image_converter.py
+++ b/supervisely/convert/image/sly/sly_image_converter.py
@@ -13,19 +13,12 @@ from supervisely.io.fs import (
 )
 from supervisely.io.json import load_json_file
 from supervisely.project.project import find_project_dirs
-from supervisely.project.project_settings import LabelingInterface
 
 
 class SLYImageConverter(ImageConverter):
 
     def __str__(self):
         return AvailableImageConverters.SLY
-
-    def validate_labeling_interface(self) -> bool:
-        return self._labeling_interface in [
-            LabelingInterface.DEFAULT,
-            LabelingInterface.IMAGE_MATTING,
-        ]
 
     @property
     def ann_ext(self) -> str:

--- a/supervisely/project/project_settings.py
+++ b/supervisely/project/project_settings.py
@@ -20,6 +20,8 @@ class LabelingInterface(str, StrEnum):
     MULTISPECTRAL = "multispectral"
     MULTIVIEW = "multi_view"
     IMAGE_MATTING = "image_matting"
+    FISHEYE = "fisheye"
+
 
 class ProjectSettingsJsonFields:
     MULTI_VIEW = "multiView"

--- a/supervisely/video_annotation/video_figure.py
+++ b/supervisely/video_annotation/video_figure.py
@@ -110,7 +110,7 @@ class VideoFigure:
         self.updated_at = updated_at
         self.created_at = created_at
         self.track_id = track_id
-        self.smart_tool_input = smart_tool_input
+        self._smart_tool_input = smart_tool_input
 
     def _add_creation_info(self, d):
         if self.labeler_login is not None:


### PR DESCRIPTION
- Added a new labeling interface `fisheye` in the project settings
- For importing without annotation, AutoImport will search for image meta files (in any folder with the name `meta`). It will be used for the new labeling interface (`fisheye`).
- fix smart_tool_input attribute passing