### PR TITLE
Model benchmark stage 2.2. Selected classes

### DIFF
--- a/supervisely/nn/benchmark/base_benchmark.py
+++ b/supervisely/nn/benchmark/base_benchmark.py
@@ -41,7 +41,6 @@ class BaseBenchmark:
         self._eval_inference_info = None
         self._speedtest = None
         self.pbar = progress or tqdm_sly
-
         self.classes_whitelist = classes_whitelist
 
     def _get_evaluator_class(self) -> type:
@@ -59,9 +58,6 @@ class BaseBenchmark:
         batch_size: int = 8,
         cache_project_on_agent: bool = False,
     ):
-        if self.classes_whitelist:
-            inference_settings = inference_settings or {}
-            inference_settings["classes"] = self.classes_whitelist
         self.session = self._init_model_session(model_session, inference_settings)
         self._eval_inference_info = self._run_inference(
             output_project_id, batch_size, cache_project_on_agent
@@ -77,9 +73,6 @@ class BaseBenchmark:
         batch_size: int = 8,
         cache_project_on_agent: bool = False,
     ):
-        if self.classes_whitelist:
-            inference_settings = inference_settings or {}
-            inference_settings["classes"] = self.classes_whitelist
         self.session = self._init_model_session(model_session, inference_settings)
         self._eval_inference_info = self._run_inference(
             output_project_id, batch_size, cache_project_on_agent
@@ -346,6 +339,10 @@ class BaseBenchmark:
             session = model_session
         else:
             raise ValueError(f"Unsupported type of 'model_session' argument: {type(model_session)}")
+
+        if self.classes_whitelist:
+            inference_settings = inference_settings or {}
+            inference_settings["classes"] = self.classes_whitelist
 
         if inference_settings is not None:
             session.set_inference_settings(inference_settings)

--- a/supervisely/nn/benchmark/evaluation/base_evaluator.py
+++ b/supervisely/nn/benchmark/evaluation/base_evaluator.py
@@ -1,12 +1,13 @@
 import os
 import pickle
-from typing import Optional
+from typing import List, Optional
 
 from supervisely.app.widgets import SlyTqdm
 from supervisely.task.progress import tqdm_sly
 
 
 class BaseEvaluator:
+
     def __init__(
         self,
         gt_project_path: str,
@@ -14,6 +15,7 @@ class BaseEvaluator:
         result_dir: str = "./evaluation",
         progress: Optional[SlyTqdm] = None,
         items_count: Optional[int] = None,  # TODO: is it needed?
+        classes_whitelist: Optional[List[str]] = None,
     ):
         self.gt_project_path = gt_project_path
         self.dt_project_path = dt_project_path
@@ -21,6 +23,7 @@ class BaseEvaluator:
         self.total_items = items_count
         self.pbar = progress or tqdm_sly
         os.makedirs(result_dir, exist_ok=True)
+        self.classes_whitelist = classes_whitelist
 
     def evaluate(self):
         raise NotImplementedError()

--- a/supervisely/nn/benchmark/evaluation/coco/metric_provider.py
+++ b/supervisely/nn/benchmark/evaluation/coco/metric_provider.py
@@ -225,12 +225,18 @@ class _MetricProvider:
         tp_count = true_positives[:, 0]
         # FN
         cats_fn = np.array([catId2idx[match["category_id"]] for match in self.fn_matches])
-        fn_count = np.bincount(cats_fn, minlength=len(cat_ids)).astype(int)
+        if cats_fn.size == 0:
+            fn_count = np.zeros((len(cat_ids),), dtype=int)
+        else:
+            fn_count = np.bincount(cats_fn, minlength=len(cat_ids)).astype(int)
         gt_count = fn_count + tp_count
         false_negatives = gt_count[:, None] - true_positives
         # FP
         cats_fp = np.array([catId2idx[match["category_id"]] for match in self.fp_matches])
-        fp_count = np.bincount(cats_fp, minlength=len(cat_ids)).astype(int)
+        if cats_fp.size == 0:
+            fp_count = np.zeros((len(cat_ids),), dtype=int)
+        else:
+            fp_count = np.bincount(cats_fp, minlength=len(cat_ids)).astype(int)
         dt_count = fp_count + tp_count
         false_positives = dt_count[:, None] - true_positives
 

--- a/supervisely/nn/benchmark/evaluation/instance_segmentation_evaluator.py
+++ b/supervisely/nn/benchmark/evaluation/instance_segmentation_evaluator.py
@@ -35,10 +35,17 @@ class InstanceSegmentationEvaluator(BaseEvaluator):
             is_dt_dataset=True,
             accepted_shapes=["polygon", "bitmap"],
         )
