### PR TITLE
Fix multiple bugs in UI widgets: backend updates not reaching frontend in FastTable; always sync Select value; fix search/filter settings logic

### DIFF
--- a/supervisely/app/widgets/fast_table/fast_table.py
+++ b/supervisely/app/widgets/fast_table/fast_table.py
@@ -449,7 +449,13 @@ class FastTable(Widget):
             filter_function = self._default_filter_function
         self._filter_function = filter_function
 
-    def read_json(self, data: Dict, meta: Dict = None, custom_columns: Optional[List[Union[str, tuple]]] = None) -> None:
+    def read_json(
+        self,
+        data: Dict,
+        meta: Dict = None,
+        custom_columns: Optional[List[Union[str, tuple]]] = None,
+        reset_filters: bool = True,
+    ) -> None:
         """Replace table data with options and project meta in the widget
 
         More about options in `Developer Portal <https://developer.supervisely.com/app-development/widgets/tables/fasttable#read_json>`_
@@ -477,6 +483,10 @@ class FastTable(Widget):
         :type meta: dict
         :param custom_columns: List of column names. Can include widgets as tuples (column_name, widget)
         :type custom_columns: List[Union[str, tuple]], optional
+        :param reset_filters: If True (default), resets the search query and the
+            programmatic filter value. If False, both are kept and applied to
+            the new data immediately.
+        :type reset_filters: bool
 
         Example of data dict:
         .. code-block:: python
@@ -500,6 +510,7 @@ class FastTable(Widget):
                 },
             }
         """
+
         self._columns_options = self._prepare_json_data(data, "columnsOptions")
         self._read_custom_columns(custom_columns)
         if not self._columns_first_idx:
@@ -520,9 +531,10 @@ class FastTable(Widget):
         self._sort_order = sort.get("order", None)
         self._page_size = init_options.pop("pageSize", 10)
 
-        # reset search so the old query is not silently applied to the new data
-        self._search_str = ""
-        StateJson()[self.widget_id]["search"] = self._search_str
+        if reset_filters:
+            self._filter_value = None
+            self._search_str = ""
+            StateJson()[self.widget_id]["search"] = self._search_str
 
         self._filtered_data = self._filter(self._filter_value)
         self._searched_data = self._search(self._search_str)
@@ -548,16 +560,22 @@ class FastTable(Widget):
         DataJson().send_changes()
         StateJson().send_changes()
 
-    def read_pandas(self, data: pd.DataFrame) -> None:
+    def read_pandas(self, data: pd.DataFrame, reset_filters: bool = True) -> None:
         """Replace table data (rows and columns) in the widget.
 
         :param data: Table data
         :type data: pd.DataFrame
+        :param reset_filters: If True (default), resets the search query and the
+            programmatic filter value. If False, both are kept and applied to
+            the new data immediately.
+        :type reset_filters: bool
         """
+
         self._source_data = self._prepare_input_data(data)
-        # reset search so the old query is not silently applied to the new data
-        self._search_str = ""
-        StateJson()[self.widget_id]["search"] = self._search_str
+        if reset_filters:
+            self._filter_value = None
+            self._search_str = ""
+            StateJson()[self.widget_id]["search"] = self._search_str
         self._active_page = 1
         StateJson()[self.widget_id]["page"] = self._active_page
         self._filtered_data = self._filter(self._filter_value)

--- a/supervisely/app/widgets/fast_table/fast_table.py
+++ b/supervisely/app/widgets/fast_table/fast_table.py
@@ -813,8 +813,9 @@ class FastTable(Widget):
         )
 
         if len(self._parsed_source_data["data"]) != 0:
-            popped_row = self._source_data.loc[index].values
-            self._source_data = self._source_data.drop(index)
+            actual_label = self._source_data.index[index]
+            popped_row = self._source_data.iloc[index].values
+            self._source_data = self._source_data.drop(actual_label).reset_index(drop=True)
             (
                 self._parsed_source_data,
                 self._sliced_data,

--- a/supervisely/app/widgets/fast_table/fast_table.py
+++ b/supervisely/app/widgets/fast_table/fast_table.py
@@ -250,11 +250,6 @@ class FastTable(Widget):
         self._validate_input_data(data)
         self._source_data = self._prepare_input_data(data)
 
-        # Initialize filtered and searched data for proper initialization
-        self._filtered_data = self._filter(self._filter_value)
-        self._searched_data = self._search(self._search_str)
-        self._sorted_data = self._sort_table_data(self._searched_data)
-
         # prepare parsed_source_data, sliced_data, parsed_active_data
         (
             self._parsed_source_data,
@@ -774,7 +769,7 @@ class FastTable(Widget):
             self._sliced_data,
             self._parsed_active_data,
         ) = self._prepare_working_data()
-        self._rows_total = len(self._parsed_source_data["data"])
+        self._rows_total = len(self._searched_data)
         DataJson()[self.widget_id]["data"] = list(self._parsed_active_data["data"])
         DataJson()[self.widget_id]["total"] = self._rows_total
         DataJson().send_changes()
@@ -792,7 +787,7 @@ class FastTable(Widget):
             self._sliced_data,
             self._parsed_active_data,
         ) = self._prepare_working_data()
-        self._rows_total = len(self._parsed_source_data["data"])
+        self._rows_total = len(self._searched_data)
         DataJson()[self.widget_id]["data"] = list(self._parsed_active_data["data"])
         DataJson()[self.widget_id]["total"] = self._rows_total
         DataJson().send_changes()
@@ -821,7 +816,7 @@ class FastTable(Widget):
                 self._sliced_data,
                 self._parsed_active_data,
             ) = self._prepare_working_data()
-            self._rows_total = len(self._parsed_source_data["data"])
+            self._rows_total = len(self._searched_data)
             DataJson()[self.widget_id]["data"] = list(self._parsed_active_data["data"])
             DataJson()[self.widget_id]["total"] = self._rows_total
             DataJson().send_changes()
@@ -1162,7 +1157,12 @@ class FastTable(Widget):
 
     def _prepare_working_data(self):
         parsed_source_data = self._unpack_pandas_table_data(input_data=self._source_data)
-        sliced_data = self._slice_table_data(self._source_data, self._active_page)
+        # re-run the full pipeline so the active page respects current
+        # filter/search/sort instead of slicing raw source data
+        self._filtered_data = self._filter(self._filter_value)
+        self._searched_data = self._search(self._search_str)
+        self._sorted_data = self._sort_table_data(self._searched_data)
+        sliced_data = self._slice_table_data(self._sorted_data, self._active_page)
         parsed_active_data = self._unpack_pandas_table_data(sliced_data)
         return parsed_source_data, sliced_data, parsed_active_data
 

--- a/supervisely/app/widgets/fast_table/fast_table.py
+++ b/supervisely/app/widgets/fast_table/fast_table.py
@@ -520,17 +520,22 @@ class FastTable(Widget):
         self._sort_order = sort.get("order", None)
         self._page_size = init_options.pop("pageSize", 10)
 
-        # Apply sorting before preparing working data
-        self._sorted_data = self._sort_table_data(self._source_data)
+        # reset search so the old query is not silently applied to the new data
+        self._search_str = ""
+        StateJson()[self.widget_id]["search"] = self._search_str
+
+        self._filtered_data = self._filter(self._filter_value)
+        self._searched_data = self._search(self._search_str)
+        self._sorted_data = self._sort_table_data(self._searched_data)
         self._sliced_data = self._slice_table_data(self._sorted_data, actual_page=self._active_page)
         self._parsed_active_data = self._unpack_pandas_table_data(self._sliced_data)
         self._parsed_source_data = self._unpack_pandas_table_data(self._source_data)
