### PR TITLE
Add support for native PLY, LAS, LAZ file types for point clouds

### DIFF
--- a/supervisely/api/module_api.py
+++ b/supervisely/api/module_api.py
@@ -730,6 +730,8 @@ class ApiField:
     SINCE_TIME = "sinceTime"
     """"""
     TRACKED_FIGURES = "trackedFigures"
+    """"""
+    TEAM_FILE_ID = "teamFileId"
 
 
 def _get_single_item(items):

--- a/supervisely/api/pointcloud/pointcloud_api.py
+++ b/supervisely/api/pointcloud/pointcloud_api.py
@@ -40,6 +40,13 @@ from supervisely.io.fs import (
 )
 from supervisely.pointcloud.pointcloud import is_valid_format
 from supervisely.sly_logger import logger
+
+POINT_CLOUD_MIME_TYPES = {
+    ".pcd": "image/pcd",
+    ".las": "application/vnd.las",
+    ".laz": "application/vnd.laz",
+    ".ply": "application/x-ply",
+}
 from supervisely.imaging import image as sly_image
 
 
@@ -1145,10 +1152,12 @@ class PointcloudApi(RemoveableBulkModuleApi):
         for batch, numbers_batch in zip(batched(items_to_upload), batched(total_nem_items_list)):
             content_dict = {}
             for idx, item in enumerate(batch):
+                ext = get_file_ext(item).lower() if isinstance(item, str) else ".pcd"
+                mime_type = POINT_CLOUD_MIME_TYPES.get(ext, "image/pcd")
                 content_dict["{}-file".format(idx)] = (
                     str(idx),
                     func_item_to_byte_stream(item),
-                    "pcd/*",
+                    mime_type,
                 )
             encoder = MultipartEncoder(fields=content_dict)
             self._api.post("point-clouds.bulk.upload", encoder)

--- a/supervisely/api/pointcloud/pointcloud_api.py
+++ b/supervisely/api/pointcloud/pointcloud_api.py
@@ -1074,11 +1074,104 @@ class PointcloudApi(RemoveableBulkModuleApi):
                 # Point clouds uploaded to Supervisely with IDs: [19618685, 19618686]
         """
 
-        def path_to_bytes_stream(path):
-            return open(path, "rb")
+        if metas is None:
+            metas = [{}] * len(paths)
 
-        hashes = self._upload_data_bulk(path_to_bytes_stream, get_file_hash, paths, progress_cb)
-        return self.upload_hashes(dataset_id, names, hashes, metas=metas)
+        team_files_exts = set(POINT_CLOUD_MIME_TYPES) - {".pcd"}
+        tf_indices = [i for i, p in enumerate(paths) if get_file_ext(p).lower() in team_files_exts]
+        hash_indices = [i for i in range(len(paths)) if i not in set(tf_indices)]
+
+        results: Dict[int, PointcloudInfo] = {}
+
+        if hash_indices:
+            h_names = [names[i] for i in hash_indices]
+            h_paths = [paths[i] for i in hash_indices]
+            h_metas = [metas[i] for i in hash_indices]
+
+            def path_to_bytes_stream(path):
+                return open(path, "rb")
+
+            hashes = self._upload_data_bulk(
+                path_to_bytes_stream, get_file_hash, h_paths, progress_cb
+            )
+            for i, info in zip(
+                hash_indices, self.upload_hashes(dataset_id, h_names, hashes, metas=h_metas)
+            ):
+                results[i] = info
+
+        if tf_indices:
+            tf_names = [names[i] for i in tf_indices]
+            tf_paths = [paths[i] for i in tf_indices]
+            tf_metas = [metas[i] for i in tf_indices]
+            for i, info in zip(
+                tf_indices,
+                self.upload_paths_via_team_files(
+                    dataset_id, tf_names, tf_paths, tf_metas, progress_cb
+                ),
+            ):
+                results[i] = info
+
+        return [results[i] for i in range(len(paths))]
+
+    def upload_paths_via_team_files(
+        self,
+        dataset_id: int,
+        names: List[str],
+        paths: List[str],
+        metas: Optional[List[Dict]] = None,
+        progress_cb: Optional[Union[tqdm, Callable]] = None,
+    ) -> List["PointcloudInfo"]:
+        """Upload PLY/LAS/LAZ point clouds by first staging them in Team Files, then adding to dataset.
+
+        Use this method for formats not supported by the direct hash-based upload (.pcd only).
+        Temporary files are removed from Team Files after the dataset entry is created.
+        """
+        if metas is None:
+            metas = [{}] * len(paths)
+
+        dataset_info = self._api.dataset.get_info_by_id(dataset_id)
+        team_id = dataset_info.team_id
+        upload_dir = f"/sly-pointcloud-uploads/{rand_str(8)}"
+
+        file_ids = []
+        for path, name in zip(paths, names):
+            remote_path = f"{upload_dir}/{name}"
+            file_info = self._api.file.upload(team_id, path, remote_path)
+            file_ids.append(file_info.id)
+            if progress_cb is not None:
+                progress_cb(1)
+
+        try:
+            results = self.upload_team_files_ids(dataset_id, names, file_ids, metas)
+        finally:
+            try:
+                self._api.file.remove_dir(team_id, upload_dir, silent=True)
+            except Exception:
+                pass
+
+        return results
+
+    def upload_team_files_ids(
+        self,
+        dataset_id: int,
+        names: List[str],
+        team_file_ids: List[int],
+        metas: Optional[List[Dict]] = None,
+        progress_cb: Optional[Callable] = None,
+    ) -> List["PointcloudInfo"]:
+        """Add point clouds already present in Team Files to a dataset by their file IDs.
+
+        Use when files are already uploaded to Team Files and you want to reference them
+        directly without re-uploading.
+        """
+        return self._upload_bulk_add(
+            lambda item: (ApiField.TEAM_FILE_ID, item),
+            dataset_id,
+            names,
+            team_file_ids,
+            metas,
+            progress_cb,
+        )
 
     def check_existing_hashes(self, hashes: List[str]) -> List[str]:
         """

