### PR TITLE
Security: Fix RCE via restricted pickle deserialization

### DIFF
--- a/supervisely/api/image_api.py
+++ b/supervisely/api/image_api.py
@@ -78,6 +78,7 @@ from supervisely.io.env import (
 from supervisely.io.fs import (
     OFFSETS_PKL_BATCH_SIZE,
     OFFSETS_PKL_SUFFIX,
+    RestrictedUnpickler,
     clean_dir,
     ensure_base_path,
     get_file_ext,
@@ -197,10 +198,11 @@ class BlobImageInfo:
             current_batch = []
 
             with open(file_path, "rb") as f:
+                unpickler = RestrictedUnpickler(f)
                 while True:
                     try:
-                        # Load one pickle object at a time
-                        data = pickle.load(f)
+                        # Load one pickle object at a time using restricted unpickler
+                        data = unpickler.load()
 
                         if isinstance(data, list):
                             # More efficient way to process lists

--- a/supervisely/io/fs.py
+++ b/supervisely/io/fs.py
@@ -43,6 +43,28 @@ OFFSETS_PKL_SUFFIX = "_offsets.pkl"  # suffix for pickle file with image offsets
 OFFSETS_PKL_BATCH_SIZE = 10000  # 10k images per batch when loading from pickle
 
 
+import pickle
+import builtins
+
+class RestrictedUnpickler(pickle.Unpickler):
+    def find_class(self, module, name):
+        if module == "supervisely.api.image_api" and name == "BlobImageInfo":
+            from supervisely.api.image_api import BlobImageInfo
+            return BlobImageInfo
+        if module == "builtins" and name in ("list", "dict", "str", "int", "float", "bool", "set", "tuple", "NoneType"):
+            return getattr(builtins, name)
+        if module == "collections" and name == "OrderedDict":
+            import collections
+            return collections.OrderedDict
+        if module == "numpy.core.multiarray" or module == "numpy":
+            import numpy
+            return getattr(numpy, name)
+        if module == "pandas.core.frame" or module == "pandas":
+            import pandas
+            return getattr(pandas, name)
+        raise pickle.UnpicklingError(f"global '{module}.{name}' is forbidden")
+
+
 def get_file_name(path: str) -> str:
     """
     Extracts file name from a given path.

--- a/supervisely/project/project.py
+++ b/supervisely/project/project.py
@@ -71,6 +71,7 @@ from supervisely.io.fs import (
     mkdir,
     silent_remove,
     subdirs_tree,
+    RestrictedUnpickler,
 )
 from supervisely.io.fs_cache import FileCache
 from supervisely.io.json import dump_json_file, dump_json_file_async, load_json_file
@@ -83,7 +84,7 @@ from supervisely.task.progress import tqdm_sly
 TF_BLOB_DIR = "blob-files"  # directory for project blob files in team files
 
 
-class CustomUnpickler(pickle.Unpickler):
+class CustomUnpickler(RestrictedUnpickler):
     """
     Custom Unpickler for loading pickled objects of the same class with differing definitions.
     Handles cases where a class object is reconstructed using a newer definition with additional fields


### PR DESCRIPTION
### Summary
We are a team of university students from Texas A&M performing security audits on open source projects. This PR fixes a critical **Remote Code Execution (RCE)** vulnerability (CWE-502) in the Supervisely SDK caused by insecure deserialization of automatically discovered metadata files.

### Discovery Methodology
The vulnerability was identified during a static analysis audit focused on 'Kill Chain Pattern A: Insecure Deserialization'. We traced the project initialization logic in `supervisely/project/project.py`, which performs an automatic scan of dataset directories for files matching the `_offsets.pkl` suffix. This scan leads directly to a sink in `supervisely/api/image_api.py` where `pickle.load()` is called on the untrusted file without validation.

### Impact & Risk
**High Risk / Full RCE.**
Data scientists and AI researchers frequently download and share large datasets from public repositories and cloud storage. An attacker can craft a "Poisoned Project" by including a malicious `_offsets.pkl` file containing a pickled payload (e.g., using `__reduce__` to call `os.system`). 
Simply calling `sly.Project(path, sly.OpenMode.READ)` on such a directory triggers the payload, allowing the attacker to execute arbitrary code on the victim's machine with local user privileges.

### Proposed Fix
The fix transitions the SDK from an unrestricted deserialization model to a **Strict Whitelist-based Deserialization** model:

1.  **RestrictedUnpickler**: Introduced a new utility in `supervisely/io/fs.py` that overrides `find_class`. It intercepts every object reconstruction attempt and enforces a strict whitelist.
2.  **Type Whitelisting**: Restricted allowed types to:
    *   Python Primitives: `list`, `dict`, `str`, `int`, `float`, `bool`, `set`, `tuple`.
    *   Internal Models: `supervisely.api.image_api.BlobImageInfo`.
    *   Data/Scientific Types: `collections.OrderedDict`, `numpy.core.multiarray`, and `pandas` dataframes.
3.  **Unified Enforcement**:
    *   Updated `BlobImageInfo.load_from_pickle_generator` to use the restricted loader.
    *   Updated the library-wide `CustomUnpickler` to inherit from `RestrictedUnpickler`, ensuring all project state files are now protected.

### Verification
I verified the fix by running an exploit payload against the updated SDK. The attack was successfully neutralized with a `pickle.UnpicklingError: global 'posix.system' is forbidden`, while legitimate dataset loading remained fully functional.