### PR TITLE
Add instance compatibility check for Workflow methods. Add dataclasses WorkflowSettings, WorkflowMeta.

### DIFF
--- a/supervisely/__init__.py
+++ b/supervisely/__init__.py
@@ -125,6 +125,7 @@ from supervisely.api.project_api import ProjectInfo
 from supervisely.api.workspace_api import WorkspaceInfo
 from supervisely.api.team_api import TeamInfo
 from supervisely.api.entity_annotation.figure_api import FigureInfo
+from supervisely.api.app_api import WorkflowSettings, WorkflowMeta
 
 from supervisely.cli import _handle_creds_error_to_console
 

--- a/supervisely/api/app_api.py
+++ b/supervisely/api/app_api.py
@@ -108,7 +108,10 @@ _context_menu_targets = {
     },
 }
 
-# to check if the instance is compatible with the workflow features
+# Used to check if the instance is compatible with the workflow features
+# and to avoid multiple requests to the API.
+# Consists of the instance version and the result of the check for each necessary version during the session.
+# Example: {"instance_version": "6.10.1", "6.9.31": True}
 _workflow_compatibility_version_cache = {}
 
 

--- a/supervisely/api/app_api.py
+++ b/supervisely/api/app_api.py
@@ -365,7 +365,21 @@ class SessionInfo(NamedTuple):
 
 @dataclass
 class WorkflowSettings:
-    """Used to customize the appearance and behavior of the workflow node."""
+    """Used to customize the appearance and behavior of the workflow node.
+
+    :param title: Title of the node. It is displayed in the node header.
+    :type title: Optional[str]
+    :param icon: Icon of the node. It is displayed in the node body.
+    :type icon: Optional[str]
+    :param icon_color: Color of the icon.
+    :type icon_color: Optional[str]
+    :param icon_bg_color: Background color of the icon.
+    :type icon_bg_color: Optional[str]
+    :param url: URL to be opened when the user clicks on it.
+    :type url: Optional[str]
+    :param url_title: Title of the URL.
+    :type url_title: Optional[str]
+    """
 
     title: Optional[str] = None
     icon: Optional[str] = None
@@ -412,24 +426,31 @@ class WorkflowSettings:
 
 @dataclass
 class WorkflowMeta:
-    """Used to customize the appearance of the workflow main and/or related node."""
+    """Used to customize the appearance of the workflow main and/or relation node.
 
-    customRelationSettings: Optional[WorkflowSettings] = None
-    customNodeSettings: Optional[WorkflowSettings] = None
+    :param relation_settings: customizes the appearance of the relation node - inputs and outputs
+    :type relation_settings: Optional[WorkflowSettings]
+    :param node_settings: customizes the appearance of the main node - the task itself
+    :type node_settings: Optional[WorkflowSettings]
+    """
+
+    relation_settings: Optional[WorkflowSettings] = None
+    node_settings: Optional[WorkflowSettings] = None
 
     def __post_init__(self):
-        if not (self.customRelationSettings or self.customNodeSettings):
-            raise ValueError(
-                "At least one of customRelationSettings or customNodeSettings must be specified"
+        if not (self.relation_settings or self.node_settings):
+            logger.info(
+                "Workflow Warning: at least one of 'relation_settings' or 'node_settings' must be specified in WorkflowMeta. "
+                "Customization will not be applied."
             )
 
     @property
     def as_dict(self) -> Dict[str, Any]:
         result = {}
-        if self.customRelationSettings is not None:
-            result["customRelationSettings"] = self.customRelationSettings.as_dict
-        if self.customNodeSettings is not None:
-            result["customNodeSettings"] = self.customNodeSettings.as_dict
+        if self.relation_settings is not None:
+            result["customRelationSettings"] = self.relation_settings.as_dict
+        if self.node_settings is not None:
+            result["customNodeSettings"] = self.node_settings.as_dict
         return result if result != {} else None
 
     @classmethod

--- a/supervisely/api/app_api.py
+++ b/supervisely/api/app_api.py
@@ -519,6 +519,7 @@ class AppApi(TaskApi):
 
         def __init__(self, api):
             self._api = api
+            # minimum instance version that supports workflow features
             self._min_instance_version = "6.9.31"
 
         # pylint: disable=no-self-argument
@@ -549,7 +550,7 @@ class AppApi(TaskApi):
             data: dict,
             transaction_type: str,
             task_id: Optional[int] = None,
-            meta: Optional[dict] = None,
+            meta: Optional[Union[WorkflowMeta, dict]] = None,
         ) -> dict:
             """
             Add input or output to a workflow node.
@@ -561,7 +562,7 @@ class AppApi(TaskApi):
             :param task_id: Task ID. If not specified, the task ID will be determined automatically.
             :type task_id: Optional[int]
             :param meta: Additional data for node customization.
-            :type meta: Optional[dict]
+            :type meta: Optional[Union[WorkflowMeta, dict]]
             :return: Response from the API.
             :rtype: dict
             """