--- a/supervisely/api/pointcloud/pointcloud_api.py
+++ b/supervisely/api/pointcloud/pointcloud_api.py
@@ -1074,9 +1074,6 @@ class PointcloudApi(RemoveableBulkModuleApi):
                 # Point clouds uploaded to Supervisely with IDs: [19618685, 19618686]
         """
 
-        if metas is None:
-            metas = [{}] * len(paths)
-
         team_files_exts = set(POINT_CLOUD_MIME_TYPES) - {".pcd"}
         tf_indices = [i for i, p in enumerate(paths) if get_file_ext(p).lower() in team_files_exts]
         hash_indices = [i for i in range(len(paths)) if i not in set(tf_indices)]
@@ -1086,7 +1083,7 @@ class PointcloudApi(RemoveableBulkModuleApi):
         if hash_indices:
             h_names = [names[i] for i in hash_indices]
             h_paths = [paths[i] for i in hash_indices]
-            h_metas = [metas[i] for i in hash_indices]
+            h_metas = [metas[i] for i in hash_indices] if metas is not None else None
 
             def path_to_bytes_stream(path):
                 return open(path, "rb")
@@ -1102,7 +1099,7 @@ class PointcloudApi(RemoveableBulkModuleApi):
         if tf_indices:
             tf_names = [names[i] for i in tf_indices]
             tf_paths = [paths[i] for i in tf_indices]
-            tf_metas = [metas[i] for i in tf_indices]
+            tf_metas = [metas[i] for i in tf_indices] if metas is not None else None
             for i, info in zip(
                 tf_indices,
                 self.upload_paths_via_team_files(
@@ -1126,9 +1123,6 @@ class PointcloudApi(RemoveableBulkModuleApi):
         Use this method for formats not supported by the direct hash-based upload (.pcd only).
         Temporary files are removed from Team Files after the dataset entry is created.
         """
-        if metas is None:
-            metas = [{}] * len(paths)
-
         dataset_info = self._api.dataset.get_info_by_id(dataset_id)
         team_id = dataset_info.team_id
         upload_dir = f"/sly-pointcloud-uploads/{rand_str(8)}"

--- a/supervisely/convert/base_converter.py
+++ b/supervisely/convert/base_converter.py
@@ -191,6 +191,7 @@ class BaseConverter:
         labeling_interface: Optional[Union[LabelingInterface, str]] = LabelingInterface.DEFAULT,
         upload_as_links: bool = False,
         remote_files_map: Optional[Dict[str, str]] = None,
+        team_files_id_map: Optional[Dict[str, Tuple[int, str]]] = None,
     ):
         """:param input_data: Path to input directory or archive.
         :type input_data: str
@@ -200,6 +201,8 @@ class BaseConverter:
         :type upload_as_links: bool
         :param remote_files_map: Map of local paths to remote paths for link upload.
         :type remote_files_map: Dict[str, str], optional
+        :param team_files_id_map: Map of local paths to (file_id, remote_path) for team files uploads.
+        :type team_files_id_map: Dict[str, Tuple[int, str]], optional
 
         :raises ValueError: If labeling_interface is invalid.
         """
@@ -211,6 +214,7 @@ class BaseConverter:
         # import as links settings
         self._upload_as_links: bool = upload_as_links
         self._remote_files_map: Optional[Dict[str, str]] = remote_files_map
+        self._team_files_id_map: Optional[Dict[str, Tuple[int, str]]] = team_files_id_map
         self._supports_links = False  # if converter supports uploading by links
         self._force_shape_for_links = False
         self._api = Api.from_env() if self._upload_as_links else None
@@ -246,6 +250,10 @@ class BaseConverter:
     @property
     def remote_files_map(self) -> Dict[str, str]:
         return self._remote_files_map
+
+    @property
+    def team_files_id_map(self) -> Optional[Dict[str, Tuple[int, str]]]:
+        return self._team_files_id_map
 
     @property
     def supports_links(self) -> bool:
@@ -303,6 +311,7 @@ class BaseConverter:
                 self._labeling_interface,
                 self._upload_as_links,
                 self._remote_files_map,
+                self._team_files_id_map,
             )
 
             if not converter.validate_labeling_interface():

--- a/supervisely/convert/converter.py
+++ b/supervisely/convert/converter.py
@@ -73,6 +73,7 @@ class ImportManager:
         self._labeling_interface = labeling_interface
         self._upload_as_links = upload_as_links
         self._remote_files_map = {}
+        self._team_files_id_map: dict = {}
         self._modality = project_type
 
         if isinstance(input_data, str):
@@ -116,6 +117,7 @@ class ImportManager:
             self._labeling_interface,
             self._upload_as_links,
             self._remote_files_map,
+            self._team_files_id_map,
         )
         return modality_converter.detect_format()
 
@@ -149,7 +151,13 @@ class ImportManager:
                 if self._upload_as_links and str(self._modality) == ProjectType.VOLUMES.value:
                     self._scan_remote_files(input_data)
                 logger.info(f"Input data is a remote file: {input_data}. Downloading...")