+        if len(cocoGt_json["annotations"]) == 0:
+            raise ValueError("Not found any annotations in GT project")
+        if len(cocoDt_json["annotations"]) == 0:
+            raise ValueError(
+                "Not found any predictions. "
+                "Please make sure that your model produces predictions."
+            )
         assert cocoDt_json['categories'] == cocoGt_json['categories']
         assert [x['id'] for x in cocoDt_json['images']] == [x['id'] for x in cocoGt_json['images']]
         return cocoGt_json, cocoDt_json
-    
+
     def _dump_datasets(self):
         cocoGt_path, cocoDt_path, eval_data_path = self._get_eval_paths()
         dump_json_file(self.cocoGt_json, cocoGt_path, indent=None)
@@ -54,4 +61,3 @@ class InstanceSegmentationEvaluator(BaseEvaluator):
         cocoDt_path = os.path.join(base_dir, "cocoDt.json")
         eval_data_path = os.path.join(base_dir, "eval_data.pkl")
         return cocoGt_path, cocoDt_path, eval_data_path
-    

--- a/supervisely/nn/benchmark/evaluation/object_detection_evaluator.py
+++ b/supervisely/nn/benchmark/evaluation/object_detection_evaluator.py
@@ -34,6 +34,14 @@ class ObjectDetectionEvaluator(BaseEvaluator):
                 progress_cb=pbar.update,
                 classes_whitelist=self.classes_whitelist,
             )
+
+        if len(cocoGt_json["annotations"]) == 0:
+            raise ValueError("Not found any annotations in GT project")
+        if len(cocoDt_json["annotations"]) == 0:
+            raise ValueError(
+                "Not found any predictions. "
+                "Please make sure that your model produces predictions."
+            )
         assert (
             cocoDt_json["categories"] == cocoGt_json["categories"]
         ), "Classes in GT and Pred projects must be the same"

--- a/supervisely/nn/benchmark/evaluation/object_detection_evaluator.py
+++ b/supervisely/nn/benchmark/evaluation/object_detection_evaluator.py
@@ -1,7 +1,8 @@
 import os
+
 from supervisely.io.json import dump_json_file
-from supervisely.nn.benchmark.evaluation import BaseEvaluator
 from supervisely.nn.benchmark.coco_utils import read_coco_datasets, sly2coco
+from supervisely.nn.benchmark.evaluation import BaseEvaluator
 from supervisely.nn.benchmark.evaluation.coco import calculate_metrics
 
 
@@ -11,11 +12,8 @@ class ObjectDetectionEvaluator(BaseEvaluator):
         self.cocoGt, self.cocoDt = read_coco_datasets(self.cocoGt_json, self.cocoDt_json)
         with self.pbar(message="Calculating metrics", total=10) as p:
             self.eval_data = calculate_metrics(
-                self.cocoGt,
-                self.cocoDt,
-                iouType="bbox",
-                progress_cb=p.update
-                )
+                self.cocoGt, self.cocoDt, iouType="bbox", progress_cb=p.update
+            )
         self._dump_eval_results()
 
     def _convert_to_coco(self):
