### PR TITLE
Add labeling_job.get_info_by_ids and get_list(with_entities=True)

### DIFF
--- a/supervisely/_utils.py
+++ b/supervisely/_utils.py
@@ -580,6 +580,24 @@ def get_or_create_event_loop() -> asyncio.AbstractEventLoop:
             return loop
 
 
+def is_event_loop_running() -> bool:
+    """
+    Check whether an asyncio event loop is currently running in the calling thread.
+
+    Unlike :func:`get_or_create_event_loop`, this function has no side effects: it never
+    creates a loop. It is useful to decide whether it is safe to block on a coroutine via
+    :func:`run_coroutine` (blocking on a loop that runs in the current thread would deadlock).
+
+    :returns: True if an event loop is running in the current thread, False otherwise.
+    :rtype: bool
+    """
+    try:
+        asyncio.get_running_loop()
+        return True
+    except RuntimeError:
+        return False
+
+
 def run_coroutine(coroutine):
     """
     Runs an asynchronous coroutine in a synchronous context and waits for its result.

--- a/supervisely/api/api.py
+++ b/supervisely/api/api.py
@@ -413,6 +413,7 @@ class Api:
         self.async_httpx_client: httpx.AsyncClient = None
         self.httpx_client: httpx.Client = None
         self._semaphore = None
+        self._semaphore_size = None  # configured size of the global semaphore
         self._instance_version = None
         self._version_check_completed = False
         self._version_check_lock = threading.Lock()
@@ -1693,7 +1694,7 @@ class Api:
         Set async httpx client with HTTP/2 if it is not set yet.
         """
         if self.async_httpx_client is None:
-            semaphore_size = self.get_default_semaphore()._value
+            semaphore_size = self.get_default_semaphore_size()
             limits = httpx.Limits(
                 max_connections=semaphore_size + 2,
                 max_keepalive_connections=semaphore_size,
@@ -1706,7 +1707,7 @@ class Api:
         Set sync httpx client with HTTP/2 if it is not set yet.
         """
         if self.httpx_client is None:
-            semaphore_size = self.get_default_semaphore()._value
+            semaphore_size = self.get_default_semaphore_size()
             limits = httpx.Limits(
                 max_connections=semaphore_size + 2,
                 max_keepalive_connections=semaphore_size,
@@ -1818,9 +1819,9 @@ class Api:
         """
         semaphore_size = sly_env.semaphore_size()
         if semaphore_size is not None:
-            self._semaphore = asyncio.Semaphore(semaphore_size)
+            size = semaphore_size
             logger.debug(
-                f"Setting global API semaphore size to {semaphore_size} from environment variable"
+                f"Setting global API semaphore size to {size} from environment variable"
             )
         else:
             if not self._skip_https_redirect_check:
@@ -1833,7 +1834,8 @@ class Api:
             else:
                 size = 5
                 logger.debug(f"Setting global API semaphore size to {size} for HTTP")
-            self._semaphore = asyncio.Semaphore(size)
+        self._semaphore = asyncio.Semaphore(size)
+        self._semaphore_size = size
 
     def set_semaphore_size(self, size: int = None):
         """
@@ -1846,8 +1848,24 @@ class Api:
         """
         if size is not None:
             self._semaphore = asyncio.Semaphore(size)
+            self._semaphore_size = size
         else:
             self._initialize_semaphore()
+
+    def get_default_semaphore_size(self) -> int:
+        """
+        Get the configured size of the global API semaphore (the number of permits it was
+        created with), as opposed to ``get_default_semaphore()._value`` which reflects the
+        currently available permits and may be lower while requests are in-flight.
+
+        Initializes the semaphore if it has not been created yet.
+
+        :returns: Configured semaphore size.
+        :rtype: int
+        """
+        if self._semaphore is None:
+            self._initialize_semaphore()
+        return self._semaphore_size
 
     @property
     def semaphore(self) -> asyncio.Semaphore:

--- a/supervisely/api/labeling_job_api.py
+++ b/supervisely/api/labeling_job_api.py
@@ -4,7 +4,9 @@
 # docs
 from __future__ import annotations
 
+import asyncio
 import time
+from concurrent.futures import ThreadPoolExecutor
 from typing import (
     TYPE_CHECKING,
     Callable,
@@ -29,6 +31,7 @@ from supervisely.annotation.label import Label
 from supervisely.annotation.tag import Tag
 from supervisely.api.entity_annotation.figure_api import FigureInfo
 from supervisely.api.image_api import ImageInfo
+from supervisely._utils import is_event_loop_running, run_coroutine
 from supervisely.api.module_api import (
     ApiField,
     ModuleApi,
@@ -574,6 +577,7 @@ class LabelingJobApi(RemoveableBulkModuleApi, ModuleWithStatus):
         exclude_statuses: Optional[
             List[Literal["pending", "in_progress", "on_review", "completed"]]
         ] = None,
+        with_entities: bool = False,
     ) -> List[LabelingJobInfo]:
         """
         Get list of information about Labeling Job in the given Team.
@@ -598,6 +602,13 @@ class LabelingJobApi(RemoveableBulkModuleApi, ModuleWithStatus):
         :type queue_ids: Union[List, int], optional
         :param exclude_statuses: Exclude Labeling Jobs with given statuses.
         :type exclude_statuses: List[Literal["pending", "in_progress", "on_review", "completed"]], optional
+        :param with_entities: If True, the ``entities`` field of each LabelingJobInfo will be populated.
+                              The ``jobs.list`` method does not return entities, so for each job an additional
+                              ``jobs.info`` request is made. These requests run concurrently, limited by the
+                              global API semaphore (see :func:`~supervisely.api.api.Api.get_default_semaphore`).
+                              When enabled, the list request itself only fetches job IDs to avoid downloading
+                              the full info twice.
+        :type with_entities: bool, optional
         :returns: List of LabelingJobInfo objects with information about Labeling Jobs.
         :rtype: List[:class:`~supervisely.api.labeling_job_api.LabelingJobInfo`]
 
@@ -737,10 +748,74 @@ class LabelingJobApi(RemoveableBulkModuleApi, ModuleWithStatus):
             )
         if exclude_statuses is not None:
             filters.append({"field": ApiField.STATUS, "operator": "!in", "value": exclude_statuses})
-        return self.get_list_all_pages(
-            "jobs.list",
-            {ApiField.TEAM_ID: team_id, "showDisabled": show_disabled, ApiField.FILTER: filters},
+
+        data = {
+            ApiField.TEAM_ID: team_id,
+            "showDisabled": show_disabled,
+            ApiField.FILTER: filters,
+        }
+
+        if not with_entities:
+            return self.get_list_all_pages("jobs.list", data)
+
+        # `jobs.list` does not return entities, so we only fetch job IDs here
+        # (to avoid downloading the full info twice) and then enrich each job
+        # with a `jobs.info` request via :func:`get_info_by_ids`.
+        data[ApiField.FIELDS] = [ApiField.ID]
+        job_ids = self.get_list_all_pages(
+            "jobs.list", data, convert_json_info_cb=lambda info: info[ApiField.ID]
         )
+        return self.get_info_by_ids(job_ids)
+
+    async def _get_info_by_ids_async(
+        self, ids: List[int], semaphore: Optional[asyncio.Semaphore] = None
+    ) -> List[LabelingJobInfo]:
+        """
+        Concurrently fetch full LabelingJobInfo for the given job IDs via the ``jobs.info`` method,
+        using asynchronous HTTP/2 requests limited by the global API semaphore. The order of the
+        input IDs is preserved in the returned list.
+
+        :param ids: Labeling Job IDs in Supervisely.
+        :type ids: List[int]
+        :param semaphore: Semaphore for limiting the number of simultaneous requests.
+                          Defaults to the global API semaphore.
+        :type semaphore: :class:`asyncio.Semaphore`, optional
+        :returns: List of LabelingJobInfo objects in the same order as the input IDs.
+        :rtype: List[:class:`~supervisely.api.labeling_job_api.LabelingJobInfo`]
+        """
+        if semaphore is None:
+            semaphore = self._api.get_default_semaphore()
+
+        async def _fetch(job_id: int) -> LabelingJobInfo:
+            async with semaphore:
+                response = await self._api.post_async("jobs.info", {ApiField.ID: job_id})
+            return self._convert_json_info(response.json())
+
+        return await asyncio.gather(*[_fetch(job_id) for job_id in ids])
+
+    def _get_info_by_ids_threaded(
+        self, ids: List[int], max_workers: Optional[int] = None
+    ) -> List[LabelingJobInfo]:
+        """
+        Concurrently fetch full LabelingJobInfo for the given job IDs via the ``jobs.info`` method
+        using a thread pool of blocking :func:`get_info_by_id` calls. The order of the input IDs is
+        preserved in the returned list.
+
+        :param ids: Labeling Job IDs in Supervisely.
+        :type ids: List[int]
+        :param max_workers: Maximum number of concurrent requests. Defaults to the global API
+                            semaphore size (see :func:`~supervisely.api.api.Api.get_default_semaphore`).
+        :type max_workers: int, optional
+        :returns: List of LabelingJobInfo objects in the same order as the input IDs.
+        :rtype: List[:class:`~supervisely.api.labeling_job_api.LabelingJobInfo`]
+        """
+        if not ids:
+            return []
+        if max_workers is None:
+            max_workers = self._api.get_default_semaphore()._value
+        max_workers = max(1, min(max_workers, len(ids)))
+        with ThreadPoolExecutor(max_workers=max_workers) as executor:
+            return list(executor.map(self.get_info_by_id, ids))
 
     def stop(self, id: int) -> None:
         """
@@ -856,6 +931,80 @@ class LabelingJobApi(RemoveableBulkModuleApi, ModuleWithStatus):
                 # ]
         """
         return self._get_info_by_id(id, "jobs.info")
+
+    def get_info_by_ids(self, ids: List[int]) -> List[LabelingJobInfo]:
+        """
+        Get information about multiple Labeling Jobs by their IDs in a single call.
+
+        This is a fast, drop-in alternative to calling :func:`get_info_by_id` in a loop:
+        the ``jobs.info`` requests are issued concurrently while preserving the order of the
+        input IDs in the returned list. 
+
+        The method is safe to call from any context (sync scripts, app handlers, or inside a
+        running asyncio loop). It uses a layered strategy that always degrades on infrastructure
+        (event loop / asyncio / thread pool) failures instead of raising. Genuine API errors are not masked.
+
+            1. Asynchronous requests over HTTP/2, limited by the global API semaphore. 
+               Skipped when an event loop is already running in the current thread, 
+               and abandoned on any event-loop/asyncio failure.
+            2. A thread pool of blocking :func:`get_info_by_id` calls. 
+               Abandoned only on thread-pool infrastructure errors.
+            3. Plain sequential :func:`get_info_by_id` calls.
+
+        :param ids: Labeling Job IDs in Supervisely.
+        :type ids: List[int]
+        :returns: List of LabelingJobInfo objects in the same order as the input IDs.
+        :rtype: List[:class:`~supervisely.api.labeling_job_api.LabelingJobInfo`]
+
+        :Usage Example:
+
+            .. code-block:: python
+
+                import os
+                from dotenv import load_dotenv
+
+                import supervisely as sly
+
+                # Load secrets and create API object from .env file (recommended)
+                # Learn more here: https://developer.supervisely.com/getting-started/basics-of-authentication
+                if sly.is_development():
+                    load_dotenv(os.path.expanduser("~/supervisely.env"))
+
+                api = sly.Api.from_env()
+
+                job_infos = api.labeling_job.get_info_by_ids([2, 3, 5])
+                print([job.id for job in job_infos])
+                # Output: [2, 3, 5]
+        """
+        if not ids:
+            return []
+
+        # 1. Fast path: async + HTTP/2 over the global API semaphore.
+        # `run_coroutine` would deadlock if a loop is already running in this
+        # thread (a deadlock cannot be caught), so skip the async path entirely
+        # in that case. Any event-loop/asyncio failure falls back to threads.
+        if not is_event_loop_running():
+            try:
+                return run_coroutine(self._get_info_by_ids_async(ids))
+            except Exception as e:
+                logger.debug(
+                    f"Async fetch of labeling job info failed ({e!r}), "
+                    "falling back to threaded fetch."
+                )
+
+        # 2. Reliable path: thread pool of blocking `get_info_by_id` calls.
+        # Same transport as the sequential fallback, so only thread-pool
+        # infrastructure errors (not API errors) warrant degrading further.
+        try:
+            return self._get_info_by_ids_threaded(ids)
+        except RuntimeError as e:
+            logger.debug(
+                f"Threaded fetch of labeling job info failed ({e!r}), "
+                "falling back to sequential fetch."
+            )
+
+        # 3. Last resort: plain sequential requests, free of any concurrency machinery.
+        return [self.get_info_by_id(job_id) for job_id in ids]
 
     def archive(self, id: int) -> None:
         """

--- a/supervisely/api/labeling_job_api.py
+++ b/supervisely/api/labeling_job_api.py
@@ -813,8 +813,8 @@ class LabelingJobApi(RemoveableBulkModuleApi, ModuleWithStatus):
 
         :param ids: Labeling Job IDs in Supervisely.
         :type ids: List[int]
-        :param max_workers: Maximum number of concurrent requests. Defaults to the global API
-                            semaphore size (see :func:`~supervisely.api.api.Api.get_default_semaphore`).
+        :param max_workers: Maximum number of concurrent requests. Defaults to the configured global
+                            API semaphore size (see :func:`~supervisely.api.api.Api.get_default_semaphore_size`).
         :type max_workers: int, optional
         :returns: List of LabelingJobInfo objects in the same order as the input IDs.
         :rtype: List[:class:`~supervisely.api.labeling_job_api.LabelingJobInfo`]
@@ -822,7 +822,7 @@ class LabelingJobApi(RemoveableBulkModuleApi, ModuleWithStatus):
         if not ids:
             return []
         if max_workers is None:
-            max_workers = self._api.get_default_semaphore()._value
+            max_workers = self._api.get_default_semaphore_size()
         max_workers = max(1, min(max_workers, len(ids)))
         with ThreadPoolExecutor(max_workers=max_workers) as executor:
             return list(executor.map(self.get_info_by_id, ids))

--- a/supervisely/api/labeling_job_api.py
+++ b/supervisely/api/labeling_job_api.py
@@ -23,6 +23,7 @@ from tqdm import tqdm
 if TYPE_CHECKING:
     from pandas.core.frame import DataFrame
 
+import httpx
 import requests
 
 from supervisely.annotation.annotation import Annotation
@@ -760,12 +761,13 @@ class LabelingJobApi(RemoveableBulkModuleApi, ModuleWithStatus):
 
         # `jobs.list` does not return entities, so we only fetch job IDs here
         # (to avoid downloading the full info twice) and then enrich each job
-        # with a `jobs.info` request via :func:`get_info_by_ids`.
+        # with a `jobs.info` request via :func:`get_info_by_ids`. Jobs removed
+        # between listing and enrichment yield None and are dropped from the result.
         data[ApiField.FIELDS] = [ApiField.ID]
         job_ids = self.get_list_all_pages(
             "jobs.list", data, convert_json_info_cb=lambda info: info[ApiField.ID]
         )
-        return self.get_info_by_ids(job_ids)
+        return [info for info in self.get_info_by_ids(job_ids) if info is not None]
 
     async def _get_info_by_ids_async(
         self, ids: List[int], semaphore: Optional[asyncio.Semaphore] = None
@@ -786,9 +788,17 @@ class LabelingJobApi(RemoveableBulkModuleApi, ModuleWithStatus):
         if semaphore is None:
             semaphore = self._api.get_default_semaphore()
 
-        async def _fetch(job_id: int) -> LabelingJobInfo:
+        async def _fetch(job_id: int) -> Optional[LabelingJobInfo]:
             async with semaphore:
-                response = await self._api.post_async("jobs.info", {ApiField.ID: job_id})
+                try:
+                    response = await self._api.post_async("jobs.info", {ApiField.ID: job_id})
+                except httpx.HTTPStatusError as e:
+                    # Mirror the sync `_get_response_by_id` behaviour: a job that was
+                    # removed/archived (or is not accessible) between listing and this
+                    # call returns 404 -> None instead of failing the whole batch.
+                    if e.response is not None and e.response.status_code == 404:
+                        return None
+                    raise
             return self._convert_json_info(response.json())
 
         return await asyncio.gather(*[_fetch(job_id) for job_id in ids])
@@ -932,13 +942,16 @@ class LabelingJobApi(RemoveableBulkModuleApi, ModuleWithStatus):
         """
         return self._get_info_by_id(id, "jobs.info")
 
-    def get_info_by_ids(self, ids: List[int]) -> List[LabelingJobInfo]:
+    def get_info_by_ids(self, ids: List[int]) -> List[Optional[LabelingJobInfo]]:
         """
         Get information about multiple Labeling Jobs by their IDs in a single call.
 
         This is a fast, drop-in alternative to calling :func:`get_info_by_id` in a loop:
         the ``jobs.info`` requests are issued concurrently while preserving the order of the
-        input IDs in the returned list. 
+        input IDs in the returned list. Consistently with :func:`get_info_by_id`, an ID that is
+        not accessible (the job was removed/archived or you lack permissions) yields ``None`` at
+        its position instead of raising, so a job deleted between listing and this call does not
+        break the whole batch.
 
         The method is safe to call from any context (sync scripts, app handlers, or inside a
         running asyncio loop). It uses a layered strategy that always degrades on infrastructure
@@ -953,8 +966,9 @@ class LabelingJobApi(RemoveableBulkModuleApi, ModuleWithStatus):
 
         :param ids: Labeling Job IDs in Supervisely.
         :type ids: List[int]
-        :returns: List of LabelingJobInfo objects in the same order as the input IDs.
-        :rtype: List[:class:`~supervisely.api.labeling_job_api.LabelingJobInfo`]
+        :returns: List in the same order as the input IDs; an element is ``None`` if the
+                  corresponding job is not accessible.
+        :rtype: List[Optional[:class:`~supervisely.api.labeling_job_api.LabelingJobInfo`]]
 
         :Usage Example:
 


### PR DESCRIPTION
## What

- New public method `api.labeling_job.get_info_by_ids(ids)` — fetches full
  `LabelingJobInfo` for many jobs at once (with `entities` populated),
  preserving input order. A fast drop-in alternative to looping over
  `get_info_by_id`.
- New `with_entities` flag on `get_list()` — populates the `entities` field
  of each job (which `jobs.list` does not return) by enriching results via
  `get_info_by_ids`. To avoid downloading full info twice, the list request
  only fetches job IDs.
- New `is_event_loop_running()` helper in `supervisely/_utils.py`.
- New `Api.get_default_semaphore_size()` + `Api._semaphore_size` tracking the
  configured semaphore size.

## Why

Previously, getting entities for jobs required a separate `get_info_by_id`
call per job. On a team with ~250 jobs that was ~28s sequentially; the new
path is ~1.7s.

## How `get_info_by_ids` behaves

It uses a layered strategy that always degrades on infrastructure (event
loop / asyncio / thread pool) failures instead of raising, so it never breaks
due to Python-side concurrency issues, while genuine API errors still
propagate:

1. Async + HTTP/2, limited by the global API semaphore (fastest; respects
   the global concurrency limit). Skipped when a loop is already running in
   the current thread to avoid a deadlock.
2. Thread pool of blocking `get_info_by_id` calls.
3. Plain sequential `get_info_by_id`.

Safe to call from sync scripts, app handlers, and inside a running asyncio
loop.

## Deleted / inaccessible jobs

A job removed or archived between listing and the `jobs.info` call returns
404. Consistently with `get_info_by_id`, this now yields `None` instead of
raising:
- `_get_info_by_ids_async` maps 404 to `None` (mirroring sync
  `_get_response_by_id`), so a deleted job no longer fails the whole batch or
  forces a fallback to threads.
- `get_info_by_ids` returns `List[Optional[LabelingJobInfo]]`, consistent
  across the async, threaded and sequential paths.
- `get_list(with_entities=True)` drops `None` entries so removed jobs do not
  appear in the result.

## Configured semaphore size (fixes a latent `_value` bug)

`asyncio.Semaphore._value` is the count of *currently available* permits, not
the configured size. While async requests are in-flight it drops below the
configured value (down to 0), so code using it as the default concurrency was
silently degraded:
- `_set_async_client` / `_set_client` sized the httpx connection pool from
  `_value`. Since the client is created lazily on the first (often already
  concurrent) request and cached for its whole lifetime, the pool could be
  pinned to `max_connections=2` / `max_keepalive_connections=0`, permanently
  disabling keep-alive and HTTP/2 connection reuse.
- the labeling-job thread pool could clamp down to as few as 1 worker.

`Api` now stores the configured size in `self._semaphore_size` whenever the
semaphore is created and exposes it via `get_default_semaphore_size()`; these
call sites use it instead of the live `_value`.