-                return self._download_input_data(input_data)
+                local_path = self._download_input_data(input_data)
+                if self._is_team_files_path(input_data) and str(self._modality) in [
+                    ProjectType.POINT_CLOUDS.value,
+                    ProjectType.POINT_CLOUD_EPISODES.value,
+                ]:
+                    self._build_team_files_id_map(input_data, local_path, is_dir=False)
+                return local_path
         elif self._api.storage.dir_exists(self._team_id, input_data):
             if self._upload_as_links and str(self._modality) in [
                 ProjectType.IMAGES.value,
@@ -162,9 +170,38 @@ class ImportManager:
                 if self._upload_as_links and str(self._modality) == ProjectType.VOLUMES.value:
                     self._scan_remote_files(input_data, is_dir=True)
                 logger.info(f"Input data is a remote directory: {input_data}. Downloading...")
-                return self._download_input_data(input_data, is_dir=True)
+                local_path = self._download_input_data(input_data, is_dir=True)
+                if self._is_team_files_path(input_data) and str(self._modality) in [
+                    ProjectType.POINT_CLOUDS.value,
+                    ProjectType.POINT_CLOUD_EPISODES.value,
+                ]:
+                    self._build_team_files_id_map(input_data, local_path, is_dir=True)
+                return local_path
         else:
             raise RuntimeError(f"Input data not found: {input_data}")
+
+    _CLOUD_STORAGE_PREFIXES = ("s3://", "azure://", "google://", "agent://", "fs://")
+
+    def _is_team_files_path(self, path: str) -> bool:
+        return not any(path.startswith(prefix) for prefix in self._CLOUD_STORAGE_PREFIXES)
+
+    def _build_team_files_id_map(self, remote_path: str, local_path: str, is_dir: bool = False):
+        """Build {local_abs_path: (file_id, remote_path)} for all files from Team Files."""
+        if is_dir:
+            files = self._api.storage.list(self._team_id, remote_path, include_folders=False)
+            dir_path = remote_path.rstrip("/")
+            for file in files:
+                if not hasattr(file, "id") or file.id is None:
+                    continue
+                new_local = os.path.abspath(file.path.replace(dir_path, local_path))
+                self._team_files_id_map[new_local] = (file.id, file.path)
+        else:
+            file_info = self._api.storage.get_info_by_path(self._team_id, remote_path)
+            if file_info and hasattr(file_info, "id") and file_info.id is not None:
+                self._team_files_id_map[os.path.abspath(local_path)] = (
+                    file_info.id,
+                    remote_path,
+                )
 
     def _download_input_data(self, remote_path, is_dir=False):
         """Download input data from Supervisely"""

--- a/supervisely/convert/image/cityscapes/cityscapes_converter.py
+++ b/supervisely/convert/image/cityscapes/cityscapes_converter.py
@@ -26,14 +26,17 @@ class CityscapesConverter(ImageConverter):
     """Imports Cityscapes semantic segmentation format (images + JSON annotations) into Supervisely image project."""
 
     def __init__(
-            self,
-            input_data: str,
-            labeling_interface: Optional[Union[LabelingInterface, str]],
-            upload_as_links: bool,
-            remote_files_map: Optional[Dict[str, str]] = None,
+        self,
+        input_data: str,
+        labeling_interface: Optional[Union[LabelingInterface, str]],
+        upload_as_links: bool,
+        remote_files_map: Optional[Dict[str, str]] = None,
+        team_files_id_map: Optional[Dict[str, str]] = None,
     ):
         """See :class:`~supervisely.convert.base_converter.BaseConverter` for params."""
-        super().__init__(input_data, labeling_interface, upload_as_links, remote_files_map)
+        super().__init__(
+            input_data, labeling_interface, upload_as_links, remote_files_map, team_files_id_map
+        )
 
         self._classes_mapping = {}
         self._supports_links = True

--- a/supervisely/convert/image/coco/coco_converter.py
+++ b/supervisely/convert/image/coco/coco_converter.py
@@ -17,14 +17,17 @@ class COCOConverter(ImageConverter):
     """Imports COCO detection/segmentation format (images + annotations JSON) into Supervisely image project."""
 
     def __init__(
-            self,
-            input_data: str,
-            labeling_interface: Optional[Union[LabelingInterface, str]],
-            upload_as_links: bool,
-            remote_files_map: Optional[Dict[str, str]] = None,
+        self,
+        input_data: str,
+        labeling_interface: Optional[Union[LabelingInterface, str]],
+        upload_as_links: bool,
+        remote_files_map: Optional[Dict[str, str]] = None,
+        team_files_id_map: Optional[Dict[str, str]] = None,
     ):
         """See :class:`~supervisely.convert.base_converter.BaseConverter` for params."""
-        super().__init__(input_data, labeling_interface, upload_as_links, remote_files_map)
+        super().__init__(
+            input_data, labeling_interface, upload_as_links, remote_files_map, team_files_id_map
+        )
 
         self._coco_categories = []
         self._supports_links = True

--- a/supervisely/convert/image/csv/csv_converter.py
+++ b/supervisely/convert/image/csv/csv_converter.py
@@ -8,23 +8,23 @@ from tqdm import tqdm
 import supervisely.convert.image.csv.csv_helper as csv_helper
 from supervisely import (
     Annotation,
+    ProjectMeta,
+    TagCollection,
     batched,
     generate_free_name,
     is_development,
     logger,
-    ProjectMeta,
-    TagCollection,
 )
 from supervisely.api.api import Api, ApiContext
 from supervisely.convert.base_converter import AvailableImageConverters
 from supervisely.convert.image.image_converter import ImageConverter
 from supervisely.imaging.image import SUPPORTED_IMG_EXTS
+from supervisely.io.env import team_id
 from supervisely.io.fs import (
     get_file_ext,
     get_file_name_with_ext,
     list_files_recursively,
 )
-from supervisely.io.env import team_id
 from supervisely.io.json import load_json_file
 from supervisely.project.project_settings import LabelingInterface
 
@@ -98,6 +98,7 @@ class CSVConverter(ImageConverter):
         labeling_interface: Optional[Union[LabelingInterface, str]],
         upload_as_links: bool,
         remote_files_map: Optional[Dict[str, str]] = None,
+        team_files_id_map: Optional[Dict[str, str]] = None,
     ):
         """:param input_data: Path to CSV/TSV/TXT or directory.
         :type input_data: str
@@ -107,8 +108,12 @@ class CSVConverter(ImageConverter):
         :type upload_as_links: bool
         :param remote_files_map: Map for link upload.
         :type remote_files_map: Dict[str, str], optional
+        :param team_files_id_map: Map for team files upload.
+        :type team_files_id_map: Dict[str, str], optional
         """
-        super().__init__(input_data, labeling_interface, upload_as_links, remote_files_map)
+        super().__init__(
+            input_data, labeling_interface, upload_as_links, remote_files_map, team_files_id_map
+        )
 
         self._supports_links = True
         self._csv_reader = None

