### PR TITLE
Model benchmark. Stage 2.1. Fixes and corner case handling

### DIFF
--- a/supervisely/nn/benchmark/evaluation/instance_segmentation_evaluator.py
+++ b/supervisely/nn/benchmark/evaluation/instance_segmentation_evaluator.py
@@ -39,7 +39,7 @@ class InstanceSegmentationEvaluator(BaseEvaluator):
             raise ValueError("Not found any annotations in GT project")
         if len(cocoDt_json["annotations"]) == 0:
             raise ValueError(
-                "Not found any predictions in DT project. "
+                "Not found any predictions. "
                 "Please make sure that your model produces predictions."
             )
         assert cocoDt_json['categories'] == cocoGt_json['categories']

--- a/supervisely/nn/benchmark/evaluation/instance_segmentation_evaluator.py
+++ b/supervisely/nn/benchmark/evaluation/instance_segmentation_evaluator.py
@@ -35,10 +35,17 @@ class InstanceSegmentationEvaluator(BaseEvaluator):
             is_dt_dataset=True,
             accepted_shapes=["polygon", "bitmap"],
         )
+        if len(cocoGt_json["annotations"]) == 0:
+            raise ValueError("Not found any annotations in GT project")
+        if len(cocoDt_json["annotations"]) == 0:
+            raise ValueError(
+                "Not found any predictions in DT project. "
+                "Please make sure that your model produces predictions."
+            )
         assert cocoDt_json['categories'] == cocoGt_json['categories']
         assert [x['id'] for x in cocoDt_json['images']] == [x['id'] for x in cocoGt_json['images']]
         return cocoGt_json, cocoDt_json
-    
+
     def _dump_datasets(self):
         cocoGt_path, cocoDt_path, eval_data_path = self._get_eval_paths()
         dump_json_file(self.cocoGt_json, cocoGt_path, indent=None)
@@ -54,4 +61,3 @@ class InstanceSegmentationEvaluator(BaseEvaluator):
         cocoDt_path = os.path.join(base_dir, "cocoDt.json")
         eval_data_path = os.path.join(base_dir, "eval_data.pkl")
         return cocoGt_path, cocoDt_path, eval_data_path
-    

--- a/supervisely/nn/benchmark/evaluation/object_detection_evaluator.py
+++ b/supervisely/nn/benchmark/evaluation/object_detection_evaluator.py
@@ -36,7 +36,7 @@ class ObjectDetectionEvaluator(BaseEvaluator):
             raise ValueError("Not found any annotations in GT project")
         if len(cocoDt_json["annotations"]) == 0:
             raise ValueError(
-                "Not found any predictions in DT project. "
+                "Not found any predictions. "
                 "Please make sure that your model produces predictions."
             )
         assert (

--- a/supervisely/nn/benchmark/utils.py
+++ b/supervisely/nn/benchmark/utils.py
@@ -1,6 +1,6 @@
 from supervisely.nn.inference import SessionJSON
 
-WORKSPACE_NAME = "Model Benchmark: predctions and differences"
+WORKSPACE_NAME = "Model Benchmark: predictions and differences"
 WORKSPACE_DESCRIPTION = "Technical workspace for model benchmarking. Contains predictions and differences between ground truth and predictions."
 
 def try_set_conf_auto(session: SessionJSON, conf: float):

--- a/supervisely/nn/benchmark/visualization/vis_metric_base.py
+++ b/supervisely/nn/benchmark/visualization/vis_metric_base.py
@@ -31,6 +31,7 @@ class MetricVis:
         self.has_diffs_view: bool = False
         self.switchable: bool = False
         self.schema: Schema = None
+        self.empty = False
 
         self._loader = loader
         self._template_markdown = Template(template_markdown_str)

--- a/supervisely/nn/benchmark/visualization/vis_metrics/frequently_confused.py
+++ b/supervisely/nn/benchmark/visualization/vis_metrics/frequently_confused.py
@@ -18,6 +18,20 @@ class FrequentlyConfused(MetricVis):
         self.switchable: bool = True
         self._keypair_sep: str = " - "
         df = self._loader.mp.frequently_confused()
+        if df.empty:
+            self.schema = Schema(
+                empty=Widget.Markdown(
+                    title="Frequently Confused Classes",
+                    is_header=True,
+                    formats=[
+                        "Frequently Confused Classes",
+                        "No frequently confused class pairs found",
+                    ],
+                )
+            )
+            self.empty = True
+            return
+
         pair = df["category_pair"][0]
         prob = df["probability"][0]
         self.schema = Schema(
@@ -42,6 +56,9 @@ class FrequentlyConfused(MetricVis):
         )
 
     def get_figure(self, widget: Widget.Chart):  # -> Optional[Tuple[go.Figure]]:
+        if self.empty:
+            return
+
         import plotly.graph_objects as go  # pylint: disable=import-error
 
         # Frequency of confusion as bar chart
@@ -68,7 +85,7 @@ class FrequentlyConfused(MetricVis):
         return fig
 
     def get_click_data(self, widget: Widget.Chart) -> Optional[dict]:
-        if not self.clickable:
+        if not self.clickable or self.empty:
             return
         res = dict(projectMeta=self._loader.dt_project_meta.to_json())
 

--- a/supervisely/nn/benchmark/visualization/vis_texts.py
+++ b/supervisely/nn/benchmark/visualization/vis_texts.py
@@ -347,3 +347,8 @@ _Bars in the chart are sorted by <abbr title="{}">F1-score</abbr> to keep a unif
 """
     + clickable_label
 )
+
+empty = """### {}
+
+> {}
+"""

--- a/supervisely/nn/benchmark/visualization/vis_texts.py
+++ b/supervisely/nn/benchmark/visualization/vis_texts.py
@@ -198,14 +198,16 @@ In this plot, you can evaluate PR curve for each class individually.
     + clickable_label
 )
 
-markdown_confusion_matrix = """## Confusion Matrix
+markdown_confusion_matrix = (
+    """## Confusion Matrix
 
 Confusion matrix helps to find the number of confusions between different classes made by the model.
 Each row of the matrix represents the instances in a ground truth class, while each column represents the instances in a predicted class.
 The diagonal elements represent the number of correct predictions for each class (True Positives), and the off-diagonal elements show misclassifications.
 
-*Click on the chart to explore corresponding images.*
 """
+    + clickable_label
+)
 
 
 markdown_frequently_confused = (


### PR DESCRIPTION
- fix typo `predctions` → `predictions`
- raise error if no predictions
- show notification instead of chart in `Frequently Confused Classes` (if not found any confused pairs)