@@ -584,6 +585,8 @@ class AppApi(TaskApi):
                 data_id = data.get("data_id") if data_type != "app_session" else node_id
                 data_meta = data.get("meta", {})
                 if meta is not None:
+                    if isinstance(meta, WorkflowMeta):
+                        meta = meta.as_dict
                     if validate_json(meta, self.__custom_meta_schema):
                         data_meta.update(meta)
                     else:
@@ -613,7 +616,7 @@ class AppApi(TaskApi):
             version_id: Optional[int] = None,
             version_num: Optional[int] = None,
             task_id: Optional[int] = None,
-            meta: Optional[dict] = None,
+            meta: Optional[Union[WorkflowMeta, dict]] = None,
         ) -> dict:
             """
             Add input type "project" to the workflow node.
@@ -631,7 +634,7 @@ class AppApi(TaskApi):
             :param task_id: Task ID. If not specified, the task ID will be determined automatically.
             :type task_id: Optional[int]
             :param meta: Additional data for node customization.
-            :type meta: Optional[dict]
+            :type meta: Optional[Union[WorkflowMeta, dict]]
             :return: Response from the API.
             :rtype: :class:`dict`
             :meta example:
@@ -691,7 +694,7 @@ class AppApi(TaskApi):
             self,
             dataset: Union[int, DatasetInfo],
             task_id: Optional[int] = None,
-            meta: Optional[dict] = None,
+            meta: Optional[Union[WorkflowMeta, dict]] = None,
         ) -> dict:
             """
             Add input type "dataset" to the workflow node.
@@ -702,7 +705,7 @@ class AppApi(TaskApi):
             :param task_id: Task ID. If not specified, the task ID will be determined automatically.
             :type task_id: Optional[int]
             :param meta: Additional data for node customization.
-            :type meta: Optional[dict]
+            :type meta: Optional[Union[WorkflowMeta, dict]]
             :return: Response from the API.
             :rtype: :class:`dict`
             :meta example:
@@ -742,7 +745,7 @@ class AppApi(TaskApi):
             file: Union[int, FileInfo, str],
             model_weight=False,
             task_id: Optional[int] = None,
-            meta: Optional[dict] = None,
+            meta: Optional[Union[WorkflowMeta, dict]] = None,
         ) -> dict:
             """
             Add input type "file" to the workflow node.
@@ -755,7 +758,7 @@ class AppApi(TaskApi):
             :param task_id: Task ID. If not specified, the task ID will be determined automatically.
             :type task_id: Optional[int]
             :param meta: Additional data for node customization.
-            :type meta: Optional[dict]
+            :type meta: Optional[Union[WorkflowMeta, dict]]
             :return: Response from the API.
             :rtype: :class:`dict`
             :meta example:
@@ -806,7 +809,7 @@ class AppApi(TaskApi):
             self,
             path: str,
             task_id: Optional[int] = None,
-            meta: Optional[dict] = None,
+            meta: Optional[Union[WorkflowMeta, dict]] = None,
         ) -> dict:
             """
             Add input type "folder" to the workflow node.
@@ -818,7 +821,7 @@ class AppApi(TaskApi):
             :param task_id: Task ID. If not specified, the task ID will be determined automatically.
             :type task_id: Optional[int]
             :param meta: Additional data for node customization.