-        self._rows_total = len(self._parsed_source_data["data"]) 
+        self._rows_total = len(self._searched_data)
         DataJson()[self.widget_id]["data"] = list(self._parsed_active_data["data"])
         DataJson()[self.widget_id]["columns"] = self._parsed_active_data["columns"]
         DataJson()[self.widget_id]["columnsOptions"] = self._columns_options
         DataJson()[self.widget_id]["options"] = init_options
-        DataJson()[self.widget_id]["total"] = len(self._source_data)
+        DataJson()[self.widget_id]["total"] = self._rows_total
         DataJson()[self.widget_id]["pageSize"] = self._page_size
         DataJson()[self.widget_id]["projectMeta"] = self._project_meta
         StateJson()[self.widget_id]["sort"]["column"] = self._sort_column_idx
@@ -538,9 +543,6 @@ class FastTable(Widget):
         StateJson()[self.widget_id]["page"] = self._active_page
         StateJson()[self.widget_id]["selectedRows"] = []
         StateJson()[self.widget_id]["selectedCell"] = None
-        # reset search so the old query is not silently applied to the new data
-        self._search_str = ""
-        StateJson()[self.widget_id]["search"] = self._search_str
         self._maybe_update_selected_row()
         self._validate_sort_attrs()
         DataJson().send_changes()
@@ -556,17 +558,19 @@ class FastTable(Widget):
         # reset search so the old query is not silently applied to the new data
         self._search_str = ""
         StateJson()[self.widget_id]["search"] = self._search_str
-        self._sorted_data = self._sort_table_data(self._source_data)
+        self._active_page = 1
+        StateJson()[self.widget_id]["page"] = self._active_page
+        self._filtered_data = self._filter(self._filter_value)
+        self._searched_data = self._search(self._search_str)
+        self._sorted_data = self._sort_table_data(self._searched_data)
         self._sliced_data = self._slice_table_data(self._sorted_data)
         self._parsed_active_data = self._unpack_pandas_table_data(self._sliced_data)
         self._parsed_source_data = self._unpack_pandas_table_data(self._source_data)
-        self._rows_total = len(self._parsed_source_data["data"])
+        self._rows_total = len(self._searched_data)
         DataJson()[self.widget_id]["data"] = list(self._parsed_active_data["data"])
         DataJson()[self.widget_id]["columns"] = self._parsed_active_data["columns"]
-        DataJson()[self.widget_id]["total"] = len(self._source_data)
+        DataJson()[self.widget_id]["total"] = self._rows_total
         DataJson().send_changes()
-        self._active_page = 1
-        StateJson()[self.widget_id]["page"] = self._active_page
         StateJson().send_changes()
         self.clear_selection()
 

--- a/supervisely/app/widgets/fast_table/fast_table.py
+++ b/supervisely/app/widgets/fast_table/fast_table.py
@@ -418,7 +418,7 @@ class FastTable(Widget):
     def page_size(self, size: int):
         self._page_size = size
         DataJson()[self.widget_id]["pageSize"] = self._page_size
