### PR TITLE
Fix RCE via insecure pickle deserialization (CWE-502)

### DIFF
--- a/supervisely/api/image_api.py
+++ b/supervisely/api/image_api.py
@@ -78,6 +78,7 @@ from supervisely.io.env import (
 from supervisely.io.fs import (
     OFFSETS_PKL_BATCH_SIZE,
     OFFSETS_PKL_SUFFIX,
+    RestrictedUnpickler,
     clean_dir,
     ensure_base_path,
     get_file_ext,
@@ -197,10 +198,11 @@ class BlobImageInfo:
             current_batch = []
 
             with open(file_path, "rb") as f:
+                unpickler = RestrictedUnpickler(f)
                 while True:
                     try:
-                        # Load one pickle object at a time
-                        data = pickle.load(f)
+                        # Load one pickle object at a time using restricted unpickler
+                        data = unpickler.load()
 
                         if isinstance(data, list):
                             # More efficient way to process lists

--- a/supervisely/api/image_api.py
+++ b/supervisely/api/image_api.py
@@ -78,7 +78,7 @@ from supervisely.io.env import (
 from supervisely.io.fs import (
     OFFSETS_PKL_BATCH_SIZE,
     OFFSETS_PKL_SUFFIX,
-    RestrictedUnpickler,
+    BaseRestrictedUnpickler,
     clean_dir,
     ensure_base_path,
     get_file_ext,
@@ -98,6 +98,33 @@ from supervisely.project.project_type import (
 from supervisely.sly_logger import logger
 
 SUPPORTED_CONFLICT_RESOLUTIONS = ["skip", "rename", "replace"]
+
+
+class _BlobOffsetUnpickler(BaseRestrictedUnpickler):
+    """Restricted unpickler for ``*_offsets.pkl`` files.
+
+    Inherits the allowlist mechanism from :class:`~supervisely.io.fs.BaseRestrictedUnpickler`.
+    Only :class:`BlobImageInfo` and safe Python primitives are permitted;
+    everything else raises :exc:`pickle.UnpicklingError` (CWE-502 mitigation).
+    """
+
+    _ALLOWED: Dict[str, set] = {
+        "supervisely.api.image_api": {"BlobImageInfo"},
+        "builtins": {
+            "list",
+            "str",
+            "int",
+            "float",
+            "bool",
+            "bytes",
+            "bytearray",
+            "dict",
+            "tuple",
+            "NoneType",
+        },
+    }
+
+
 API_DEFAULT_PER_PAGE = 500
 
 
@@ -198,11 +225,10 @@ class BlobImageInfo:
             current_batch = []
 
             with open(file_path, "rb") as f:
-                unpickler = RestrictedUnpickler(f)
                 while True:
                     try:
                         # Load one pickle object at a time using restricted unpickler
-                        data = unpickler.load()
+                        data = _BlobOffsetUnpickler(f).load()
 
                         if isinstance(data, list):
                             # More efficient way to process lists

--- a/supervisely/io/fs.py
+++ b/supervisely/io/fs.py
@@ -43,6 +43,28 @@ OFFSETS_PKL_SUFFIX = "_offsets.pkl"  # suffix for pickle file with image offsets
 OFFSETS_PKL_BATCH_SIZE = 10000  # 10k images per batch when loading from pickle
 
 
+import pickle
+import builtins
+
+class RestrictedUnpickler(pickle.Unpickler):
+    def find_class(self, module, name):
+        if module == "supervisely.api.image_api" and name == "BlobImageInfo":
+            from supervisely.api.image_api import BlobImageInfo
+            return BlobImageInfo
+        if module == "builtins" and name in ("list", "dict", "str", "int", "float", "bool", "set", "tuple", "NoneType"):
+            return getattr(builtins, name)
+        if module == "collections" and name == "OrderedDict":
+            import collections
+            return collections.OrderedDict
+        if module == "numpy.core.multiarray" or module == "numpy":
+            import numpy
+            return getattr(numpy, name)
+        if module == "pandas.core.frame" or module == "pandas":
+            import pandas
+            return getattr(pandas, name)
+        raise pickle.UnpicklingError(f"global '{module}.{name}' is forbidden")
+
+
 def get_file_name(path: str) -> str:
     """
     Extracts file name from a given path.

--- a/supervisely/io/fs.py
+++ b/supervisely/io/fs.py
@@ -7,6 +7,7 @@ import errno
 import hashlib
 import mimetypes
 import os
+import pickle
 import re
 import shutil
 import subprocess
@@ -20,6 +21,7 @@ from typing import (
     List,
     Literal,
     Optional,
+    Set,
     Tuple,
     Union,
 )
@@ -43,26 +45,42 @@ OFFSETS_PKL_SUFFIX = "_offsets.pkl"  # suffix for pickle file with image offsets
 OFFSETS_PKL_BATCH_SIZE = 10000  # 10k images per batch when loading from pickle
 
 
-import pickle
-import builtins
+class BaseRestrictedUnpickler(pickle.Unpickler):
+    """Base unpickler that enforces an allowlist of modules and classes.
 
-class RestrictedUnpickler(pickle.Unpickler):
-    def find_class(self, module, name):
-        if module == "supervisely.api.image_api" and name == "BlobImageInfo":
-            from supervisely.api.image_api import BlobImageInfo
-            return BlobImageInfo
-        if module == "builtins" and name in ("list", "dict", "str", "int", "float", "bool", "set", "tuple", "NoneType"):
-            return getattr(builtins, name)
-        if module == "collections" and name == "OrderedDict":
-            import collections
-            return collections.OrderedDict
-        if module == "numpy.core.multiarray" or module == "numpy":
-            import numpy
-            return getattr(numpy, name)
-        if module == "pandas.core.frame" or module == "pandas":
-            import pandas
-            return getattr(pandas, name)
-        raise pickle.UnpicklingError(f"global '{module}.{name}' is forbidden")
+    Any class not covered by the allowlist raises :exc:`pickle.UnpicklingError`
+    instead of being imported and instantiated.
+
+    Subclasses should configure the allowlist via two class-level attributes:
+
+    * ``_ALLOWED`` — exact ``{module: {class_name, ...}}`` whitelist.
+      Takes priority over ``_ALLOWED_MODULE_PREFIXES``.
+    * ``_ALLOWED_MODULE_PREFIXES`` — tuple of module-name prefixes.
+      Every class whose module starts with one of these prefixes is allowed.
+
+    Both attributes can be combined: exact entries in ``_ALLOWED`` are checked
+    first; if no match is found the prefix list is tried next.
+    """
+
+    _ALLOWED: Dict[str, Set[str]] = {}
+    _ALLOWED_MODULE_PREFIXES: Tuple[str, ...] = ()
+
+    def find_class(self, module: str, name: str):
+        # 1. Exact module+class whitelist (highest priority, e.g. tight sinks)
+        allowed_names = self._ALLOWED.get(module)
+        if allowed_names is not None and name in allowed_names:
+            return super().find_class(module, name)
+
+        # 2. Module-prefix whitelist (broader allow, e.g. all supervisely.*)
+        if self._ALLOWED_MODULE_PREFIXES and any(
+            module == prefix or module.startswith(prefix + ".")
+            for prefix in self._ALLOWED_MODULE_PREFIXES
+        ):
+            return super().find_class(module, name)
+
+        raise pickle.UnpicklingError(
+            f"Blocked unsafe class during deserialization: {module}.{name}"
+        )
 
 
 def get_file_name(path: str) -> str:

--- a/supervisely/project/project.py
+++ b/supervisely/project/project.py
@@ -71,6 +71,7 @@ from supervisely.io.fs import (
     mkdir,
     silent_remove,
     subdirs_tree,
+    RestrictedUnpickler,
 )
 from supervisely.io.fs_cache import FileCache
 from supervisely.io.json import dump_json_file, dump_json_file_async, load_json_file
@@ -83,7 +84,7 @@ from supervisely.task.progress import tqdm_sly
 TF_BLOB_DIR = "blob-files"  # directory for project blob files in team files
 
 
-class CustomUnpickler(pickle.Unpickler):
+class CustomUnpickler(RestrictedUnpickler):
     """
     Custom Unpickler for loading pickled objects of the same class with differing definitions.
     Handles cases where a class object is reconstructed using a newer definition with additional fields

--- a/supervisely/project/project.py
+++ b/supervisely/project/project.py
@@ -57,6 +57,7 @@ from supervisely.collection.key_indexed_collection import (
 from supervisely.geometry.bitmap import Bitmap
 from supervisely.imaging import image as sly_image
 from supervisely.io.fs import (
+    BaseRestrictedUnpickler,
     clean_dir,
     copy_file,
     copy_file_async,
@@ -71,7 +72,6 @@ from supervisely.io.fs import (
     mkdir,
     silent_remove,
     subdirs_tree,
-    RestrictedUnpickler,
 )
 from supervisely.io.fs_cache import FileCache
 from supervisely.io.json import dump_json_file, dump_json_file_async, load_json_file
@@ -84,13 +84,24 @@ from supervisely.task.progress import tqdm_sly
 TF_BLOB_DIR = "blob-files"  # directory for project blob files in team files
 
 
-class CustomUnpickler(RestrictedUnpickler):
+class CustomUnpickler(BaseRestrictedUnpickler):
     """
     Custom Unpickler for loading pickled objects of the same class with differing definitions.
-    Handles cases where a class object is reconstructed using a newer definition with additional fields
-    or an outdated definition missing some fields.
-    Supports loading namedtuple objects with missing or extra fields.
+
+    Inherits the allowlist security mechanism from
+    :class:`~supervisely.io.fs.BaseRestrictedUnpickler` (CWE-502 mitigation) and
+    adds backward-compatibility handling for NamedTuple classes whose field set
+    has changed between SDK versions (missing or extra fields).
     """
+
+    # Modules allowed during deserialization of .bin project files.
+    _ALLOWED_MODULE_PREFIXES = (
+        "supervisely",
+        "builtins",
+        "collections",
+        "_collections",
+        "datetime",
+    )
 
     def __init__(self, file, **kwargs):
         """
@@ -105,7 +116,7 @@ class CustomUnpickler(RestrictedUnpickler):
 
     def find_class(self, module, name):
         prefix = "Pickled"
-        cls = super().find_class(module, name)
+        cls = super().find_class(module, name)  # * security check + class resolution
         if hasattr(cls, "_fields") and "Info" in cls.__name__:
             orig_new = cls.__new__
 


### PR DESCRIPTION
## Summary

Fixes two RCE vectors caused by unrestricted `pickle.load()` calls (CWE-502): auto-loaded `*_offsets.pkl` on `Project` open and crafted `.bin` files in `upload_bin()`.

Follows up on #1704 with a refactored implementation.
 Thanks to @aniketshirodkar for identifying the issue and the initial fix.

## Fix

Added `BaseRestrictedUnpickler` base class (`supervisely/io/fs.py`) enforcing a module/class allowlist in `find_class()` — raises `pickle.UnpicklingError` for anything outside it.

- `_BlobOffsetUnpickler` (image_api.py) — tight allowlist: `BlobImageInfo` + safe builtins only
- `CustomUnpickler` (project.py) — module-prefix allowlist: `supervisely.*`, `builtins`, `collections`, `datetime`; NamedTuple backward-compat logic unchanged