### PR TITLE
AutoImport: Import Supervisely annotations into project with multi-view labeling interface

### DIFF
--- a/supervisely/convert/base_converter.py
+++ b/supervisely/convert/base_converter.py
@@ -398,6 +398,5 @@ class BaseConverter:
             return meta1
 
         if existing == LabelingInterface.DEFAULT:
-            new_settings = meta1.project_settings.clone(labeling_interface=new)
-            return meta1.clone(project_settings=new_settings)
+            return meta1.clone(project_settings=meta2.project_settings)
         return meta1

--- a/supervisely/convert/image/multi_view/multi_view.py
+++ b/supervisely/convert/image/multi_view/multi_view.py
@@ -1,6 +1,6 @@
 import os
 from collections import defaultdict
-from typing import Dict
+from typing import Dict, Union
 
 from tqdm import tqdm
 
@@ -33,13 +33,13 @@ class MultiViewImageConverter(ImageConverter):
             logger.debug(f"Found multi-view images in {self._input_data}.")
             return True
 
-    def _find_image_directories(self) -> Dict[str, list]:
+    def _find_image_directories(self) -> Union[Dict[str, list], None]:
         group_map = defaultdict(list)
         ann_exts = [".json", ".xml", ".txt"]
         for root, _, files in os.walk(self._input_data):
             for file in files:
                 if get_file_ext(file) in ann_exts:
-                    return
+                    return None
                 if get_file_ext(file) in SUPPORTED_IMG_EXTS:
                     group_map[root].append(os.path.join(root, file))
             

--- a/supervisely/convert/image/multi_view/multi_view.py
+++ b/supervisely/convert/image/multi_view/multi_view.py
@@ -2,8 +2,6 @@ import os
 from collections import defaultdict
 from typing import Dict, Union
 
-from tqdm import tqdm
-
 from supervisely import ProjectMeta, generate_free_name, is_development, logger
 from supervisely.api.api import Api, ApiContext
 from supervisely.convert.base_converter import AvailableImageConverters

--- a/supervisely/convert/image/multi_view/multi_view.py
+++ b/supervisely/convert/image/multi_view/multi_view.py
@@ -26,7 +26,7 @@ class MultiViewImageConverter(ImageConverter):
         logger.debug(f"Validating format: {self.__str__()}")
         group_map = self._find_image_directories()
         if not group_map:
-            logger.debug(f"No multi-view images found in {self._input_data}.")
+            logger.debug(f"Input data does not match {str(self)} format.")
             return False
         else:
             self._group_map = group_map
@@ -35,9 +35,14 @@ class MultiViewImageConverter(ImageConverter):
 
     def _find_image_directories(self) -> Dict[str, list]:
         group_map = defaultdict(list)
+        ann_exts = [".json", ".xml", ".txt"]
         for root, _, files in os.walk(self._input_data):
-            if any([get_file_ext(file) in SUPPORTED_IMG_EXTS for file in files]):
-                group_map[root] = list_files(root, SUPPORTED_IMG_EXTS)
+            for file in files:
+                if get_file_ext(file) in ann_exts:
+                    return
+                if get_file_ext(file) in SUPPORTED_IMG_EXTS:
+                    group_map[root].append(os.path.join(root, file))
+            
         return group_map
 
     def upload_dataset(

--- a/supervisely/convert/image/sly/sly_image_converter.py
+++ b/supervisely/convert/image/sly/sly_image_converter.py
@@ -10,6 +10,7 @@ from supervisely.convert.image.image_converter import ImageConverter
 from supervisely.io.fs import dirs_filter, file_exists, get_file_ext
 from supervisely.io.json import load_json_file
 from supervisely.project.project import find_project_dirs
+from supervisely.project.project_settings import LabelingInterface
 
 DATASET_ITEMS = "items"
 NESTED_DATASETS = "datasets"
@@ -31,6 +32,14 @@ class SLYImageConverter(ImageConverter):
     @property
     def key_file_ext(self) -> str:
         return ".json"
+
+    def validate_labeling_interface(self) -> bool:
+        return self._labeling_interface in [
+            LabelingInterface.DEFAULT,
+            LabelingInterface.IMAGE_MATTING,
+            LabelingInterface.FISHEYE,
+            LabelingInterface.MULTIVIEW,
+        ]
 
     def generate_meta_from_annotation(self, ann_path: str, meta: ProjectMeta) -> ProjectMeta:
         ann_json = load_json_file(ann_path)

--- a/supervisely/convert/image/sly/sly_image_converter.py
+++ b/supervisely/convert/image/sly/sly_image_converter.py
@@ -1,5 +1,5 @@
 import os
-from typing import Dict
+from typing import Dict, Optional
 
 import supervisely.convert.image.sly.sly_image_helper as sly_image_helper
 from supervisely import Annotation, Dataset, OpenMode, Project, ProjectMeta, logger
@@ -118,8 +118,8 @@ class SLYImageConverter(ImageConverter):
         self,
         item: ImageConverter.Item,
         meta: ProjectMeta = None,
-        renamed_classes: dict = None,
-        renamed_tags: dict = None,
+        renamed_classes: Optional[Dict[str, str]] = None,
+        renamed_tags: Optional[Dict[str, str]] = None,
     ) -> Annotation:
         """Convert to Supervisely format."""
         if meta is None:
@@ -142,7 +142,7 @@ class SLYImageConverter(ImageConverter):
     def read_sly_project(self, input_data: str) -> bool:
         try:
             self._items = []
-            project = {}
+            project : Dict = {}
             ds_cnt = 0
             self._meta = None
             logger.debug("Trying to find Supervisely project format in the input data")
@@ -194,7 +194,7 @@ class SLYImageConverter(ImageConverter):
     def read_sly_dataset(self, input_data: str) -> bool:
         try:
             self._items = []
-            project = {}
+            project : Dict = {}
             ds_cnt = 0
             self._meta = None
             logger.debug("Trying to read Supervisely datasets")
@@ -265,7 +265,7 @@ class SLYImageConverter(ImageConverter):
             project_structure: Dict,
             project_id: int,
             dataset_id: int,
-            parent_id: int = None,
+            parent_id: Optional[int] = None,
             first_dataset=False,
         ):
 

--- a/supervisely/convert/image/sly/sly_image_converter.py
+++ b/supervisely/convert/image/sly/sly_image_converter.py
@@ -142,7 +142,7 @@ class SLYImageConverter(ImageConverter):
     def read_sly_project(self, input_data: str) -> bool:
         try:
             self._items = []
-            project : Dict = {}
+            project = {}
             ds_cnt = 0
             self._meta = None
             logger.debug("Trying to find Supervisely project format in the input data")
@@ -194,7 +194,7 @@ class SLYImageConverter(ImageConverter):
     def read_sly_dataset(self, input_data: str) -> bool:
         try:
             self._items = []
-            project : Dict = {}
+            project = {}
             ds_cnt = 0
             self._meta = None
             logger.debug("Trying to read Supervisely datasets")


### PR DESCRIPTION
1. Improvement: Allow the import of Supervisely format annotations into an existing project with the multi-view settings already enabled:
  - Added "multiview" to labeling interface validation in the sly converter
  - Updated multi-view converter validation to return `False` if any possible annotation files are found (to avoid converter conflicts)
2. Fix: Update all project settings when updating the labeling interface