-            :type meta: Optional[dict]
+            :type meta: Optional[Union[WorkflowMeta, dict]]
             :return: Response from the API.
             :rtype: :class:`dict`
             :meta example:
@@ -863,7 +866,7 @@ class AppApi(TaskApi):
             self,
             input_task_id: int,
             task_id: Optional[int] = None,
-            meta: Optional[dict] = None,
+            meta: Optional[Union[WorkflowMeta, dict]] = None,
         ) -> dict:
             """
             Add input type "task" to the workflow node.
@@ -874,7 +877,7 @@ class AppApi(TaskApi):
             :param task_id: Task ID of the node. If not specified, the task ID will be determined automatically.
             :type task_id: Optional[int]
             :param meta: Additional data for node customization.
-            :type meta: Optional[dict]
+            :type meta: Optional[Union[WorkflowMeta, dict]]
             :return: Response from the API.
             :rtype: :class:`dict`
             :meta example:
@@ -912,7 +915,7 @@ class AppApi(TaskApi):
             project: Union[int, ProjectInfo],
             version_id: Optional[int] = None,
             task_id: Optional[int] = None,
-            meta: Optional[dict] = None,
+            meta: Optional[Union[WorkflowMeta, dict]] = None,
         ) -> dict:
             """
             Add output type "project" to the workflow node.
@@ -926,7 +929,7 @@ class AppApi(TaskApi):
             :param task_id: Task ID. If not specified, the task ID will be determined automatically.
             :type task_id: Optional[int]
             :param meta: Additional data for node customization.
-            :type meta: Optional[dict]
+            :type meta: Optional[Union[WorkflowMeta, dict]]
             :return: Response from the API.
             :rtype: :class:`dict`
             :meta example:
@@ -976,7 +979,7 @@ class AppApi(TaskApi):
             self,
             dataset: Union[int, DatasetInfo],
             task_id: Optional[int] = None,
-            meta: Optional[dict] = None,
+            meta: Optional[Union[WorkflowMeta, dict]] = None,
         ) -> dict:
             """
             Add output type "dataset" to the workflow node.
@@ -987,7 +990,7 @@ class AppApi(TaskApi):
             :param task_id: Task ID. If not specified, the task ID will be determined automatically.
             :type task_id: Optional[int]
             :param meta: Additional data for node customization.
-            :type meta: Optional[dict]
+            :type meta: Optional[Union[WorkflowMeta, dict]]
             :return: Response from the API.
             :rtype: :class:`dict`
             :meta example:
@@ -1027,7 +1030,7 @@ class AppApi(TaskApi):
             file: Union[int, FileInfo],
             model_weight=False,
             task_id: Optional[int] = None,
-            meta: Optional[dict] = None,
+            meta: Optional[Union[WorkflowMeta, dict]] = None,
         ) -> dict:
             """
             Add output type "file" to the workflow node.
@@ -1040,7 +1043,7 @@ class AppApi(TaskApi):
             :param task_id: Task ID. If not specified, the task ID will be determined automatically.
             :type task_id: Optional[int]
             :param meta: Additional data for node customization.
-            :type meta: Optional[dict]
+            :type meta: Optional[Union[WorkflowMeta, dict]]
             :return: Response from the API.
             :rtype: :class:`dict`
             :meta example:
@@ -1081,7 +1084,7 @@ class AppApi(TaskApi):
             self,
             path: str,
             task_id: Optional[int] = None,
-            meta: Optional[dict] = None,
+            meta: Optional[Union[WorkflowMeta, dict]] = None,
         ) -> dict:
             """
             Add output type "folder" to the workflow node.
@@ -1093,7 +1096,7 @@ class AppApi(TaskApi):
             :param task_id: Task ID. If not specified, the task ID will be determined automatically.
             :type task_id: Optional[int]
             :param meta: Additional data for node customization.
-            :type meta: Optional[dict]
+            :type meta: Optional[Union[WorkflowMeta, dict]]
             :return: Response from the API.
             :rtype: :class:`dict`
             :meta example:
@@ -1137,7 +1140,7 @@ class AppApi(TaskApi):
         def add_output_app(
             self,
             task_id: Optional[int] = None,
-            meta: Optional[dict] = None,
+            meta: Optional[Union[WorkflowMeta, dict]] = None,
         ) -> dict:
             """
             Add output type "app_session" to the workflow node.