--- a/supervisely/convert/image/masks/images_with_masks_converter.py
+++ b/supervisely/convert/image/masks/images_with_masks_converter.py
@@ -4,32 +4,45 @@ from typing import Dict, Optional, Union
 import supervisely.convert.image.masks.image_with_masks_helper as helper
 from supervisely import (
     Annotation,
-    ProjectMeta,
-    logger,
-    ObjClass,
     Bitmap,
+    ObjClass,
     ObjClassCollection,
+    ProjectMeta,
     Rectangle,
+    logger,
 )
 from supervisely.convert.base_converter import AvailableImageConverters
 from supervisely.convert.image.image_converter import ImageConverter
-from supervisely.io.fs import file_exists, dirs_with_marker, dir_exists, get_file_name, list_files, dirs_filter, remove_junk_from_dir, get_file_ext
+from supervisely.convert.image.image_helper import validate_image_bounds
+from supervisely.io.fs import (
+    dir_exists,
+    dirs_filter,
+    dirs_with_marker,
+    file_exists,
+    get_file_ext,
+    get_file_name,
+    list_files,
+    remove_junk_from_dir,
+)
 from supervisely.io.json import load_json_file
 from supervisely.project.project_settings import LabelingInterface
-from supervisely.convert.image.image_helper import validate_image_bounds
+
 
 class ImagesWithMasksConverter(ImageConverter):
     """Imports images with per-class mask folders (PNG) and classes JSON mapping into Supervisely image project."""
 
     def __init__(
-            self,
-            input_data: str,
-            labeling_interface: Optional[Union[LabelingInterface, str]],
-            upload_as_links: bool,
-            remote_files_map: Optional[Dict[str, str]] = None,
+        self,
+        input_data: str,
+        labeling_interface: Optional[Union[LabelingInterface, str]],
+        upload_as_links: bool,
+        remote_files_map: Optional[Dict[str, str]] = None,
+        team_files_id_map: Optional[Dict] = None,
     ):
         """See :class:`~supervisely.convert.base_converter.BaseConverter` for params."""
-        super().__init__(input_data, labeling_interface, upload_as_links, remote_files_map)
+        super().__init__(
+            input_data, labeling_interface, upload_as_links, remote_files_map, team_files_id_map
+        )
 
         self._classes_mapping = {}
 

--- a/supervisely/convert/image/medical2d/medical2d_converter.py
+++ b/supervisely/convert/image/medical2d/medical2d_converter.py
@@ -6,12 +6,22 @@ import magic
 import nrrd
 import numpy as np
 
-from supervisely import Annotation, batched, generate_free_name, is_development, ProjectMeta, logger, TagMeta, Tag, TagValueType
+from supervisely import (
+    Annotation,
+    ProjectMeta,
+    Tag,
+    TagMeta,
+    TagValueType,
+    batched,
+    generate_free_name,
+    is_development,
+    logger,
+)
 from supervisely.api.api import Api, ApiContext
 from supervisely.convert.base_converter import AvailableImageConverters
 from supervisely.convert.image.image_converter import ImageConverter
 from supervisely.convert.image.medical2d import medical2d_helper as helper
-from supervisely.io.fs import remove_dir, get_file_ext, mkdir, get_file_name
+from supervisely.io.fs import get_file_ext, get_file_name, mkdir, remove_dir
 from supervisely.project.project_settings import LabelingInterface
 from supervisely.volume.volume import is_nifti_file
 
@@ -21,14 +31,17 @@ class Medical2DImageConverter(ImageConverter):
     """Imports medical 2D images (NRRD, NIfTI slices) with annotations into Supervisely; supports DICOM grouping."""
 
     def __init__(
-            self,
-            input_data: str,
-            labeling_interface: Optional[Union[LabelingInterface, str]],
-            upload_as_links: bool,
-            remote_files_map: Optional[Dict[str, str]] = None,
+        self,
+        input_data: str,
+        labeling_interface: Optional[Union[LabelingInterface, str]],
+        upload_as_links: bool,
+        remote_files_map: Optional[Dict[str, str]] = None,
+        team_files_id_map: Optional[Dict] = None,
     ):
         """See :class:`~supervisely.convert.base_converter.BaseConverter` for params."""
-        super().__init__(input_data, labeling_interface, upload_as_links, remote_files_map)
+        super().__init__(
+            input_data, labeling_interface, upload_as_links, remote_files_map, team_files_id_map
+        )
 
         self._filtered = None
         self._group_tag_names = defaultdict(int)
@@ -154,7 +167,6 @@ class Medical2DImageConverter(ImageConverter):
             existing_names = set([img.name for img in api.image.get_list(dataset_id)])
 
             api.project.images_grouping(id=dataset.project_id, enable=True, tag_name=group_tag_name)
-
 
             if log_progress:
                 progress, progress_cb = self.get_progress(self.items_count, "Uploading images...")

--- a/supervisely/convert/image/multi_view/multi_view.py
+++ b/supervisely/convert/image/multi_view/multi_view.py
@@ -1,6 +1,6 @@
 import os
 from collections import defaultdict
-from typing import Dict, Union, Optional
+from typing import Dict, Optional, Union
 
 from supervisely import ProjectMeta, generate_free_name, is_development, logger
 from supervisely.api.api import Api, ApiContext
@@ -15,14 +15,17 @@ class MultiViewImageConverter(ImageConverter):
     """Imports multi-view image groups (multiple images per sample) for multiview labeling interface."""
 
     def __init__(
-            self,
-            input_data: str,
-            labeling_interface: Optional[Union[LabelingInterface, str]],
-            upload_as_links: bool,
-            remote_files_map: Optional[Dict[str, str]] = None,
+        self,
+        input_data: str,
+        labeling_interface: Optional[Union[LabelingInterface, str]],
+        upload_as_links: bool,
+        remote_files_map: Optional[Dict[str, str]] = None,
+        team_files_id_map: Optional[Dict] = None,
     ):
         """See :class:`~supervisely.convert.base_converter.BaseConverter` for params."""
-        super().__init__(input_data, labeling_interface, upload_as_links, remote_files_map)
+        super().__init__(
+            input_data, labeling_interface, upload_as_links, remote_files_map, team_files_id_map
+        )
 
         self._supports_links = True
         self._force_shape_for_links = self.upload_as_links
@@ -54,7 +57,7 @@ class MultiViewImageConverter(ImageConverter):
                     return None
                 if get_file_ext(file) in SUPPORTED_IMG_EXTS:
                     group_map[root].append(os.path.join(root, file))