@@ -27,14 +25,18 @@ class ObjectDetectionEvaluator(BaseEvaluator):
                 is_dt_dataset=False,
                 accepted_shapes=["rectangle"],
                 progress_cb=pbar.update,
+                classes_whitelist=self.classes_whitelist,
             )
             cocoDt_json = sly2coco(
                 self.dt_project_path,
                 is_dt_dataset=True,
                 accepted_shapes=["rectangle"],
                 progress_cb=pbar.update,
+                classes_whitelist=self.classes_whitelist,
             )
-        assert cocoDt_json["categories"] == cocoGt_json["categories"], "Classes in GT and Pred projects must be the same"
+        assert (
+            cocoDt_json["categories"] == cocoGt_json["categories"]
+        ), "Classes in GT and Pred projects must be the same"
         assert [x["id"] for x in cocoDt_json["images"]] == [x["id"] for x in cocoGt_json["images"]]
         return cocoGt_json, cocoDt_json
 

--- a/supervisely/nn/benchmark/utils.py
+++ b/supervisely/nn/benchmark/utils.py
@@ -1,6 +1,6 @@
 from supervisely.nn.inference import SessionJSON
 
-WORKSPACE_NAME = "Model Benchmark: predctions and differences"
+WORKSPACE_NAME = "Model Benchmark: predictions and differences"
 WORKSPACE_DESCRIPTION = "Technical workspace for model benchmarking. Contains predictions and differences between ground truth and predictions."
 
 def try_set_conf_auto(session: SessionJSON, conf: float):

--- a/supervisely/nn/benchmark/visualization/vis_metric_base.py
+++ b/supervisely/nn/benchmark/visualization/vis_metric_base.py
@@ -31,6 +31,7 @@ class MetricVis:
         self.has_diffs_view: bool = False
         self.switchable: bool = False
         self.schema: Schema = None
+        self.empty = False
 
         self._loader = loader
         self._template_markdown = Template(template_markdown_str)

--- a/supervisely/nn/benchmark/visualization/vis_metrics/explorer_grid.py
+++ b/supervisely/nn/benchmark/visualization/vis_metrics/explorer_grid.py
@@ -54,7 +54,7 @@ class ExplorerGrid(MetricVis):
         return res
 
     def get_gallery(self, widget: Widget.Gallery):
-        return self._get_gallery(widget, limit=8)
+        return self._get_gallery(widget, limit=9)
 
     def get_gallery_click_data(self, widget: Widget.Gallery):
         res = {}

--- a/supervisely/nn/benchmark/visualization/vis_metrics/frequently_confused.py
+++ b/supervisely/nn/benchmark/visualization/vis_metrics/frequently_confused.py
@@ -18,6 +18,20 @@ class FrequentlyConfused(MetricVis):
         self.switchable: bool = True
         self._keypair_sep: str = " - "
         df = self._loader.mp.frequently_confused()
+        if df.empty:
+            self.schema = Schema(
+                empty=Widget.Markdown(
+                    title="Frequently Confused Classes",
+                    is_header=True,
+                    formats=[
+                        "Frequently Confused Classes",
+                        "No frequently confused class pairs found",
+                    ],
+                )
+            )
+            self.empty = True
+            return
+
         pair = df["category_pair"][0]
         prob = df["probability"][0]
         self.schema = Schema(
@@ -42,6 +56,9 @@ class FrequentlyConfused(MetricVis):
         )
 
     def get_figure(self, widget: Widget.Chart):  # -> Optional[Tuple[go.Figure]]:
+        if self.empty:
+            return
+
         import plotly.graph_objects as go  # pylint: disable=import-error
 
         # Frequency of confusion as bar chart
@@ -68,7 +85,7 @@ class FrequentlyConfused(MetricVis):
         return fig
 
     def get_click_data(self, widget: Widget.Chart) -> Optional[dict]:
-        if not self.clickable:
+        if not self.clickable or self.empty:
             return
         res = dict(projectMeta=self._loader.dt_project_meta.to_json())
 

