### PR TITLE
Fix RCE via insecure pickle deserialization (CWE-502)

### DIFF
--- a/supervisely/api/image_api.py
+++ b/supervisely/api/image_api.py
@@ -78,6 +78,7 @@ from supervisely.io.env import (
 from supervisely.io.fs import (
     OFFSETS_PKL_BATCH_SIZE,
     OFFSETS_PKL_SUFFIX,
+    BaseRestrictedUnpickler,
     clean_dir,
     ensure_base_path,
     get_file_ext,
@@ -97,6 +98,33 @@ from supervisely.project.project_type import (
 from supervisely.sly_logger import logger
 
 SUPPORTED_CONFLICT_RESOLUTIONS = ["skip", "rename", "replace"]
+
+
+class _BlobOffsetUnpickler(BaseRestrictedUnpickler):
+    """Restricted unpickler for ``*_offsets.pkl`` files.
+
+    Inherits the allowlist mechanism from :class:`~supervisely.io.fs.BaseRestrictedUnpickler`.
+    Only :class:`BlobImageInfo` and safe Python primitives are permitted;
+    everything else raises :exc:`pickle.UnpicklingError` (CWE-502 mitigation).
+    """
+
+    _ALLOWED: Dict[str, set] = {
+        "supervisely.api.image_api": {"BlobImageInfo"},
+        "builtins": {
+            "list",
+            "str",
+            "int",
+            "float",
+            "bool",
+            "bytes",
+            "bytearray",
+            "dict",
+            "tuple",
+            "NoneType",
+        },
+    }
+
+
 API_DEFAULT_PER_PAGE = 500
 
 
@@ -200,7 +228,7 @@ class BlobImageInfo:
                 while True:
                     try:
                         # Load one pickle object at a time
-                        data = pickle.load(f)
+                        data = _BlobOffsetUnpickler(f).load()
 
                         if isinstance(data, list):
                             # More efficient way to process lists

--- a/supervisely/io/fs.py
+++ b/supervisely/io/fs.py
@@ -7,6 +7,7 @@ import errno
 import hashlib
 import mimetypes
 import os
+import pickle
 import re
 import shutil
 import subprocess
@@ -20,6 +21,7 @@ from typing import (
     List,
     Literal,
     Optional,
+    Set,
     Tuple,
     Union,
 )
@@ -41,6 +43,45 @@ from supervisely.task.progress import Progress
 JUNK_FILES = [".DS_Store", "__MACOSX", "._.DS_Store", "Thumbs.db", "desktop.ini"]
 OFFSETS_PKL_SUFFIX = "_offsets.pkl"  # suffix for pickle file with image offsets
 OFFSETS_PKL_BATCH_SIZE = 10000  # 10k images per batch when loading from pickle
+
+
+class BaseRestrictedUnpickler(pickle.Unpickler):
+    """Base unpickler that enforces an allowlist of modules and classes.
+
+    Prevents Remote Code Execution via malicious pickle payloads (CWE-502).
+    Any class not covered by the allowlist raises :exc:`pickle.UnpicklingError`
+    instead of being imported and instantiated.
+
+    Subclasses configure the allowlist via two class-level attributes:
+
+    * ``_ALLOWED`` — exact ``{module: {class_name, ...}}`` whitelist.
+      Takes priority over ``_ALLOWED_MODULE_PREFIXES``.
+    * ``_ALLOWED_MODULE_PREFIXES`` — tuple of module-name prefixes.
+      Every class whose module starts with one of these prefixes is allowed.
+
+    Both attributes can be combined: exact entries in ``_ALLOWED`` are checked
+    first; if no match is found the prefix list is tried next.
+    """
+
+    _ALLOWED: Dict[str, Set[str]] = {}
+    _ALLOWED_MODULE_PREFIXES: Tuple[str, ...] = ()
+
+    def find_class(self, module: str, name: str):
+        # 1. Exact module+class whitelist (highest priority, e.g. tight sinks)
+        allowed_names = self._ALLOWED.get(module)
+        if allowed_names is not None and name in allowed_names:
+            return super().find_class(module, name)
+
+        # 2. Module-prefix whitelist (broader allow, e.g. all supervisely.*)
+        if self._ALLOWED_MODULE_PREFIXES and any(
+            module == prefix or module.startswith(prefix + ".")
+            for prefix in self._ALLOWED_MODULE_PREFIXES
+        ):
+            return super().find_class(module, name)
+
+        raise pickle.UnpicklingError(
+            f"Blocked unsafe class during deserialization: {module}.{name}"
+        )
 
 
 def get_file_name(path: str) -> str:

--- a/supervisely/project/project.py
+++ b/supervisely/project/project.py
@@ -57,6 +57,7 @@ from supervisely.collection.key_indexed_collection import (
 from supervisely.geometry.bitmap import Bitmap
 from supervisely.imaging import image as sly_image
 from supervisely.io.fs import (
+    BaseRestrictedUnpickler,
     clean_dir,
     copy_file,
     copy_file_async,
@@ -83,13 +84,23 @@ from supervisely.task.progress import tqdm_sly
 TF_BLOB_DIR = "blob-files"  # directory for project blob files in team files
 
 
-class CustomUnpickler(pickle.Unpickler):
+class CustomUnpickler(BaseRestrictedUnpickler):
+    """Custom Unpickler for loading pickled objects of the same class with differing definitions.
+
+    Inherits the allowlist security mechanism from
+    :class:`~supervisely.io.fs.BaseRestrictedUnpickler` (CWE-502 mitigation) and
+    adds backward-compatibility handling for NamedTuple classes whose field set
+    has changed between SDK versions (missing or extra fields).
     """
-    Custom Unpickler for loading pickled objects of the same class with differing definitions.
-    Handles cases where a class object is reconstructed using a newer definition with additional fields
-    or an outdated definition missing some fields.
-    Supports loading namedtuple objects with missing or extra fields.
-    """
+
+    # Modules allowed during deserialization of .bin project files.
+    _ALLOWED_MODULE_PREFIXES = (
+        "supervisely",
+        "builtins",
+        "collections",
+        "_collections",
+        "datetime",
+    )
 
     def __init__(self, file, **kwargs):
         """
@@ -104,7 +115,7 @@ class CustomUnpickler(pickle.Unpickler):
 
     def find_class(self, module, name):
         prefix = "Pickled"
-        cls = super().find_class(module, name)
+        cls = super().find_class(module, name)  # security check + class resolution
         if hasattr(cls, "_fields") and "Info" in cls.__name__:
             orig_new = cls.__new__
 


### PR DESCRIPTION
## Summary

Fixes two RCE vectors caused by unrestricted `pickle.load()` calls (CWE-502): auto-loaded `*_offsets.pkl` on `Project` open and crafted `.bin` files in `upload_bin()`.

## Fix

Added `RestrictedUnpickler` base class (`supervisely/io/fs.py`) enforcing a module/class allowlist in `find_class()` — raises `pickle.UnpicklingError` for anything outside it.

- `_BlobOffsetUnpickler` (image_api.py) — tight allowlist: `BlobImageInfo` + safe builtins only
- `CustomUnpickler` (project.py) — module-prefix allowlist: `supervisely.*`, `builtins`, `collections`, `datetime`; NamedTuple backward-compat logic unchanged