-            
+
         return group_map
 
     def upload_dataset(

--- a/supervisely/convert/image/pascal_voc/pascal_voc_converter.py
+++ b/supervisely/convert/image/pascal_voc/pascal_voc_converter.py
@@ -10,10 +10,10 @@ from supervisely import (
     TagValueType,
     logger,
 )
+from supervisely.annotation.tag_meta import detect_tag_value_type
 from supervisely.convert.base_converter import AvailableImageConverters
 from supervisely.convert.image.image_converter import ImageConverter
 from supervisely.convert.image.pascal_voc import pascal_voc_helper
-from supervisely.annotation.tag_meta import detect_tag_value_type
 from supervisely.io.fs import (
     dir_exists,
     dirs_filter,
@@ -63,9 +63,12 @@ class PascalVOCConverter(ImageConverter):
         labeling_interface: Optional[Union[LabelingInterface, str]],
         upload_as_links: bool,
         remote_files_map: Optional[Dict[str, str]] = None,
+        team_files_id_map: Optional[Dict] = None,
     ):
         """See :class:`~supervisely.convert.base_converter.BaseConverter` for params."""
-        super().__init__(input_data, labeling_interface, upload_as_links, remote_files_map)
+        super().__init__(
+            input_data, labeling_interface, upload_as_links, remote_files_map, team_files_id_map
+        )
 
         self.color2class_name: Optional[Dict[str, str]] = None
         self.with_instances: bool = False

--- a/supervisely/convert/image/yolo/yolo_converter.py
+++ b/supervisely/convert/image/yolo/yolo_converter.py
@@ -30,9 +30,12 @@ class YOLOConverter(ImageConverter):
         labeling_interface: Optional[Union[LabelingInterface, str]],
         upload_as_links: bool,
         remote_files_map: Optional[Dict[str, str]] = None,
+        team_files_id_map: Optional[Dict] = None,
     ):
         """See :class:`~supervisely.convert.base_converter.BaseConverter` for params."""
-        super().__init__(input_data, labeling_interface, upload_as_links, remote_files_map)
+        super().__init__(
+            input_data, labeling_interface, upload_as_links, remote_files_map, team_files_id_map
+        )
 
         self._yaml_info: dict = None
         self._with_keypoint = False

--- a/supervisely/convert/pointcloud/bag/bag_converter.py
+++ b/supervisely/convert/pointcloud/bag/bag_converter.py
@@ -68,14 +68,17 @@ class BagConverter(PointcloudConverter):
             self._topic = topic
 
     def __init__(
-            self,
-            input_data: str,
-            labeling_interface: Optional[Union[LabelingInterface, str]],
-            upload_as_links: bool,
-            remote_files_map: Optional[Dict[str, str]] = None,
+        self,
+        input_data: str,
+        labeling_interface: Optional[Union[LabelingInterface, str]],
+        upload_as_links: bool,
+        remote_files_map: Optional[Dict[str, str]] = None,
+        team_files_id_map: Optional[Dict[str, str]] = None,
     ):
         """See :class:`~supervisely.convert.base_converter.BaseConverter` for params."""
-        super().__init__(input_data, labeling_interface, upload_as_links, remote_files_map)
+        super().__init__(
+            input_data, labeling_interface, upload_as_links, remote_files_map, team_files_id_map
+        )
 
         self._total_msg_count = 0
         self._is_pcd_episode = False

--- a/supervisely/convert/pointcloud/las/las_converter.py
+++ b/supervisely/convert/pointcloud/las/las_converter.py
@@ -15,40 +15,10 @@ class LasConverter(PointcloudConverter):
         return AvailablePointcloudConverters.LAS
 
     def validate_format(self) -> bool:
-        las_list = []
-        for root, _, files in os.walk(self._input_data):
-            for file in files:
-                full_path = os.path.join(root, file)
-                ext = get_file_ext(full_path)
-                if file in JUNK_FILES:
-                    continue
-                elif ext in [".las", ".laz"]:
-                    las_list.append(full_path)
-
-        # create Items
-        self._items = []
-
-        # Warning about coordinate shift
-        if len(las_list) > 0:
-            logger.info(
-                "⚠️ IMPORTANT: Coordinate shift will be applied to all LAS/LAZ files during conversion to PCD format. "
-                "This is necessary to avoid floating-point precision issues and visual artifacts. "
-                "The shift values (X, Y, Z offsets) will be logged for each file. "
-                "If you need to convert annotations back to original LAS coordinates or use them with original LAS files, "
-                "you MUST add these shift values back to the PCD/annotation coordinates. "
-                "Check the logs for 'Applied coordinate shift' messages for each file."
-            )
-
-        for las_path in las_list:
-            ext = get_file_ext(las_path)
-            pcd_path = las_path.replace(ext, ".pcd")
-            las_helper.las2pcd(las_path, pcd_path)
-            if not os.path.exists(pcd_path):
-                logger.warning(f"Failed to convert LAS/LAZ to PCD. Skipping: {las_path}")
-                continue
-            item = self.Item(pcd_path)
-            self._items.append(item)
-        return self.items_count > 0
+        # Deprecated: LAS/LAZ files are now natively supported by Supervisely.
+        # Raw LAS/LAZ files are handled by the base PointcloudConverter;
+        # LAS/LAZ files inside a SLY project are handled by SlyPointcloudConverter.
+        return False
 
     def to_supervisely(
         self,

--- a/supervisely/convert/pointcloud/lyft/lyft_converter.py
+++ b/supervisely/convert/pointcloud/lyft/lyft_converter.py
@@ -56,9 +56,12 @@ class LyftConverter(PointcloudConverter):
         labeling_interface: str,
         upload_as_links: bool,
         remote_files_map: Optional[Dict[str, str]] = None,
+        team_files_id_map: Optional[Dict[str, str]] = None,
     ):
         """See :class:`~supervisely.convert.base_converter.BaseConverter` for params."""
-        super().__init__(input_data, labeling_interface, upload_as_links, remote_files_map)
+        super().__init__(
+            input_data, labeling_interface, upload_as_links, remote_files_map, team_files_id_map
+        )
         self._is_pcd_episode = False
         self._lyft = None
 

