### PR TITLE
Fix FastTable broken on js-bundle 2.2.5 (lodash from window.sly) + search/listener fixes

### DIFF
--- a/supervisely/app/widgets/fast_table/script.js
+++ b/supervisely/app/widgets/fast_table/script.js
@@ -358,6 +358,10 @@ Vue.component('fast-table', {
   },
 
   computed: {
+    lodash() {
+      return (window.sly && window.sly.packages && window.sly.packages.lodash) || window._;
+    },
+
     canGoBack() {
       return this.page - 1 > 0;
     },
@@ -390,7 +394,7 @@ Vue.component('fast-table', {
     },
 
     classesMap() {
-      return this.projectMeta ? _.keyBy(this.projectMeta.classes, 'title') : {};
+      return this.projectMeta ? this.lodash.keyBy(this.projectMeta.classes, 'title') : {};
     },
 
     needsRightGradient() {
@@ -512,7 +516,7 @@ Vue.component('fast-table', {
             const key = this.rowKeyValue(r);
             if (!selectedIdx.has(key)) {
               if (quota <= 0) break;
-              result.push(_.cloneDeep(r));
+              result.push(this.lodash.cloneDeep(r));
               selectedIdx.add(key);
               quota -= 1;
             }
@@ -522,7 +526,7 @@ Vue.component('fast-table', {
           for (const r of this.data) {
             const key = this.rowKeyValue(r);
             if (!selectedIdx.has(key)) {
-              result.push(_.cloneDeep(r));
+              result.push(this.lodash.cloneDeep(r));
               selectedIdx.add(key);
             }
           }
@@ -560,7 +564,7 @@ Vue.component('fast-table', {
       if (checked) {
         if (max && max > 0) {
           if (max === 1) {
-            result = [_.cloneDeep(row)];
+            result = [this.lodash.cloneDeep(row)];
             this.$emit('update:selected-rows', result);
             return;
           }
@@ -570,7 +574,7 @@ Vue.component('fast-table', {
             return;
           }
         }
-        if (!exists) result = [...current, _.cloneDeep(row)];
+        if (!exists) result = [...current, this.lodash.cloneDeep(row)];
       } else {
         if (exists) result = current.filter(r => this.rowKeyValue(r) !== key);
       }
@@ -611,6 +615,6 @@ Vue.component('fast-table', {
   },
 
   created() {
-      this.updateData = _.debounce(this._updateData, 300);
+      this.updateData = this.lodash.debounce(this._updateData, 300);
   },
 });

--- a/supervisely/app/widgets/fast_table/script.js
+++ b/supervisely/app/widgets/fast_table/script.js
@@ -596,7 +596,8 @@ Vue.component('fast-table', {
 
     highlight(text) {
       if (!this.search) return text;
-      return text.toString().replace(new RegExp(this.search, 'gi'), match => '<span class="bg-yellow-400">'+match+'</span>');
+      const escaped = this.search.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+      return text.toString().replace(new RegExp(escaped, 'gi'), match => '<span class="bg-yellow-400">'+match+'</span>');
     },
 
     rowKeyValue(row) {
@@ -611,7 +612,7 @@ Vue.component('fast-table', {
   },
 
   beforeDestroy() {
-    this.$refs.scrollBox.addEventListener('scroll', this.handleScroll);
+    this.$refs.scrollBox.removeEventListener('scroll', this.handleScroll);
   },
 
   created() {


### PR DESCRIPTION
## Problem

FastTable was completely broken after the `js-bundle` bump `2.2.2 → 2.2.5` (#1692). The widget crashed on init/render with:

- `ReferenceError: _ is not defined` in `created()` (`_.debounce`)
- `ReferenceError: _ is not defined` in `classesMap` (`_.keyBy`) → render crash
- `TypeError: Cannot read properties of undefined (reading 'addEventListener')` in `mounted()` (cascade — `$refs.scrollBox` missing after failed render)

Symptoms reported: pagination stuck on page 1, search only highlights but doesn't filter rows, sorting broken. All of it was a side effect of the component crashing.

## Root cause

Bundle 2.2.5 removed the global lodash `_`; lodash now lives at `window.sly.packages.lodash` (same change the platform did in `index.html` in #1692). FastTable was the only widget still calling the bare global `_`.

## Changes

- Access lodash via a `lodash` computed alias: `window.sly.packages.lodash` with fallback to `window._`. Replaced all `_.keyBy/_.cloneDeep/_.debounce`.
- `highlight()`: escape regex special chars before `new RegExp` — fixes `SyntaxError` on input like `(` `[` `\` and false matches from `.`.
- `beforeDestroy()`: `removeEventListener` instead of `addEventListener` (was leaking scroll listeners on remount).

## Testing

Verified manually in Chrome on a 5000-row demo table:
- Render OK, no console errors on load or interaction
- Class column (the `classesMap` path that crashed) renders colors/shapes
- Pagination next/prev works (Rows 1-10 → 11-20)
- Sort toggles asc/desc and reorders
- Search filters rows (5000 → 661 for "apple") and highlights
- Search with `(` no longer throws; `.jpg` highlights literally