--- a/supervisely/nn/benchmark/visualization/vis_metrics/overview.py
+++ b/supervisely/nn/benchmark/visualization/vis_metrics/overview.py
@@ -25,12 +25,8 @@ class Overview(MetricVis):
                 title="Overview",
                 is_header=True,
                 formats=[
-                    info.get("deploy_params", {}).get(
-                        "checkpoint_name",
-                    ),
+                    info.get("deploy_params", {}).get("checkpoint_name"),
                     info.get("architecture"),
-                    # info.get("year", "???"),
-                    # info.get("authors", "???"),
                     info.get("task_type"),
                     info.get("runtime"),
                     info.get("hardware"),
@@ -38,6 +34,8 @@ class Overview(MetricVis):
                     link_text,
                     self._loader.docs_link,
                     self._loader.docs_link,
+                    self._loader.gt_project_info.id,
+                    self._loader.gt_project_info.name
                 ],
             ),
             markdown_key_metrics=Widget.Markdown(

--- a/supervisely/nn/benchmark/visualization/vis_metrics/overview.py
+++ b/supervisely/nn/benchmark/visualization/vis_metrics/overview.py
@@ -33,7 +33,6 @@ class Overview(MetricVis):
                     url,
                     link_text,
                     self._loader.docs_link,
-                    self._loader.docs_link,
                     self._loader.gt_project_info.id,
                     self._loader.gt_project_info.name
                 ],

--- a/supervisely/nn/benchmark/visualization/vis_texts.py
+++ b/supervisely/nn/benchmark/visualization/vis_texts.py
@@ -32,6 +32,7 @@ markdown_overview = """# {}
 - **Hardware**: {}
 - **Checkpoint URL**: <a href="{}" target="_blank">{}</a>
 - Learn metrics details and how to use them in <a href="{}" target="_blank">technical report</a>
+- Ground Truth project: <a href="/projects/{}/datasets" target="_blank">{}</a>
 """
 # - **Model**: {}
 # - **Training dataset (?)**: COCO 2017 train

--- a/supervisely/nn/benchmark/visualization/vis_texts.py
+++ b/supervisely/nn/benchmark/visualization/vis_texts.py
@@ -198,14 +198,16 @@ In this plot, you can evaluate PR curve for each class individually.
     + clickable_label
 )
 
-markdown_confusion_matrix = """## Confusion Matrix
+markdown_confusion_matrix = (
+    """## Confusion Matrix
 
 Confusion matrix helps to find the number of confusions between different classes made by the model.
 Each row of the matrix represents the instances in a ground truth class, while each column represents the instances in a predicted class.
 The diagonal elements represent the number of correct predictions for each class (True Positives), and the off-diagonal elements show misclassifications.
 
-*Click on the chart to explore corresponding images.*
 """
+    + clickable_label
+)
 
 
 markdown_frequently_confused = (
@@ -345,3 +347,8 @@ _Bars in the chart are sorted by <abbr title="{}">F1-score</abbr> to keep a unif
 """
     + clickable_label
 )
+
+empty = """### {}
+
+> {}
+"""

--- a/supervisely/nn/benchmark/visualization/visualizer.py
+++ b/supervisely/nn/benchmark/visualization/visualizer.py
@@ -366,6 +366,8 @@ class Visualizer:
                         labels.append(label)
 
                     for label in gt_ann.labels:
+                        if label.obj_class.name not in self.classes_whitelist:
+                            continue
                         if label.geometry.sly_id not in matched_gt_ids:
                             if self._is_label_compatible_to_cv_task(label):
                                 new_label = label.add_tags(

--- a/supervisely/nn/benchmark/visualization/visualizer.py
+++ b/supervisely/nn/benchmark/visualization/visualizer.py
@@ -21,9 +21,7 @@ from supervisely.project.project_meta import ProjectMeta
 if TYPE_CHECKING:
     from supervisely.nn.benchmark.base_benchmark import BaseBenchmark
 
-from supervisely.nn.benchmark.evaluation.coco.metric_provider import (
-    MetricProvider,
-)
+from supervisely.nn.benchmark.evaluation.coco.metric_provider import MetricProvider
 from supervisely.nn.benchmark.visualization.vis_click_data import ClickData, IdMapper
 from supervisely.nn.benchmark.visualization.vis_metric_base import MetricVis
 from supervisely.nn.benchmark.visualization.vis_metrics import ALL_METRICS
@@ -47,13 +45,10 @@ class Visualizer:
         self.dt_project_info = benchmark.dt_project_info
         self.gt_project_info = benchmark.gt_project_info
         self.diff_project_info = benchmark.diff_project_info
+        self.classes_whitelist = benchmark.classes_whitelist
 
-        self.gt_project_meta = ProjectMeta.from_json(
-            data=self._api.project.get_meta(id=self.gt_project_info.id)
-        )
-        self.dt_project_meta = ProjectMeta.from_json(
-            data=self._api.project.get_meta(id=self.dt_project_info.id)
-        )
+        self.gt_project_meta = self._get_filtered_project_meta(self.gt_project_info.id)
+        self.dt_project_meta = self._get_filtered_project_meta(self.dt_project_info.id)
         self._docs_link = "https://docs.supervisely.com/neural-networks/model-evaluation-benchmark/"
 
         if benchmark.cv_task == CVTask.OBJECT_DETECTION:
@@ -164,9 +159,7 @@ class Visualizer:
         gallery._update_filters()
         res.update(gallery.get_json_state())
 
-        self.dt_project_meta = ProjectMeta.from_json(
-            data=self._api.project.get_meta(id=self.dt_project_info.id)
-        )
+        self.dt_project_meta = self._get_filtered_project_meta(self.dt_project_info.id)
         res["projectMeta"] = self.dt_project_meta.to_json()
         for basename in ["modal_general.json", "modal_general_diff.json"]:
             local_path = f"{self.layout_dir}/data/{basename}"
@@ -530,3 +523,15 @@ class Visualizer:
         if self.cv_task == CVTask.OBJECT_DETECTION:
             return isinstance(label.geometry, Rectangle)
         return False
+
+    def _get_filtered_project_meta(self, project_id: int) -> ProjectMeta:
+        meta = self._api.project.get_meta(project_id)
+        meta = ProjectMeta.from_json(meta)
+        remove_classes = []
+        if self.classes_whitelist:
+            for obj_class in meta.obj_classes:
+                if obj_class.name not in self.classes_whitelist:
+                    remove_classes.append(obj_class.name)
+            if remove_classes:
+                meta = meta.delete_obj_classes(remove_classes)
+        return meta

--- a/supervisely/nn/inference/session.py
+++ b/supervisely/nn/inference/session.py
@@ -175,8 +175,9 @@ class SessionJSON:
     def _validate_new_inference_settings(self, new_settings: dict) -> None:
         default_settings = self.get_default_inference_settings()
         for key, value in new_settings.items():
-            if key not in default_settings:
-                raise ValueError(f"Key '{key}' is not acceptable. Acceptable keys are: {default_settings}")
+            if key not in default_settings and key != "classes":
+                acceptable_keys = ", ".join(default_settings.keys()) + ", 'classes'"
+                raise ValueError(f"Key '{key}' is not acceptable. Acceptable keys are: {acceptable_keys}")
 
     def inference_image_id(self, image_id: int, upload=False) -> Dict[str, Any]:
         endpoint = "inference_image_id"


### PR DESCRIPTION
- using selected classes from the training or the evaluator app
- allow "classes" key in inference_settings

From PR https://github.com/supervisely/supervisely/pull/1095:
- fix typo `predctions` → `predictions`
- raise error if no predictions
- show notification instead of chart in `Frequently Confused Classes` (if not found any confused pairs)