--- a/supervisely/convert/pointcloud/ply/ply_converter.py
+++ b/supervisely/convert/pointcloud/ply/ply_converter.py
@@ -19,46 +19,10 @@ class PlyConverter(PointcloudConverter):
         return ".json"
 
     def validate_format(self) -> bool:
-        ply_list = []
-        ann_dict = {}
-        rimg_dict = {}
-        used_img_ext = []
-        for root, _, files in os.walk(self._input_data):
-            for file in files:
-                full_path = os.path.join(root, file)
-                ext = get_file_ext(full_path)
-                if file in JUNK_FILES:
-                    continue
-                elif ext == ".ply":
-                    ply_list.append(full_path)
-                elif ext ==  self.ann_ext:
-                    ann_dict[file] = full_path
-                elif self._is_image_file(full_path):
-                    rimg_dict[file] = full_path
-                    if ext not in used_img_ext:
-                        used_img_ext.append(ext)
-
-        # create Items
-        self._items = []
-        for ply_path in ply_list:
-            pcd_path = ply_path.replace(".ply", ".pcd")
-            ply_helper.ply2pcd(ply_path, pcd_path)
-            if not os.path.exists(pcd_path):
-                logger.warning(f"Failed to convert PLY to PCD. Skipping: {ply_path}")
-                continue
-            item = self.Item(pcd_path)
-            for ext in used_img_ext:
-                rimg_name = f"{item.name}{ext}"
-                if not rimg_name in rimg_dict:
-                    rimg_name = f"{get_file_name(item.name)}{ext}"
-                if rimg_name in rimg_dict:
-                    rimg_path = rimg_dict[rimg_name]
-                    rimg_ann_name = f"{rimg_name}.json"
-                    if rimg_ann_name in ann_dict:
-                        rimg_ann_path = ann_dict[rimg_ann_name]
-                        item.set_related_images((rimg_path, rimg_ann_path))
-            self._items.append(item)
-        return self.items_count > 0
+        # Deprecated: PLY files are now natively supported by Supervisely.
+        # Raw PLY files are handled by the base PointcloudConverter;
+        # PLY files inside a SLY project are handled by SlyPointcloudConverter.
+        return False
 
     def to_supervisely(
         self,

--- a/supervisely/convert/pointcloud/pointcloud_converter.py
+++ b/supervisely/convert/pointcloud/pointcloud_converter.py
@@ -129,27 +129,52 @@ class PointcloudConverter(BaseConverter):
         for batch in batched(self._items, batch_size=batch_size):
             item_names = []
             item_paths = []
+            team_file_ids = []
             anns = []
             for item in batch:
                 item.name = generate_free_name(
                     existing_pointcloud_names, item.name, with_ext=True, extend_used_names=True
                 )
                 item_names.append(item.name)
-                if self.upload_as_links:
+                abs_path = os.path.abspath(item.path)
+                if self._team_files_id_map and abs_path in self._team_files_id_map:
+                    team_file_ids.append(self._team_files_id_map[abs_path][0])
+                    item_paths.append(None)
+                elif self.upload_as_links:
                     item_paths.append(
-                        self.remote_files_map.get(os.path.abspath(item.path), item.path)
+                        self.remote_files_map.get(abs_path, item.path)
                     )
+                    team_file_ids.append(None)
                 else:
                     item_paths.append(item.path)
+                    team_file_ids.append(None)
 
                 ann = self.to_supervisely(item, meta, renamed_classes, renamed_tags)
                 anns.append(ann)
 
-            pcd_infos = upload_fn(
-                dataset_id,
-                item_names,
-                item_paths,
-            )
+            # split batch by upload method
+            tf_indices = [i for i, fid in enumerate(team_file_ids) if fid is not None]
+            reg_indices = [i for i in range(len(item_names)) if i not in set(tf_indices)]
+
+            pcd_infos_map: Dict[int, object] = {}
+            if tf_indices:
+                tf_names = [item_names[i] for i in tf_indices]
+                tf_ids = [team_file_ids[i] for i in tf_indices]
+                for i, info in zip(
+                    tf_indices,
+                    api.pointcloud.upload_team_files_ids(dataset_id, tf_names, tf_ids),
+                ):
+                    pcd_infos_map[i] = info
+            if reg_indices:
+                reg_names = [item_names[i] for i in reg_indices]
+                reg_paths = [item_paths[i] for i in reg_indices]
+                for i, info in zip(
+                    reg_indices,
+                    upload_fn(dataset_id, reg_names, reg_paths),
+                ):
+                    pcd_infos_map[i] = info
+
+            pcd_infos = [pcd_infos_map[i] for i in range(len(item_names))]
             pcd_ids = [pcd_info.id for pcd_info in pcd_infos]
             pcl_to_rimg_figures: Dict[int, Dict[str, List[Dict]]] = {}
             pcl_to_rimg_to_id: Dict[int, Dict[str, int]] = {}

--- a/supervisely/convert/pointcloud/pointcloud_converter.py
+++ b/supervisely/convert/pointcloud/pointcloud_converter.py
@@ -303,7 +303,7 @@ class PointcloudConverter(BaseConverter):
                     if any(
                         p.replace("_", " ") in ["images", "related images", "photo context"]
                         for p in [dir_name, parent_dir_name]
-                    ) or dir_name.endswith("_pcd"):
+                    ) or dir_name.endswith(("_pcd", "_ply", "_las", "_laz")):
                         rimg_ann_dict[file] = full_path
                 elif self._is_image_file(full_path):
                     dir_name = os.path.basename(root)
@@ -326,7 +326,7 @@ class PointcloudConverter(BaseConverter):
         items = []
         for pcd_path in pcd_list:
             item = self.Item(pcd_path)
-            rimg_dir_name = item.name.replace(".pcd", "_pcd")
+            rimg_dir_name = item.name.replace(".", "_")
             rimgs = rimg_dict.get(rimg_dir_name, [])
             for rimg_path in rimgs:
                 rimg_ann_name = f"{get_file_name_with_ext(rimg_path)}.json"
