### PR TITLE
Optimize frame streaming pipeline

### DIFF
--- a/supervisely/video/sampling.py
+++ b/supervisely/video/sampling.py
@@ -5,6 +5,8 @@ import threading
 import urllib.parse
 from typing import Any, AsyncGenerator, Callable, Dict, List, Optional, Tuple, Union
 
+from tqdm import tqdm
+
 import cv2
 import numpy as np
 
@@ -637,7 +639,8 @@ def _sync_build_pts_map(
     token: Optional[str],
     video_id: int,
     end_frame: Optional[int] = None,
-) -> Tuple[List[int], bool]:
+    packet_cb: Optional[Callable[[], None]] = None,
+) -> Tuple[List[int], bool, Any]:
     """Synchronously demux video and build a sorted PTS list. Safe to run in a thread pool.
 
     :param video_url: Public URL of the video to demux.
@@ -647,8 +650,20 @@ def _sync_build_pts_map(
         Avoids scanning the entire video when only a subset of frames is needed.
         Early termination happens at ``end_frame + 64`` instead of ``end_frame`` to account for B-frame reordering (typically ≤16 frames).
         ``None`` reads the full video (required when ``end`` is unknown).
+    :param packet_cb: Optional callable invoked for each valid packet collected.
+        Intended for progress reporting (e.g. ``tqdm.update``).
+    :returns: Tuple ``(pts_list, decode_from_start, container)``. For the seek-based
+        decode path (``decode_from_start is False``) the open container is returned
+        so the caller can reuse it for decoding, avoiding a second TCP/HTTP(S)
+        handshake — a significant win for remote/S3 videos. For the
+        ``decode_from_start`` path the container is closed and ``None`` is returned,
+        because that path requires a pristine container (decoding from the very
+        beginning). The caller owns closing the returned container.
     """
+    logger.debug("Opening video container for video_id=%d ...", video_id)
     container = _av_open(video_url, token)
+    logger.debug("Video container opened, starting demux for video_id=%d.", video_id)
+    keep_open = False
     try:
         video_streams = container.streams.video
         if not video_streams:
@@ -663,15 +678,21 @@ def _sync_build_pts_map(
                 saw_pts_ne_dts = True
             if pkt.pts is not None and pkt.pts >= 0:
                 pts_list.append(pkt.pts)
+                if packet_cb is not None:
+                    packet_cb()
             if stop_after is not None and len(pts_list) >= stop_after:
                 break
 
         pts_list.sort()
         has_b_frames = getattr(v_stream.codec_context, "has_b_frames", 0) > 0
         decode_from_start = has_b_frames and not saw_pts_ne_dts
-        return pts_list, decode_from_start
+        # Reuse the already-open container for the seek-based decode path; the
+        # decode-from-start path needs a fresh container, so close this one.
+        keep_open = not decode_from_start
+        return pts_list, decode_from_start, (container if keep_open else None)
     finally:
-        container.close()
+        if not keep_open:
+            container.close()
 
 
 async def async_stream_video_frames(
@@ -680,6 +701,7 @@ async def async_stream_video_frames(
     start: Optional[int] = None,
     end: Optional[int] = None,
     queue_maxsize: int = 32,
+    show_decoding_progress: bool = False,
 ) -> AsyncGenerator[Tuple[int, np.ndarray], None]:
     """Async generator that streams decoded video frames by frame index.
 
@@ -700,6 +722,11 @@ async def async_stream_video_frames(
         Increase on memory-rich systems for higher throughput.
         Peak RAM ≈ ``(queue_maxsize + 1) x H x W x 3`` bytes.
     :type queue_maxsize: int, optional
+    :param show_decoding_progress: If ``True``, display tqdm progress bars for the low-level
+        I/O phases: the demuxing phase (building the PTS map) and, for the B-frame full-decode path, the decoding phase. 
+        Both bars count packets (``pkt``) and are independent of the per-frame ``progress_cb``.
+        Default ``False``.
+    :type show_decoding_progress: bool, optional
     :yields: Tuple of ``(frame_index, rgb_image)`` where ``rgb_image`` is a
         ``numpy.ndarray`` of shape ``(H, W, 3)`` in RGB uint8 format.
     :rtype: AsyncGenerator[Tuple[int, numpy.ndarray], None]
@@ -717,7 +744,6 @@ async def async_stream_video_frames(
                 print(frame_idx, img.shape)
     """
 
-    video_url = _resolve_video_url(api, video_id)
     loop = asyncio.get_running_loop()
 
     decode_executor = concurrent.futures.ThreadPoolExecutor(
@@ -725,12 +751,35 @@ async def async_stream_video_frames(
     )
 
     try:
-        pts_list, decode_from_start = await loop.run_in_executor(
-            decode_executor, _sync_build_pts_map, video_url, api.token, video_id, end
+        video_url = _resolve_video_url(api, video_id)
+    except Exception:
+        decode_executor.shutdown(wait=False)
+        raise
+
+    demux_bar = (
+        tqdm(desc=f"Demuxing video ID {video_id}", unit="pkt", leave=False)
+        if show_decoding_progress
+        else None
+    )
+
+    packet_cb = demux_bar.update if demux_bar is not None else None
+
+    try:
+        pts_list, decode_from_start, prebuilt_container = await loop.run_in_executor(
+            decode_executor,
+            _sync_build_pts_map,
+            video_url,
+            api.token,
+            video_id,
+            end,
+            packet_cb,
         )
     except Exception:
         decode_executor.shutdown(wait=False)
         raise
+    finally:
+        if demux_bar is not None:
+            demux_bar.close()
 
     if decode_from_start:
         logger.warning(
@@ -746,6 +795,9 @@ async def async_stream_video_frames(
     )
 
     if not pts_list:
+        if prebuilt_container is not None:
+            # Close on the executor thread to keep PyAV access single-threaded.
+            await loop.run_in_executor(decode_executor, prebuilt_container.close)
         decode_executor.shutdown(wait=False)
         return
 
@@ -767,9 +819,18 @@ async def async_stream_video_frames(
                 continue
         return False
 
-    def _worker() -> None:
+    def _worker(container: Any) -> None:
         try:
-            container: Any = _av_open(video_url, api.token)
+            if container is None:
+                # decode_from_start path: open a fresh, pristine container.
+                logger.debug("Opening video container for decoding video_id=%d ...", video_id)
+                container = _av_open(video_url, api.token)
+                logger.debug(
+                    "Video container opened, starting decode for video_id=%d.", video_id
+                )
+            else:
+                # Reusing the container already opened during PTS map building.
+                logger.debug("Reusing open container for decoding video_id=%d.", video_id)
             try:
                 video_streams = container.streams.video
                 if not video_streams:
@@ -777,22 +838,33 @@ async def async_stream_video_frames(
                 v_stream = video_streams[0]
 
                 if decode_from_start:
-                    remaining: set = set(range(_start, _end + 1))
-                    for pkt in container.demux(v_stream):
-                        if cancel_event.is_set():
-                            break
-                        for frame in pkt.decode():
-                            if frame.pts is None or frame.is_corrupt:
-                                continue
-                            frame_idx = pts_to_index.get(frame.pts)
-                            if frame_idx is None or frame_idx not in remaining:
-                                continue
-                            img = frame.to_ndarray(format="rgb24")
-                            if not _put((frame_idx, img)):
-                                return
-                            remaining.discard(frame_idx)
-                        if not remaining:
-                            break
+                    decode_bar = (
+                        tqdm(desc=f"Decoding video ID {video_id}", unit="pkt", leave=False)
+                        if show_decoding_progress
+                        else None
+                    )
+                    try:
+                        remaining: set = set(range(_start, _end + 1))
+                        for pkt in container.demux(v_stream):
+                            if decode_bar is not None:
+                                decode_bar.update()
+                            if cancel_event.is_set():
+                                break
+                            for frame in pkt.decode():
+                                if frame.pts is None or frame.is_corrupt:
+                                    continue
+                                frame_idx = pts_to_index.get(frame.pts)
+                                if frame_idx is None or frame_idx not in remaining:
+                                    continue
+                                img = frame.to_ndarray(format="rgb24")
+                                if not _put((frame_idx, img)):
+                                    return
+                                remaining.discard(frame_idx)
+                            if not remaining:
+                                break
+                    finally:
+                        if decode_bar is not None:
+                            decode_bar.close()
                 else:
                     # Single seek to the first requested frame, then decode sequentially.
                     # This avoids O(N) seeks for contiguous ranges.
@@ -822,7 +894,7 @@ async def async_stream_video_frames(
         finally:
             _put(None)  # sentinel — always sent last
 
-    future = loop.run_in_executor(decode_executor, _worker)
+    future = loop.run_in_executor(decode_executor, _worker, prebuilt_container)
     try:
         while True:
             item = await queue.get()
@@ -848,6 +920,7 @@ async def async_stream_video_frames_to_dir(
     image_writer: Optional[Callable[[str, np.ndarray], None]] = None,
     max_write_workers: int = 4,
     queue_maxsize: int = 32,
+    show_decoding_progress: bool = False,
 ) -> List[str]:
     """Async version of :func:`stream_video_frames_to_dir`.
 
@@ -875,6 +948,9 @@ async def async_stream_video_frames_to_dir(
     :type max_write_workers: int, optional
     :param queue_maxsize: Decode prefetch buffer size in frames (default 32).
     :type queue_maxsize: int, optional
+    :param show_decoding_progress: If ``True``, display tqdm progress bars for the demuxing
+        and (B-frame) decoding phases. See :func:`async_stream_video_frames` for details.
+    :type show_decoding_progress: bool, optional
     :returns: List of absolute paths to saved frame files.
     :rtype: List[str]
     """
@@ -911,6 +987,7 @@ async def async_stream_video_frames_to_dir(
             start=start,
             end=end,
             queue_maxsize=queue_maxsize,
+            show_decoding_progress=show_decoding_progress,
         ):
             path = os.path.join(output_dir, f"frame_{frame_idx:06d}.{ext}")
             await write_sem.acquire()
@@ -941,6 +1018,7 @@ def stream_video_frames_to_dir(
     image_writer: Optional[Callable[[str, np.ndarray], None]] = None,
     max_write_workers: int = 4,
     queue_maxsize: int = 32,
+    show_decoding_progress: bool = False,
 ) -> List[str]:
     """Stream decoded video frames and save them to a directory.
 
@@ -973,6 +1051,9 @@ def stream_video_frames_to_dir(
     :param queue_maxsize: Decode prefetch buffer size in frames (default 32).
         Peak RAM ≈ ``(queue_maxsize + max_write_workers + 1) x frame_bytes``.
     :type queue_maxsize: int, optional
+    :param show_decoding_progress: If ``True``, display tqdm progress bars for the demuxing
+        and (B-frame) decoding phases. See :func:`async_stream_video_frames` for details.
+    :type show_decoding_progress: bool, optional
     :returns: List of absolute paths to the saved frame files.
     :rtype: List[str]
 
@@ -1001,6 +1082,7 @@ def stream_video_frames_to_dir(
         image_writer=image_writer,
         max_write_workers=max_write_workers,
         queue_maxsize=queue_maxsize,
+        show_decoding_progress=show_decoding_progress,
     )
     try:
         running_loop = asyncio.get_running_loop()

--- a/supervisely/video/sampling.py
+++ b/supervisely/video/sampling.py
@@ -796,8 +796,8 @@ async def async_stream_video_frames(
                 else:
                     # Single seek to the first requested frame, then decode sequentially.
                     # This avoids O(N) seeks for contiguous ranges.
-                    wanted: Dict[int, int] = {pts_list[i]: i for i in range(_start, _end + 1)}
-                    end_pts: int = pts_list[_end]
+                    wanted = {pts_list[i]: i for i in range(_start, _end + 1)}
+                    end_pts = pts_list[_end]
                     container.seek(
                         pts_list[_start], stream=v_stream, backward=True, any_frame=False
                     )

--- a/supervisely/video/sampling.py
+++ b/supervisely/video/sampling.py
@@ -892,14 +892,17 @@ async def async_stream_video_frames_to_dir(
     write_executor = concurrent.futures.ThreadPoolExecutor(
         max_workers=max_write_workers, thread_name_prefix="frame_write"
     )
-    saved_paths = []
     pending = []
 
-    async def _write_frame(path: str, img: np.ndarray) -> None:
+    async def _write_frame(path: str, img: np.ndarray) -> str:
         try:
             await loop.run_in_executor(write_executor, image_writer, path, img)
         finally:
             write_sem.release()
+        # Report success only after the file is actually on disk.
+        if progress_cb is not None:
+            progress_cb(1)
+        return path
 
     try:
         async for frame_idx, img in async_stream_video_frames(
@@ -911,16 +914,15 @@ async def async_stream_video_frames_to_dir(
         ):
             path = os.path.join(output_dir, f"frame_{frame_idx:06d}.{ext}")
             await write_sem.acquire()
-            saved_paths.append(path)
             pending.append(asyncio.create_task(_write_frame(path, img)))
-            if progress_cb is not None:
-                progress_cb(1)
 
-        if pending:
-            await asyncio.gather(*pending)
+        # gather preserves submission order, so saved_paths stays frame-ordered
+        # and contains only paths whose writes completed successfully.
+        saved_paths = list(await asyncio.gather(*pending)) if pending else []
     except Exception:
         for task in pending:
             task.cancel()
+        await asyncio.gather(*pending, return_exceptions=True)
         raise
     finally:
         write_executor.shutdown(wait=False)

--- a/supervisely/video/sampling.py
+++ b/supervisely/video/sampling.py
@@ -632,22 +632,39 @@ def _av_open(video_url: str, token: Optional[str] = None) -> Any:
     return av.open(video_url, options=av_options)
 
 
-def _sync_build_pts_map(video_url: str, token: Optional[str], video_id: int) -> Tuple[List[int], bool]:
-    """Synchronously demux video and build a sorted PTS list. Safe to run in a thread pool."""
-    container: Any = _av_open(video_url, token)
+def _sync_build_pts_map(
+    video_url: str,
+    token: Optional[str],
+    video_id: int,
+    end_frame: Optional[int] = None,
+) -> Tuple[List[int], bool]:
+    """Synchronously demux video and build a sorted PTS list. Safe to run in a thread pool.
+
+    :param video_url: Public URL of the video to demux.
+    :param token: API token for authenticated access to the video URL, if required.
+    :param video_id: Video ID (for logging purposes only).
+    :param end_frame: Stop demuxing after collecting ``end_frame + 64`` PTS values.
+        Avoids scanning the entire video when only a subset of frames is needed.
+        Early termination happens at ``end_frame + 64`` instead of ``end_frame`` to account for B-frame reordering (typically ≤16 frames).
+        ``None`` reads the full video (required when ``end`` is unknown).
+    """
+    container = _av_open(video_url, token)
     try:
         video_streams = container.streams.video
         if not video_streams:
             raise RuntimeError(f"PyAV found no video streams in video {video_id}.")
         v_stream = video_streams[0]
 
-        pts_list: List[int] = []
+        pts_list = []
         saw_pts_ne_dts = False
+        stop_after = (end_frame + 64) if end_frame is not None else None
         for pkt in container.demux(v_stream):
             if pkt.pts is not None and pkt.dts is not None and pkt.pts != pkt.dts:
                 saw_pts_ne_dts = True
             if pkt.pts is not None and pkt.pts >= 0:
                 pts_list.append(pkt.pts)
+            if stop_after is not None and len(pts_list) >= stop_after:
+                break
 
         pts_list.sort()
         has_b_frames = getattr(v_stream.codec_context, "has_b_frames", 0) > 0
@@ -657,36 +674,12 @@ def _sync_build_pts_map(video_url: str, token: Optional[str], video_id: int) -> 
         container.close()
 
 
-async def _async_build_pts_map(
-    api: Any,
-    video_id: int,
-) -> Tuple[List[int], bool]:
-    """Build frame-index -> PTS map and detect no-CTTS B-frame streams."""
-    video_url = _resolve_video_url(api, video_id)
-    loop = asyncio.get_running_loop()
-    pts_list, decode_from_start = await loop.run_in_executor(
-        None, _sync_build_pts_map, video_url, api.token, video_id
-    )
-    if decode_from_start:
-        logger.warning(
-            "B-frame stream without CTTS detected; "
-            "using full decode from start for stable frame extraction.",
-            extra={"video_id": video_id},
-        )
-    logger.debug(
-        "build_pts_map: video_id=%d - %d pts values (demux, non-negative, sorted), decode_from_start=%s.",
-        video_id,
-        len(pts_list),
-        decode_from_start,
-    )
-    return pts_list, decode_from_start
-
-
 async def async_stream_video_frames(
     api: Any,
     video_id: int,
     start: Optional[int] = None,
     end: Optional[int] = None,
+    queue_maxsize: int = 32,
 ) -> AsyncGenerator[Tuple[int, np.ndarray], None]:
     """Async generator that streams decoded video frames by frame index.
 
@@ -703,6 +696,10 @@ async def async_stream_video_frames(
     :type start: int, optional
     :param end: Last frame index to yield (inclusive, 0-based). Defaults to the last frame.
     :type end: int, optional
+    :param queue_maxsize: Decode prefetch buffer size in frames (default 32).
+        Increase on memory-rich systems for higher throughput.
+        Peak RAM ≈ ``(queue_maxsize + 1) x H x W x 3`` bytes.
+    :type queue_maxsize: int, optional
     :yields: Tuple of ``(frame_index, rgb_image)`` where ``rgb_image`` is a
         ``numpy.ndarray`` of shape ``(H, W, 3)`` in RGB uint8 format.
     :rtype: AsyncGenerator[Tuple[int, numpy.ndarray], None]
@@ -719,31 +716,48 @@ async def async_stream_video_frames(
             async for frame_idx, img in async_stream_video_frames(api, video_id=123, start=0, end=9):
                 print(frame_idx, img.shape)
     """
-    pts_map, decode_from_start = await _async_build_pts_map(
-        api=api,
-        video_id=video_id,
-    )
-
-    if not pts_map:
-        return
-
-    _start: int = max(0, start if start is not None else 0)
-    _end: int = min(max(_start, end), len(pts_map) - 1) if end is not None else len(pts_map) - 1
-
-    pts_to_index: Dict[int, int] = {pts: idx for idx, pts in enumerate(pts_map)}
 
     video_url = _resolve_video_url(api, video_id)
     loop = asyncio.get_running_loop()
-    queue: asyncio.Queue = asyncio.Queue(maxsize=8)
+
+    decode_executor = concurrent.futures.ThreadPoolExecutor(
+        max_workers=1, thread_name_prefix="av_decode"
+    )
+
+    try:
+        pts_list, decode_from_start = await loop.run_in_executor(
+            decode_executor, _sync_build_pts_map, video_url, api.token, video_id, end
+        )
+    except Exception:
+        decode_executor.shutdown(wait=False)
+        raise
+
+    if decode_from_start:
+        logger.warning(
+            "B-frame stream without CTTS detected; "
+            "using full decode from start for stable frame extraction.",
+            extra={"video_id": video_id},
+        )
+    logger.debug(
+        "build_pts_map: video_id=%d - %d pts values (demux, non-negative, sorted), decode_from_start=%s.",
+        video_id,
+        len(pts_list),
+        decode_from_start,
+    )
+
+    if not pts_list:
+        decode_executor.shutdown(wait=False)
+        return
+
+    _start = max(0, start if start is not None else 0)
+    _end = min(max(_start, end), len(pts_list) - 1) if end is not None else len(pts_list) - 1
+
+    pts_to_index = {pts: idx for idx, pts in enumerate(pts_list)}
+
+    queue = asyncio.Queue(maxsize=queue_maxsize)
     cancel_event = threading.Event()
 
     def _put(item: Any) -> bool:
-        """Put *item* into the queue from a worker thread.
-
-        Retries with a 0.2-second timeout until the queue accepts the item or
-        ``cancel_event`` is set.  Returns ``True`` on success, ``False`` if
-        cancelled.
-        """
         while not cancel_event.is_set():
             fut = asyncio.run_coroutine_threadsafe(queue.put(item), loop)
             try:
@@ -782,10 +796,10 @@ async def async_stream_video_frames(
                 else:
                     # Single seek to the first requested frame, then decode sequentially.
                     # This avoids O(N) seeks for contiguous ranges.
-                    wanted: Dict[int, int] = {pts_map[i]: i for i in range(_start, _end + 1)}
-                    end_pts: int = pts_map[_end]
+                    wanted: Dict[int, int] = {pts_list[i]: i for i in range(_start, _end + 1)}
+                    end_pts: int = pts_list[_end]
                     container.seek(
-                        pts_map[_start], stream=v_stream, backward=True, any_frame=False
+                        pts_list[_start], stream=v_stream, backward=True, any_frame=False
                     )
                     for frame in container.decode(v_stream):
                         if cancel_event.is_set():
@@ -808,7 +822,7 @@ async def async_stream_video_frames(
         finally:
             _put(None)  # sentinel — always sent last
 
-    future = loop.run_in_executor(None, _worker)
+    future = loop.run_in_executor(decode_executor, _worker)
     try:
         while True:
             item = await queue.get()
@@ -820,6 +834,7 @@ async def async_stream_video_frames(
     finally:
         cancel_event.set()
         await future
+        decode_executor.shutdown(wait=True)
 
 
 async def async_stream_video_frames_to_dir(
@@ -831,6 +846,8 @@ async def async_stream_video_frames_to_dir(
     ext: str = "png",
     progress_cb: Optional[Callable] = None,
     image_writer: Optional[Callable[[str, np.ndarray], None]] = None,
+    max_write_workers: int = 4,
+    queue_maxsize: int = 32,
 ) -> List[str]:
     """Async version of :func:`stream_video_frames_to_dir`.
 
@@ -854,6 +871,10 @@ async def async_stream_video_frames_to_dir(
     :param image_writer: Custom function ``(path, image) -> None`` for writing frames.
         Defaults to :func:`supervisely.imaging.image.write`.
     :type image_writer: callable, optional
+    :param max_write_workers: Number of parallel write threads (default 4).
+    :type max_write_workers: int, optional
+    :param queue_maxsize: Decode prefetch buffer size in frames (default 32).
+    :type queue_maxsize: int, optional
     :returns: List of absolute paths to saved frame files.
     :rtype: List[str]
     """
@@ -864,18 +885,46 @@ async def async_stream_video_frames_to_dir(
         image_writer = sly_image.write
 
     loop = asyncio.get_running_loop()
-    saved_paths: List[str] = []
-    async for frame_idx, img in async_stream_video_frames(
-        api=api,
-        video_id=video_id,
-        start=start,
-        end=end,
-    ):
-        path = os.path.join(output_dir, f"frame_{frame_idx:06d}.{ext}")
-        await loop.run_in_executor(None, image_writer, path, img)
-        saved_paths.append(path)
-        if progress_cb is not None:
-            progress_cb(1)
+    # Semaphore bounds concurrent writes in flight — primary OOM guard.
+    # When all slots are occupied, acquire() blocks the consumer loop,
+    # which fills the decode queue, which stalls the FFmpeg worker.
+    write_sem = asyncio.Semaphore(max_write_workers)
+    write_executor = concurrent.futures.ThreadPoolExecutor(
+        max_workers=max_write_workers, thread_name_prefix="frame_write"
+    )
+    saved_paths = []
+    pending = []
+
+    async def _write_frame(path: str, img: np.ndarray) -> None:
+        try:
+            await loop.run_in_executor(write_executor, image_writer, path, img)
+        finally:
+            write_sem.release()
+
+    try:
+        async for frame_idx, img in async_stream_video_frames(
+            api=api,
+            video_id=video_id,
+            start=start,
+            end=end,
+            queue_maxsize=queue_maxsize,
+        ):
+            path = os.path.join(output_dir, f"frame_{frame_idx:06d}.{ext}")
+            await write_sem.acquire()
+            saved_paths.append(path)
+            pending.append(asyncio.create_task(_write_frame(path, img)))
+            if progress_cb is not None:
+                progress_cb(1)
+
+        if pending:
+            await asyncio.gather(*pending)
+    except Exception:
+        for task in pending:
+            task.cancel()
+        raise
+    finally:
+        write_executor.shutdown(wait=False)
+
     return saved_paths
 
 
@@ -888,6 +937,8 @@ def stream_video_frames_to_dir(
     ext: str = "png",
     progress_cb: Optional[Callable] = None,
     image_writer: Optional[Callable[[str, np.ndarray], None]] = None,
+    max_write_workers: int = 4,
+    queue_maxsize: int = 32,
 ) -> List[str]:
     """Stream decoded video frames and save them to a directory.
 
@@ -914,6 +965,12 @@ def stream_video_frames_to_dir(
     :param image_writer: Custom function ``(path, image) -> None`` for writing frames.
         Defaults to :func:`supervisely.imaging.image.write`.
     :type image_writer: callable, optional
+    :param max_write_workers: Number of parallel write threads (default 4).
+        Increase on memory-rich systems for higher write throughput.
+    :type max_write_workers: int, optional
+    :param queue_maxsize: Decode prefetch buffer size in frames (default 32).
+        Peak RAM ≈ ``(queue_maxsize + max_write_workers + 1) x frame_bytes``.
+    :type queue_maxsize: int, optional
     :returns: List of absolute paths to the saved frame files.
     :rtype: List[str]
 
@@ -940,6 +997,8 @@ def stream_video_frames_to_dir(
         ext=ext,
         progress_cb=progress_cb,
         image_writer=image_writer,
+        max_write_workers=max_write_workers,
+        queue_maxsize=queue_maxsize,
     )
     try:
         running_loop = asyncio.get_running_loop()


### PR DESCRIPTION
## Video frame streaming: performance optimizations

### Problem

`stream_video_frames_to_dir` was unacceptably slow on long 4K videos.
Profiling identified two bottlenecks:

1. Full-video demux on every call. `_sync_build_pts_map` iterated
   through every packet in the file to build the PTS list (~85 s for a
   long 4K clip) even when only 5 frames near the middle were needed.

2. Sequential frame writes. Each decoded frame was written to disk
   serially inside the async loop, so CPU-bound image encoding and I/O
   stalled the decoder.


### Changes

#### Early demux termination (`_sync_build_pts_map`)

Added an `end_frame: Optional[int]` parameter. When provided, demuxing
stops as soon as `end_frame + 64` PTS values have been collected. The
+64 margin accounts for B-frame decoder reorder windows (typically <=16
frames) with a conservative safety buffer.

  Before: always reads the full file
    for pkt in container.demux(v_stream): ...

  After: stops early when the range is known
    stop_after = (end_frame + 64) if end_frame is not None else None
    if stop_after is not None and len(pts_list) >= stop_after:
        break


#### Dedicated decode executor (`async_stream_video_frames`)

- Video URL is resolved once and reused for both the demux pass and the
  decode pass (was resolved separately for each).
- Demux and decode now run in a dedicated
  ThreadPoolExecutor(max_workers=1, thread_name_prefix="av_decode")
  instead of the default executor. Keeps FFmpeg I/O isolated from write
  threads and makes shutdown deterministic.
- `end` is passed through to `_sync_build_pts_map` for early
  termination.
- `queue_maxsize` is now a parameter (was hardcoded to 8). Default: 32.


#### PyAV container reuse for seek-based decode

For the common seek-based path, the PyAV container opened during the
demux phase is now reused for decoding instead of being closed and
reopened. This eliminates a second TCP/HTTP(S) handshake — especially
costly for S3 and other remote storage backends.

The decode-from-start fallback (B-frame streams without CTTS) is
unaffected and still opens a fresh container, since that path
deliberately avoids relying on seek.


#### Parallel frame writes (`async_stream_video_frames_to_dir`)

Writes are now dispatched to a ThreadPoolExecutor(max_workers=4,
thread_name_prefix="frame_write"). An asyncio.Semaphore(max_write_workers)
provides backpressure: when all write slots are occupied the consumer
loop blocks, the decode queue fills, and the FFmpeg worker stalls —
bounding peak RAM to (queue_maxsize + max_write_workers + 1) * frame_bytes
regardless of clip length.


#### Bug fixes (`async_stream_video_frames_to_dir`)

- `progress_cb` is now called after the frame file is fully written to
  disk, not when the write task is submitted. Previously the bar could
  reach 100% before files existed on disk.
- `saved_paths` is now built from completed write results via
  `asyncio.gather`, so the returned list contains only paths whose files
  were successfully written. Previously paths were appended on submission
  and could include files that were never created.
- Cancelled write tasks are now awaited after cancellation on error,
  preventing `ResourceWarning` and orphaned asyncio tasks.


#### Progress visibility (`show_decoding_progress`)

Added `show_decoding_progress: bool = False` to `async_stream_video_frames`,
`async_stream_video_frames_to_dir`, and `stream_video_frames_to_dir`.
When enabled:

- A tqdm packet counter (`Demuxing video ID X`) is shown during the
  demux phase, which otherwise looks like a hang on large remote files.
- A second counter (`Decoding video ID X`) is shown during the
  decode-from-start path, where the frame bar stays at 0 for the
  entire duration of the full decode.

Both bars are independent of the per-frame `progress_cb`.
`logger.debug` calls are added around each `av.open()` so connection
latency is visible at `DEBUG` log level without enabling the tqdm bars.


#### Dead code removal

`_async_build_pts_map` was an async wrapper around `_sync_build_pts_map`.
After the refactor it was no longer called anywhere and has been removed.


### Peak RAM

  peak ~= (queue_maxsize + max_write_workers + 1) * H * W * 3 bytes
  Default config, 4K (3840x2160): ~880 MB


### Backwards compatibility

`stream_video_frames_to_dir` and `async_stream_video_frames_to_dir`
are fully backwards-compatible. New parameters (`max_write_workers`,
`queue_maxsize`, `show_decoding_progress`) have defaults matching
previous implicit behaviour.