### PR TITLE
Get list of nested datasets in the given dataset

### DIFF
--- a/supervisely/api/dataset_api.py
+++ b/supervisely/api/dataset_api.py
@@ -918,3 +918,44 @@ class DatasetApi(UpdateableModule, RemoveableModuleApi):
                     yield from yield_tree(children, new_path)
 
         yield from yield_tree(self.get_tree(project_id), [])
+
+    def get_nested(self, project_id: int, dataset_id: int) -> List[DatasetInfo]:
+        """Returns a list of all nested datasets in the specified dataset.
+
+        :param project_id: Project ID in which the Dataset is located.
+        :type project_id: int
+        :param dataset_id: Dataset ID for which the nested datasets are returned.
+        :type dataset_id: int
+
+        :return: List of nested datasets.
+        :rtype: List[DatasetInfo]
+
+        :Usage example:
+
+        .. code-block:: python
+
+            import supervisely as sly
+
+            api = sly.Api.from_env()
+
+            project_id = 123
+            dataset_id = 456
+
+            datasets = api.dataset.get_nested(project_id, dataset_id)
+            for dataset in datasets:
+                print(dataset.name, dataset.id) # Output: ds1 123
+
+        """
+        tree = self.get_tree(project_id)
+
+        nested = []
+
+        def recurse(tree: Dict[DatasetInfo, Dict], needed_dataset: bool = False):
+            for dataset_info, children in tree.items():
+                if needed_dataset:
+                    nested.append(dataset_info)
+
+                recurse(children, needed_dataset or dataset_info.id == dataset_id)
+
+        recurse(tree)
+        return nested


### PR DESCRIPTION
Usage example:

```python

import supervisely as sly

api = sly.Api.from_env()

project_id = 123
dataset_id = 456

datasets = api.dataset.get_nested(project_id, dataset_id)
for dataset in datasets:
    print(dataset.name, dataset.id) # Output: ds1 123
                
 ```