@@ -342,7 +342,7 @@ class PointcloudConverter(BaseConverter):
 
     def _convert_to_pcd_if_needed(self, pcd_path: str, ext: str) -> Optional[str]:
         """Convert point cloud to .pcd format if it is in another supported format."""
-        if ext == ".pcd":
+        if ext in (".pcd", ".ply", ".las", ".laz"):
             return pcd_path
         elif ext == ".bin":
             if self.upload_as_links:

--- a/supervisely/convert/pointcloud/pointcloud_converter.py
+++ b/supervisely/convert/pointcloud/pointcloud_converter.py
@@ -164,7 +164,6 @@ class PointcloudConverter(BaseConverter):
                     tf_indices,
                     api.pointcloud.upload_team_files_ids(dataset_id, tf_names, tf_ids),
                 ):
-                    logger.info(f"Uploaded pointcloud '{item_names[i]}' via Team Files with file ID {team_file_ids[i]}.")
                     pcd_infos_map[i] = info
             if reg_indices:
                 reg_names = [item_names[i] for i in reg_indices]

--- a/supervisely/convert/pointcloud/pointcloud_converter.py
+++ b/supervisely/convert/pointcloud/pointcloud_converter.py
@@ -164,6 +164,7 @@ class PointcloudConverter(BaseConverter):
                     tf_indices,
                     api.pointcloud.upload_team_files_ids(dataset_id, tf_names, tf_ids),
                 ):
+                    logger.info(f"Uploaded pointcloud '{item_names[i]}' via Team Files with file ID {team_file_ids[i]}.")
                     pcd_infos_map[i] = info
             if reg_indices:
                 reg_names = [item_names[i] for i in reg_indices]

--- a/supervisely/convert/pointcloud/sly/sly_pointcloud_converter.py
+++ b/supervisely/convert/pointcloud/sly/sly_pointcloud_converter.py
@@ -104,7 +104,7 @@ class SLYPointcloudConverter(PointcloudConverter):
                     item.ann_data = ann_path
                     sly_ann_detected = True
 
-            rimg_dir_name = item.name.replace(".pcd", "_pcd")
+            rimg_dir_name = item.name.replace(".", "_")
             rimgs = rimg_dict.get(rimg_dir_name, [])
             for rimg_path in rimgs:
                 rimg_ann_name = f"{get_file_name_with_ext(rimg_path)}.json"

--- a/supervisely/convert/pointcloud_episodes/bag/bag_converter.py
+++ b/supervisely/convert/pointcloud_episodes/bag/bag_converter.py
@@ -2,8 +2,12 @@ from typing import Dict, Optional, Union
 
 from supervisely.convert.base_converter import AvailablePointcloudEpisodesConverters
 from supervisely.convert.pointcloud.bag.bag_converter import BagConverter
-from supervisely.convert.pointcloud_episodes.pointcloud_episodes_converter import PointcloudEpisodeConverter
-from supervisely.pointcloud_annotation.pointcloud_episode_annotation import PointcloudEpisodeAnnotation
+from supervisely.convert.pointcloud_episodes.pointcloud_episodes_converter import (
+    PointcloudEpisodeConverter,
+)
+from supervisely.pointcloud_annotation.pointcloud_episode_annotation import (
+    PointcloudEpisodeAnnotation,
+)
 from supervisely.project.project_settings import LabelingInterface
 
 
@@ -29,14 +33,17 @@ class BagEpisodesConverter(BagConverter, PointcloudEpisodeConverter):
             return PointcloudEpisodeAnnotation()
 
     def __init__(
-            self,
-            input_data: str,
-            labeling_interface: Optional[Union[LabelingInterface, str]],
-            upload_as_links: bool,
-            remote_files_map: Optional[Dict[str, str]] = None,
+        self,
+        input_data: str,
+        labeling_interface: Optional[Union[LabelingInterface, str]],
+        upload_as_links: bool,
+        remote_files_map: Optional[Dict[str, str]] = None,
+        team_files_id_map: Optional[Dict[str, str]] = None,
     ):
         """See :class:`~supervisely.convert.base_converter.BaseConverter` for params."""
-        super().__init__(input_data, labeling_interface, upload_as_links, remote_files_map)
+        super().__init__(
+            input_data, labeling_interface, upload_as_links, remote_files_map, team_files_id_map
+        )
 
         self._type = "point_cloud_episode"
         self._is_pcd_episode = True

--- a/supervisely/convert/pointcloud_episodes/lyft/lyft_converter.py
+++ b/supervisely/convert/pointcloud_episodes/lyft/lyft_converter.py
@@ -1,14 +1,34 @@
+from collections import defaultdict
+from datetime import datetime
+from pathlib import Path
 from typing import Dict, Optional, Union
 
+from supervisely import (
+    Api,
+    ObjClass,
+    PointcloudEpisodeFrame,
+    PointcloudEpisodeObject,
+    PointcloudFigure,
+    PointcloudObject,
+    ProjectMeta,
+    TagMeta,
+    TagValueType,
+    is_development,
+    logger,
+)
+from supervisely.api.api import ApiField
 from supervisely.convert.base_converter import AvailablePointcloudEpisodesConverters
+from supervisely.convert.pointcloud.lyft import lyft_helper
 from supervisely.convert.pointcloud.lyft.lyft_converter import LyftConverter
 from supervisely.convert.pointcloud_episodes.pointcloud_episodes_converter import (
     PointcloudEpisodeConverter,
 )
+from supervisely.geometry.cuboid_3d import Cuboid3d
+from supervisely.io import fs
 from supervisely.pointcloud_annotation.pointcloud_episode_annotation import (
     PointcloudEpisodeAnnotation,
-    PointcloudEpisodeObjectCollection,
     PointcloudEpisodeFrameCollection,
+    PointcloudEpisodeObjectCollection,
     PointcloudEpisodeTagCollection,
     PointcloudFigure,
 )
@@ -16,27 +36,6 @@ from supervisely.pointcloud_annotation.pointcloud_episode_tag import (
     PointcloudEpisodeTag,
 )
 from supervisely.project.project_settings import LabelingInterface
