### PR TITLE
Refactor async listing method for figures in FigureApi

### DIFF
--- a/supervisely/api/entity_annotation/figure_api.py
+++ b/supervisely/api/entity_annotation/figure_api.py
@@ -877,9 +877,8 @@ class FigureApi(RemoveableBulkModuleApi):
                 for info in response_json["entities"]:
                     figure_info = self._convert_json_info(info, True)
                     page_figures.append(figure_info)
-                    if progress_cb is not None:
-                        progress_cb.total += 1
-                        progress_cb.update(1)
+                if progress_cb is not None:
+                    progress_cb.update(len(response_json["entities"]))
                 return page_figures
 
         async def _get_all_pages(ids_filter, progress_cb: tqdm = None):
@@ -900,9 +899,8 @@ class FigureApi(RemoveableBulkModuleApi):
             for info in response_json["entities"]:
                 figure_info = self._convert_json_info(info, True)
                 all_figures.append(figure_info)
-                if progress_cb is not None:
-                    progress_cb.total += 1
-                    progress_cb.update(1)
+            if progress_cb is not None:
+                progress_cb.update(len(response_json["entities"]))
 
             # Process remaining pages in parallel if needed
             if pages_count > 1:

--- a/supervisely/api/entity_annotation/figure_api.py
+++ b/supervisely/api/entity_annotation/figure_api.py
@@ -818,7 +818,7 @@ class FigureApi(RemoveableBulkModuleApi):
         :type log_progress: bool, optional
         :param batch_size: Size of the batch for downloading figures per 1 request. Default is 300.
                         Used for batching image_ids when filtering by specific images.
-                        Adjust this value for optimal performance, value cannot exceed 300.
+                        Adjust this value for optimal performance, value cannot exceed 500.
         :type batch_size: int, optional
         :return: A dictionary where keys are image IDs and values are lists of figures.
         :rtype: Dict[int, List[FigureInfo]]
@@ -939,7 +939,6 @@ class FigureApi(RemoveableBulkModuleApi):
 
         # Combine results from all batches
         images_figures = defaultdict(list)
-        total_processed = 0
 
         if log_progress:
             # Calculate total figures from all batches
@@ -949,7 +948,6 @@ class FigureApi(RemoveableBulkModuleApi):
         for batch_figures in all_results:
             for figure in batch_figures:
                 images_figures[figure.entity_id].append(figure)
-                total_processed += 1
                 if log_progress:
                     progress_cb.update(1)
 
@@ -982,7 +980,7 @@ class FigureApi(RemoveableBulkModuleApi):
         :type log_progress: bool, optional
         :param batch_size: Size of the batch for downloading figures per 1 request. Default is 300.
                         Used for batching image_ids when filtering by specific images.
-                        Adjust this value for optimal performance, value cannot exceed 300.
+                        Adjust this value for optimal performance, value cannot exceed 500.
         :type batch_size: int, optional
 
         :return: A dictionary where keys are image IDs and values are lists of figures.


### PR DESCRIPTION
This PR refactors the async listing method for figures in FigureApi to improve performance through batching. The refactoring introduces a new `batch_size` parameter and restructures the code to process image IDs in configurable batches rather than sending all IDs in a single request.

- Adds configurable `batch_size` parameter (default 300) for controlling request batch sizes
- Restructures async figure downloading to use batch processing strategy
- Implements parallel processing of batches with small delays to reduce server load