@@ -1146,7 +1149,7 @@ class AppApi(TaskApi):
             :param task_id: App Task ID. If not specified, the task ID will be determined automatically.
             :type task_id: Optional[int]
             :param meta: Additional data for node customization.
-            :type meta: Optional[dict]
+            :type meta: Optional[Union[WorkflowMeta, dict]]
             :return: Response from the API.
             :rtype: :class:`dict`
             :meta example:
@@ -1183,7 +1186,7 @@ class AppApi(TaskApi):
             self,
             output_task_id: int,
             task_id: Optional[int] = None,
-            meta: Optional[dict] = None,
+            meta: Optional[Union[WorkflowMeta, dict]] = None,
         ) -> dict:
             """
             Add output type "task" to the workflow node.
@@ -1194,7 +1197,7 @@ class AppApi(TaskApi):
             :param task_id: Task ID of the node. If not specified, the task ID will be determined automatically.
             :type task_id: Optional[int]
             :param meta: Additional data for node customization.
-            :type meta: Optional[dict]
+            :type meta: Optional[Union[WorkflowMeta, dict]]
             :return: Response from the API.
             :rtype: :class:`dict`
             :meta example:
@@ -1231,7 +1234,7 @@ class AppApi(TaskApi):
             self,
             id: int,
             task_id: Optional[int] = None,
-            meta: Optional[dict] = None,
+            meta: Optional[Union[WorkflowMeta, dict]] = None,
         ) -> dict:
             """
             Add output type "job" to the workflow node. Job is a Labeling Job.
@@ -1242,7 +1245,7 @@ class AppApi(TaskApi):
             :param task_id: Task ID. If not specified, the task ID will be determined automatically.
             :type task_id: Optional[int]
             :param meta: Additional data for node customization.
-            :type meta: Optional[dict]
+            :type meta: Optional[Union[WorkflowMeta, dict]]
             :return: Response from the API.
             :rtype: :class:`dict`
             :meta example:

--- a/supervisely/api/app_api.py
+++ b/supervisely/api/app_api.py
@@ -115,7 +115,7 @@ _context_menu_targets = {
 _workflow_compatibility_version_cache = {}
 
 
-def check_workflow_compatibility(api, min_instance_version):
+def check_workflow_compatibility(api, min_instance_version: str) -> bool:
     """Check if the instance is compatible with the workflow features.
     If the instance is not compatible, the user will be notified about it.
 

--- a/supervisely/api/app_api.py
+++ b/supervisely/api/app_api.py
@@ -523,7 +523,7 @@ class AppApi(TaskApi):
             self._min_instance_version = "6.9.31"
 
         # pylint: disable=no-self-argument
-        def check_instance_compatibility(min_instance_version: str = None):
+        def check_instance_compatibility(min_instance_version: Optional[str] = None):
             """Decorator to check instance compatibility with workflow features.
             If the instance is not compatible, the function will not be executed."""
 


### PR DESCRIPTION
### New dataclasses

 -  `WorkflowSettings` as interface which helps to create settings to customize the appearance and behavior of the workflow node
 -  `WorkflowMeta` as interface where you assign settings to main or relation node. It's easy to convert the `meta` in the dictionary via `as_dict` property or get it right after initialization with the `create_as_dict()` class method
 
 ### Check instance version compatibility for every `Workflow` method

 - The `_workflow_compatibility_version_cache` global variable stores the validation results for the current session for each new `min_instance_version` that has already been validated, to avoid unnecessary API calls.
 - The `check_instance_compatibility` decorator is used on each `Workflow` method to check compatibility. If new methods will require a new instance version - it is necessary to add this to the decorator as argument.
 - You could pass meta to the `Workflow` methods as `WorkflowMeta` instance.
 - Initial `min_instance_version` for `Workflow` features is hardcoded as "6.9.31"