-
-from pathlib import Path
-from supervisely import (
-    Api,
-    ObjClass,
-    ProjectMeta,
-    logger,
-    is_development,
-    PointcloudObject,
-    PointcloudEpisodeObject,
-    PointcloudFigure,
-    PointcloudEpisodeFrame,
-    TagMeta,
-    TagValueType,
-)
-from supervisely.io import fs
-from supervisely.convert.pointcloud.lyft import lyft_helper
-from supervisely.api.api import ApiField
-from datetime import datetime
-from supervisely.geometry.cuboid_3d import Cuboid3d
-from collections import defaultdict
 
 # from supervisely.annotation.tag_meta import TagTargetType as TagTT
 
@@ -50,9 +49,12 @@ class LyftEpisodesConverter(LyftConverter, PointcloudEpisodeConverter):
         labeling_interface: Optional[Union[LabelingInterface, str]],
         upload_as_links: bool,
         remote_files_map: Optional[Dict[str, str]] = None,
+        team_files_id_map: Optional[Dict[str, str]] = None,
     ):
         """See :class:`~supervisely.convert.base_converter.BaseConverter` for params."""
-        super().__init__(input_data, labeling_interface, upload_as_links, remote_files_map)
+        super().__init__(
+            input_data, labeling_interface, upload_as_links, remote_files_map, team_files_id_map
+        )
 
         self._type = "point_cloud_episode"
         self._is_pcd_episode = True

--- a/supervisely/convert/pointcloud_episodes/pointcloud_episodes_converter.py
+++ b/supervisely/convert/pointcloud_episodes/pointcloud_episodes_converter.py
@@ -366,7 +366,7 @@ class PointcloudEpisodeConverter(BaseConverter):
             if pcd_name in pcd_dict:
                 updated_frames_pcd_map[i] = pcd_name
                 item = self.Item(pcd_dict[pcd_name], i)
-                rimg_dir_name = pcd_name.replace(".pcd", "_pcd")
+                rimg_dir_name = pcd_name.replace(".", "_")
                 rimgs = rimg_dict.get(rimg_dir_name, [])
                 for rimg_path in rimgs:
                     rimg_ann_name = f"{get_file_name_with_ext(rimg_path)}.json"

--- a/supervisely/convert/pointcloud_episodes/pointcloud_episodes_converter.py
+++ b/supervisely/convert/pointcloud_episodes/pointcloud_episodes_converter.py
@@ -83,9 +83,12 @@ class PointcloudEpisodeConverter(BaseConverter):
         labeling_interface: Optional[Union[LabelingInterface, str]],
         upload_as_links: bool = False,
         remote_files_map: Optional[Dict[str, str]] = None,
+        team_files_id_map: Optional[Dict[str, str]] = None,
     ):
         """See :class:`~supervisely.convert.base_converter.BaseConverter` for params."""
-        super().__init__(input_data, labeling_interface, upload_as_links, remote_files_map)
+        super().__init__(
+            input_data, labeling_interface, upload_as_links, remote_files_map, team_files_id_map
+        )
         self._annotation = None
         self._frame_pointcloud_map = None
         self._frame_count = None

--- a/supervisely/convert/pointcloud_episodes/semantic_kitti/semantic_kitti_converter.py
+++ b/supervisely/convert/pointcloud_episodes/semantic_kitti/semantic_kitti_converter.py
@@ -93,8 +93,11 @@ class SemanticKITTIConverter(PointcloudEpisodeConverter):
         labeling_interface: Optional[Union[LabelingInterface, str]],
         upload_as_links: bool = False,
         remote_files_map: Optional[Dict[str, str]] = None,
+        team_files_id_map: Optional[Dict[str, str]] = None,
     ):
-        super().__init__(input_data, labeling_interface, upload_as_links, remote_files_map)
+        super().__init__(
+            input_data, labeling_interface, upload_as_links, remote_files_map, team_files_id_map
+        )
         self._label_map = {}
 
     def __str__(self) -> str:

--- a/supervisely/convert/pointcloud_episodes/sly/sly_pointcloud_episodes_converter.py
+++ b/supervisely/convert/pointcloud_episodes/sly/sly_pointcloud_episodes_converter.py
@@ -119,7 +119,7 @@ class SLYPointcloudEpisodesConverter(PointcloudEpisodeConverter):
             if pcd_name in pcd_dict:
                 updated_frames_pcd_map[i] = pcd_name
                 item = self.Item(pcd_dict[pcd_name], i)
-                rimg_dir_name = pcd_name.replace(".pcd", "_pcd")
+                rimg_dir_name = pcd_name.replace(".", "_")
                 rimgs = rimg_dict.get(rimg_dir_name, [])
                 for rimg_path in rimgs:
                     rimg_ann_name = f"{get_file_name_with_ext(rimg_path)}.json"

--- a/supervisely/pointcloud/pointcloud.py
+++ b/supervisely/pointcloud/pointcloud.py
@@ -11,7 +11,7 @@ from supervisely.io.fs import ensure_base_path
 from supervisely.sly_logger import logger
 
 # Do NOT use directly for extension validation. Use is_valid_ext() /  has_valid_ext() below instead.
-ALLOWED_POINTCLOUD_EXTENSIONS = [".pcd"]
+ALLOWED_POINTCLOUD_EXTENSIONS = [".pcd", ".ply", ".las", ".laz"]
 
 
 class PointcloudExtensionError(Exception):


### PR DESCRIPTION
**Update `pointcloud_api.py`:** 
  - update `upload_paths` auto-routes by extension: `.pcd` → hash flow, `.ply/.las/.laz` → Team Files flow
  - new method `upload_paths_via_team_files(dataset_id, names, paths, ...)` — uploads local files to a temp Team  Files dir, then adds to dataset
  - new method `upload_team_files_ids(dataset_id, names, team_file_ids, ...)` — adds already-uploaded Team  Files entries to dataset

**AutoImport**
  - update subconverters to support new formats and new params
  - deprecate `ply_converter` and `las_converter` converters (base converter handles these formats  natively)
  - For Team Files sources, builds `team_files_id_map` map after download – to add files by ID instead of re-uploading