### PR TITLE
Width for the Transfer widget

### DIFF
--- a/supervisely/app/widgets/transfer/style.css
+++ b/supervisely/app/widgets/transfer/style.css
@@ -1,0 +1,3 @@
+.wide-transfer .el-transfer-panel {
+  width: var(--panel-width, 150px);
+}

--- a/supervisely/app/widgets/transfer/template.html
+++ b/supervisely/app/widgets/transfer/template.html
@@ -1,4 +1,6 @@
-<div>
+<link rel="stylesheet" href="./sly/css/app/widgets/transfer/style.css" />
+
+<div class="wide-transfer" style="--panel-width: {{{widget._width}}}px;">
   <el-transfer
     {% if widget._filterable is true %}
     filterable

--- a/supervisely/app/widgets/transfer/transfer.py
+++ b/supervisely/app/widgets/transfer/transfer.py
@@ -41,7 +41,7 @@ class Transfer(Widget):
     :param right_checked: A list of keys of the items in the right (target) list, which should be checked at widget
                         initialization. Defaults to None.
     :type right_checked: List[str], optional
-    :param width: The width of the widget in pixels. Defaults to 150.
+    :param width: The width of the widget in pixels. The default and minimum width is 150 pixels.
     :type width: int, optional
 
     :Methods:

--- a/supervisely/app/widgets/transfer/transfer.py
+++ b/supervisely/app/widgets/transfer/transfer.py
@@ -160,7 +160,7 @@ class Transfer(Widget):
         self._filterable = filterable
         self._filter_placeholder = filter_placeholder
 
-        self._width = width
+        self._width = max(width, 150)
 
         self._titles = titles if titles is not None else ["Source", "Target"]
 


### PR DESCRIPTION
The feature allows to set the widget's width in pixels.

Example:

```python
transfer = Tranfser(items, width=300)
```