-        DataJson().send_changes()
+        self._refresh()  # re-slice the active page for the new size
 
     def set_sort(
         self, func: Callable[[pd.DataFrame, int, Optional[Literal["asc", "desc"]]], pd.DataFrame]
@@ -538,6 +538,9 @@ class FastTable(Widget):
         StateJson()[self.widget_id]["page"] = self._active_page
         StateJson()[self.widget_id]["selectedRows"] = []
         StateJson()[self.widget_id]["selectedCell"] = None
+        # reset search so the old query is not silently applied to the new data
+        self._search_str = ""
+        StateJson()[self.widget_id]["search"] = self._search_str
         self._maybe_update_selected_row()
         self._validate_sort_attrs()
         DataJson().send_changes()
@@ -550,6 +553,9 @@ class FastTable(Widget):
         :type data: pd.DataFrame
         """
         self._source_data = self._prepare_input_data(data)
+        # reset search so the old query is not silently applied to the new data
+        self._search_str = ""
+        StateJson()[self.widget_id]["search"] = self._search_str
         self._sorted_data = self._sort_table_data(self._source_data)
         self._sliced_data = self._slice_table_data(self._sorted_data)
         self._parsed_active_data = self._unpack_pandas_table_data(self._sliced_data)
@@ -858,7 +864,7 @@ class FastTable(Widget):
         @server.post(row_clicked_route_path)
         def _click():
             try:
-                clicked_row = self.get_selected_row()
+                clicked_row = self.get_clicked_row()
                 if clicked_row is None:
                     return
                 func(clicked_row)
@@ -1398,7 +1404,12 @@ class FastTable(Widget):
             {"idx": idx, "row": selected_row.get("items", selected_row.get("row", None))}
         ]
         StateJson()[self.widget_id]["selectedRows"] = self._selected_rows
-        page = idx // self._page_size + 1
+        try:
+            # navigate to the page where the row is located in the current (sorted/filtered) view
+            position = self._sorted_data.index.get_loc(idx)
+        except (KeyError, AttributeError):
+            position = idx
+        page = position // self._page_size + 1
         if self._active_page != page:
             self._active_page = page
             StateJson()[self.widget_id]["page"] = self._active_page

--- a/supervisely/app/widgets/fast_table/fast_table.py
+++ b/supervisely/app/widgets/fast_table/fast_table.py
@@ -393,6 +393,7 @@ class FastTable(Widget):
         """
         self._fix_columns = self._validate_fix_columns_value(value)
         DataJson()[self.widget_id]["options"]["fixColumns"] = self._fix_columns
+        DataJson().send_changes()
 
     @property
     def project_meta(self) -> Dict[str, Any]:
@@ -412,6 +413,7 @@ class FastTable(Widget):
         """
         self._project_meta = self._unpack_project_meta(meta)
         DataJson()[self.widget_id]["projectMeta"] = self._project_meta
+        DataJson().send_changes()
 
     @property
     def page_size(self) -> int:
@@ -421,6 +423,7 @@ class FastTable(Widget):
     def page_size(self, size: int):
         self._page_size = size
         DataJson()[self.widget_id]["pageSize"] = self._page_size
+        DataJson().send_changes()
 
     def set_sort(
         self, func: Callable[[pd.DataFrame, int, Optional[Literal["asc", "desc"]]], pd.DataFrame]
@@ -820,6 +823,7 @@ class FastTable(Widget):
             self._rows_total = len(self._parsed_source_data["data"])
             DataJson()[self.widget_id]["data"] = list(self._parsed_active_data["data"])
             DataJson()[self.widget_id]["total"] = self._rows_total
+            DataJson().send_changes()
             self._maybe_update_selected_row()
             return popped_row
 
@@ -830,7 +834,7 @@ class FastTable(Widget):
         self._sliced_data = pd.DataFrame(columns=self._columns_first_idx)
         self._parsed_active_data = {"data": [], "columns": []}
         self._rows_total = 0
-        DataJson()[self.widget_id]["data"] = {}
+        DataJson()[self.widget_id]["data"] = []
         DataJson()[self.widget_id]["total"] = 0
         DataJson().send_changes()
         self._maybe_update_selected_row()
@@ -1060,6 +1064,7 @@ class FastTable(Widget):
         # Update DataJson with sorted and paginated data
         DataJson()[self.widget_id]["data"] = list(self._parsed_active_data["data"])
         DataJson()[self.widget_id]["total"] = self._rows_total
+        DataJson().send_changes()
         self._maybe_update_selected_row()
         StateJson().send_changes()
 

--- a/supervisely/app/widgets/fast_table/script.js
+++ b/supervisely/app/widgets/fast_table/script.js
@@ -582,7 +582,6 @@ Vue.component('fast-table', {
     },
 
     updateSelectedRadio(row) {
-      console.log('updateSelectedRadio', row);
       const clonedRow = JSON.parse(JSON.stringify(row));
       this.$emit('update:selected-rows', [clonedRow])
     },

--- a/supervisely/app/widgets/select/select.py
+++ b/supervisely/app/widgets/select/select.py
@@ -155,6 +155,7 @@ class Select(ConditionalWidget):
         self._filterable = filterable
         self._placeholder = placeholder
         self._changes_handled = False
+        self._value_changed_callback = None
         self._size = size
         self._multiple = multiple
         self._with_link = False
@@ -175,6 +176,16 @@ class Select(ConditionalWidget):
             self._links = {items[i].value: link for i, link in enumerate(items_links)}
 
         super().__init__(items=items, widget_id=widget_id, file_path=__file__)
+
+        # Always register the route: the frontend posts on every change, so the
+        # backend StateJson stays in sync and selection survives page reload.
+        route_path = self.get_route_path(Select.Routes.VALUE_CHANGED)
+        server = self._sly_app.get_server()
+
+        @server.post(route_path)
+        def _value_changed():
+            if self._value_changed_callback is not None:
+                self._value_changed_callback(self.get_value())
 
     def _get_first_value(self) -> Select.Item:
         if self._items is not None and len(self._items) > 0:
@@ -231,16 +242,9 @@ class Select(ConditionalWidget):
         return labels
 
     def value_changed(self, func):
-        route_path = self.get_route_path(Select.Routes.VALUE_CHANGED)
-        server = self._sly_app.get_server()
         self._changes_handled = True
-
-        @server.post(route_path)
-        def _click():
-            res = self.get_value()
-            func(res)
-
-        return _click
+        self._value_changed_callback = func
+        return func
 
     def get_items(self) -> List[Select.Item]:
         res = []

--- a/supervisely/app/widgets/select/template.html
+++ b/supervisely/app/widgets/select/template.html
@@ -1,8 +1,6 @@
 <el-select
   v-model="state.{{{widget.widget_id}}}.value"
-  {% if widget._changes_handled == true %}
   @change="post('/{{{widget.widget_id}}}/value_changed')"
-  {% endif %}
   {% if widget._size is not none %}
   :size="data.{{{widget.widget_id}}}.size"
   {% endif %}

--- a/tests/test_widget_fast_table.py
+++ b/tests/test_widget_fast_table.py
@@ -1394,10 +1394,9 @@ class TestFastTableLeftoverBugs:
         assert table._search_str == ""
         assert StateJson()[table.widget_id]["search"] == ""
 
-    def test_read_pandas_applies_filter_immediately(self):
-        """Programmatic filter must act on the new data right away, not on the
-        next user interaction (search is user input and is reset; filter is a
-        persistent app-level setting, like sort)."""
+    def test_read_pandas_resets_filter_by_default(self):
+        """Default reset_filters=True clears both the search query and the
+        programmatic filter value — new data arrives unfiltered."""
         from supervisely.app import DataJson
 
         table = FastTable(data=[[10], [20], [30], [40], [50]], columns=["v"])
@@ -1407,22 +1406,66 @@ class TestFastTableLeftoverBugs:
 
         table.read_pandas(pd.DataFrame([[1], [2], [30], [40]], columns=["v"]))
 
-        # filter is kept and already applied: 30 and 40 pass, 1 and 2 do not
-        assert table._rows_total == 2
-        assert DataJson()[table.widget_id]["total"] == 2
-        active = [r["items"][0] for r in table._parsed_active_data["data"]]
-        assert active == [30, 40]
+        assert table._filter_value is None
+        assert table._rows_total == 4
+        assert DataJson()[table.widget_id]["total"] == 4
         # no surprise on the next interaction
         table._refresh()
-        assert table._rows_total == 2
+        assert table._rows_total == 4
 
-    def test_read_json_applies_filter_immediately(self):
+    def test_read_pandas_keeps_filters_when_asked(self):
+        """reset_filters=False keeps search and filter and applies both to the
+        new data immediately, not on the next user interaction."""
+        from supervisely.app import DataJson
+        from supervisely.app.content import StateJson
+
+        table = FastTable(
+            data=[["fruit_10", 10], ["fruit_20", 20], ["car_30", 30], ["fruit_40", 40]],
+            columns=["name", "v"],
+        )
+        table.set_filter(lambda df, v: df if v is None else df[df[df.columns[1]] > v])
+        table.filter(15)
+        table.search("fruit")
+
+        table.read_pandas(
+            pd.DataFrame(
+                [["fruit_1", 1], ["fruit_30", 30], ["car_40", 40]], columns=["name", "v"]
+            ),
+            reset_filters=False,
+        )
+
+        # search is kept in the box and applied; filter is kept and applied
+        assert table._search_str == "fruit"
+        assert StateJson()[table.widget_id]["search"] == "fruit"
+        assert table._filter_value == 15
+        active = [r["items"][0] for r in table._parsed_active_data["data"]]
+        assert active == ["fruit_30"]  # fruit_1 fails filter, car_40 fails search
+        assert table._rows_total == 1
+        assert DataJson()[table.widget_id]["total"] == 1
+        # no surprise on the next interaction
+        table._refresh()
+        assert table._rows_total == 1
+
+    def test_read_json_resets_filter_by_default(self):
         table = FastTable(data=[[10], [20], [30]], columns=["v"])
         table.set_filter(lambda df, v: df if v is None else df[df[df.columns[0]] > v])
         table.filter(25)
 
         table.read_json({"data": [[1], [50]], "columns": ["v"], "options": {}})
 
+        assert table._filter_value is None
+        assert table._rows_total == 2
+
+    def test_read_json_keeps_filters_when_asked(self):
+        table = FastTable(data=[[10], [20], [30]], columns=["v"])
+        table.set_filter(lambda df, v: df if v is None else df[df[df.columns[0]] > v])
+        table.filter(25)
+
+        table.read_json(
+            {"data": [[1], [50]], "columns": ["v"], "options": {}}, reset_filters=False
+        )
+
+        assert table._filter_value == 25
         assert table._rows_total == 1
         active = [r["items"][0] for r in table._parsed_active_data["data"]]
         assert active == [50]

--- a/tests/test_widget_fast_table.py
+++ b/tests/test_widget_fast_table.py
@@ -1394,6 +1394,39 @@ class TestFastTableLeftoverBugs:
         assert table._search_str == ""
         assert StateJson()[table.widget_id]["search"] == ""
 
+    def test_read_pandas_applies_filter_immediately(self):
+        """Programmatic filter must act on the new data right away, not on the
+        next user interaction (search is user input and is reset; filter is a
+        persistent app-level setting, like sort)."""
+        from supervisely.app import DataJson
+
+        table = FastTable(data=[[10], [20], [30], [40], [50]], columns=["v"])
+        table.set_filter(lambda df, v: df if v is None else df[df[df.columns[0]] > v])
+        table.filter(25)
+        assert table._rows_total == 3
+
+        table.read_pandas(pd.DataFrame([[1], [2], [30], [40]], columns=["v"]))
+
+        # filter is kept and already applied: 30 and 40 pass, 1 and 2 do not
+        assert table._rows_total == 2
+        assert DataJson()[table.widget_id]["total"] == 2
+        active = [r["items"][0] for r in table._parsed_active_data["data"]]
+        assert active == [30, 40]
+        # no surprise on the next interaction
+        table._refresh()
+        assert table._rows_total == 2
+
+    def test_read_json_applies_filter_immediately(self):
+        table = FastTable(data=[[10], [20], [30]], columns=["v"])
+        table.set_filter(lambda df, v: df if v is None else df[df[df.columns[0]] > v])
+        table.filter(25)
+
+        table.read_json({"data": [[1], [50]], "columns": ["v"], "options": {}})
+
+        assert table._rows_total == 1
+        active = [r["items"][0] for r in table._parsed_active_data["data"]]
+        assert active == [50]
+
     def test_select_row_navigates_to_sorted_page(self):
         """select_row must compute the page from the row position in the sorted view."""
         table = FastTable(

--- a/tests/test_widget_fast_table.py
+++ b/tests/test_widget_fast_table.py
@@ -446,6 +446,20 @@ class TestFastTableDataFormats:
         assert table._rows_total == 2
         assert popped.tolist() == [5, 6]
 
+    def test_pop_row_repeated(self):
+        """pop_row must reset the dataframe index: dropping by label without
+        reset left a hole, so a second pop_row(0) raised KeyError."""
+        data = [[1, 2], [3, 4], [5, 6]]
+        table = FastTable(data=data, columns=["a", "b"])
+
+        first = table.pop_row(0)
+        second = table.pop_row(0)
+
+        assert first.tolist() == [1, 2]
+        assert second.tolist() == [3, 4]
+        assert table._rows_total == 1
+        assert table._source_data.index.tolist() == [0]
+
     def test_mixed_data_types_in_columns(self):
         """Test table with mixed data types (strings and numbers)."""
         data = [
@@ -936,6 +950,39 @@ class TestFastTableSorting:
         # Should be sorted on initialization
         sorted_df = table._sorted_data
         assert sorted_df.iloc[:, 0].tolist() == [1, 2, 5, 8]
+
+    def test_sort_on_init_with_dataframe(self):
+        """Active page must be sorted when sort params are passed to the
+        constructor with a DataFrame input. _prepare_working_data() used to
+        slice raw _source_data, so the page showed unsorted rows while the
+        sort arrow pointed at the column."""
+        df = pd.DataFrame([[5, "e"], [2, "b"], [8, "h"], [1, "a"]], columns=["num", "letter"])
+        table = FastTable(data=df, sort_column_idx=0, sort_order="desc", page_size=2)
+
+        active_rows = [r["items"][0] for r in table.get_json_data()["data"]]
+        assert active_rows == [8, 5]
+
+    def test_add_rows_keeps_sort(self):
+        """Row mutations must not revert the active page to unsorted order."""
+        data = [[5, "e"], [2, "b"], [8, "h"], [1, "a"]]
+        table = FastTable(data=data, columns=["num", "letter"])
+        table.sort(column_idx=0, order="desc")
+
+        table.add_rows([[9, "z"]])
+
+        active_rows = [r["items"][0] for r in table._parsed_active_data["data"]]
+        assert active_rows == [9, 8, 5, 2, 1]
+
+    def test_pop_row_keeps_sort(self):
+        """Removing a row must keep the active page sorted."""
+        data = [[5, "e"], [2, "b"], [8, "h"], [1, "a"]]
+        table = FastTable(data=data, columns=["num", "letter"])
+        table.sort(column_idx=0, order="desc")
+
+        table.pop_row(0)
+
+        active_rows = [r["items"][0] for r in table._parsed_active_data["data"]]
+        assert active_rows == [8, 2, 1]
 
     def test_sort_none_column_idx(self):
         """Test that passing None parameters without reset preserves current sorting."""

--- a/tests/test_widget_fast_table.py
+++ b/tests/test_widget_fast_table.py
@@ -1356,5 +1356,80 @@ class TestFastTableSorting:
         assert isinstance(sorted_df.iloc[0, 0], float)
 
 
+class TestFastTableLeftoverBugs:
+
+    def test_page_size_setter_reslices_data(self):
+        """page_size setter must re-slice the active page, not only send the new size."""
+        from supervisely.app import DataJson
+
+        table = FastTable(data=[[i, f"r{i}"] for i in range(1, 11)], columns=["id", "name"], page_size=10)
+
+        table.page_size = 5
+
+        assert len(DataJson()[table.widget_id]["data"]) == 5
+        assert DataJson()[table.widget_id]["total"] == 10
+
+    def test_read_pandas_resets_search(self):
+        """Old search must not be silently applied to the new data."""
+        from supervisely.app.content import StateJson
+
+        table = FastTable(data=[["fruit apple", 1], ["fruit pear", 2], ["car", 3]], columns=["name", "v"])
+        table.search("fruit")
+
+        table.read_pandas(pd.DataFrame([["x", 10], ["y", 20], ["z", 30]], columns=["name", "v"]))
+
+        assert table._search_str == ""
+        assert StateJson()[table.widget_id]["search"] == ""
+        table._refresh()
+        assert table._rows_total == 3
+
+    def test_read_json_resets_search(self):
+        from supervisely.app.content import StateJson
+
+        table = FastTable(data=[["fruit", 1], ["car", 2]], columns=["name", "v"])
+        table.search("fruit")
+
+        table.read_json({"data": [["x", 10], ["y", 20]], "columns": ["name", "v"], "options": {}})
+
+        assert table._search_str == ""
+        assert StateJson()[table.widget_id]["search"] == ""
+
+    def test_select_row_navigates_to_sorted_page(self):
+        """select_row must compute the page from the row position in the sorted view."""
+        table = FastTable(
+            data=[[i, f"r{i}"] for i in range(1, 10)], columns=["id", "name"],
+            page_size=3, is_selectable=True,
+        )
+        table.sort(column_idx=0, order="desc")
+
+        table.select_row(0)  # id=1 -> sorted position 8 -> page 3
+
+        assert table._active_page == 3
+        page_ids = [r["items"][0] for r in table._parsed_active_data["data"]]
+        assert 1 in page_ids
+
+    def test_row_click_with_multiselect(self):
+        """row_click handler must use get_clicked_row(): with 2+ rows checked
+        get_selected_row() raised ValueError -> HTTP 500."""
+        from supervisely.app.content import StateJson
+
+        table = FastTable(data=[[i, f"r{i}"] for i in range(1, 5)], columns=["id", "name"], is_selectable=True)
+        received = []
+
+        @table.row_click
+        def _handler(row):
+            received.append((row.row_index, row.row))
+
+        table.select_rows([0, 1])
+        server = table._sly_app.get_server()
+        route = table.get_route_path(FastTable.Routes.ROW_CLICKED)
+        endpoint = next(r.endpoint for r in server.routes if getattr(r, "path", None) == route)
+        StateJson()[table.widget_id]["clickedRow"] = {"idx": 2, "row": [3, "r3"]}
+
+        endpoint()  # must not raise
+
+        assert received == [(2, [3, "r3"])]
+
+
 if __name__ == "__main__":
     pytest.main([__file__, "-v"])


### PR DESCRIPTION
**FastTable**: 

- bug: `sort()`, `pop_row()` and the `fixed_columns_num`/`project_meta`/`page_size` setters updated DataJson without calling `DataJson().send_changes()`, so backend changes reached the frontend only after a page reload.
  - fix: added the missing send_changes(). 
- bug: KeyError in row removal logic (`.drop()`)
  - fix: use actual index label for dropping rows `.reset_index(drop=True)`
- bug:  initial page shows unsorted data
  - fix: update `_prepare_working_data()` to sort/filter data after row mutations
- bug: `page_size` setter updated the label but the table still showed old rows
  - fix: re-slice the active page via `_refresh()`
- bug: `read_pandas()`/`read_json()` kept the old search query and silently applied it to the new data
  - fix: reset search string and `StateJson` search on data reload
- bug: `select_row()` navigated to the wrong page when the table is sorted
  - fix: compute the page from the row position in the sorted view
- bug: `row_click` callback crashed with HTTP 500 when 2+ rows are checked (`ValueError: Multiple rows selected`)
  - fix: use `get_clicked_row()` instead of `get_selected_row()`

---
**Select**: 
- bug: `@change` was posted only when a `value_changed` callback was subscribed, so without it the selected value never reached backend StateJson and was lost on page reload.
  - fix: the route is now always registered and the frontend posts on every change.
