### PR TITLE
Fix unreliable jsonpatch diff corrupting DataJson/StateJson sync

### DIFF
--- a/supervisely/app/content.py
+++ b/supervisely/app/content.py
@@ -14,6 +14,7 @@ from concurrent.futures import ThreadPoolExecutor
 from typing import Optional, Union
 
 import jsonpatch
+import jsonpointer
 from fastapi import Request
 
 from supervisely._utils import is_production
@@ -116,7 +117,40 @@ class _PatchableJson(dict):
 
     def _get_patch(self):
         patch = jsonpatch.JsonPatch.from_diff(self._last, self)
-        return patch
+        # `jsonpatch.from_diff` (its DiffBuilder, since jsonpatch 1.24) folds an
+        # add and a value-equal remove into a single `move` even across unrelated
+        # subtrees, and rewrites list-index ops while doing so. For payloads that
+        # replace several sibling lists at once and share many equal scalars
+        # (e.g. FastTable's `columns` / `columnsOptions` list-of-dicts / `data`
+        # rows), the resulting patch can fail to apply (JsonPatchConflict /
+        # "list index out of range") or silently produce the wrong document.
+        # Set iteration order of dict keys makes which case is hit depend on
+        # PYTHONHASHSEED, so it surfaces intermittently. Verify the patch
+        # reproduces the current state; if not, fall back to an explicit
+        # per-top-level-key replace, which is always self-consistent.
+        try:
+            check = copy.deepcopy(self._last)
+            patch.apply(check, in_place=True)
+            if check == dict(self):
+                return patch
+        except Exception:
+            pass
+        return self._build_safe_patch()
+
+    def _build_safe_patch(self):
+        current = dict(self)
+        ops = []
+        for key in self._last:
+            if key not in current:
+                path = jsonpointer.JsonPointer.from_parts([key]).path
+                ops.append({"op": "remove", "path": path})
+        for key, value in current.items():
+            path = jsonpointer.JsonPointer.from_parts([key]).path
+            if key not in self._last:
+                ops.append({"op": "add", "path": path, "value": copy.deepcopy(value)})
+            elif self._last[key] != value:
+                ops.append({"op": "replace", "path": path, "value": copy.deepcopy(value)})
+        return jsonpatch.JsonPatch(ops)
 
     async def _apply_patch(self, patch):
         async with async_lock(self._lock):

--- a/tests/unit/test_content_patch.py
+++ b/tests/unit/test_content_patch.py
@@ -1,0 +1,155 @@
+"""
+Regression tests for `_PatchableJson._get_patch` (supervisely/app/content.py).
+
+Background
+----------
+`jsonpatch.JsonPatch.from_diff` (its DiffBuilder, since jsonpatch 1.24) folds an
+`add` and a value-equal `remove` into a single `move` even across unrelated
+subtrees, rewriting list-index operations as it goes. For payloads that replace
+several sibling lists at once and share many equal scalar values — exactly what
+`FastTable.read_json` produces (`columns` / `columnsOptions` list-of-dicts /
+`data` rows) — the generated patch can either fail to apply
+(`JsonPatchConflict` / "list index out of range") or silently apply to the
+*wrong* document. Which case is hit depends on dict-key set-iteration order,
+i.e. on `PYTHONHASHSEED`, so in production it surfaces intermittently.
+
+`_get_patch` must therefore guarantee one invariant regardless of what
+`from_diff` returns:
+
+    applying the returned patch to `_last` reproduces the current state exactly.
+"""
+
+import copy
+import random
+
+import jsonpatch
+import pytest
+
+from supervisely.app.content import DataJson
+
+
+@pytest.fixture
+def data_json():
+    d = DataJson()
+    d.clear()
+    d._last = {}
+    yield d
+    d.clear()
+    d._last = {}
+
+
+def _roundtrip(d):
+    """Apply the patch _get_patch() returns to _last and return the result."""
+    patch = d._get_patch()
+    result = copy.deepcopy(d._last)
+    patch.apply(result, in_place=True)
+    return result
+
+
+def _set(d, content):
+    d.clear()
+    d.update(copy.deepcopy(content))
+
+
+def test_get_patch_roundtrips_on_schema_change(data_json):
+    """The exact FastTable.read_json scenario: replace columns / columnsOptions /
+    data wholesale (different schema)."""
+    d = data_json
+    _set(d, {
+        "tbl": {
+            "columns": ["Run", "AUC (Part)", "Notes"],
+            "columnsOptions": [{"tooltip": "run name"}, {"postfix": "%", "maxValue": 100}, {"subtitle": "free"}],
+            "data": [{"items": ["r1", 90, "a"]}, {"items": ["r2", 80, "b"]}],
+            "total": 2,
+            "pageSize": 10,
+        }
+    })
+    d._last = copy.deepcopy(dict(d))
+    _set(d, {
+        "tbl": {
+            "columns": ["Run", "Multi-threshold score", "AUC (Part)", "Extra"],
+            "columnsOptions": [{}, {"postfix": "%"}, {"postfix": "%", "maxValue": 100}, {"tooltip": "extra"}],
+            "data": [{"items": ["r1", 70, 90, "x"]}],
+            "total": 1,
+            "pageSize": 10,
+        }
+    })
+    assert _roundtrip(d) == dict(d)
+
+
+def test_get_patch_roundtrips_when_from_diff_is_broken(monkeypatch, data_json):
+    """Deterministic guard (independent of PYTHONHASHSEED): if `from_diff`
+    returns a patch that does not reproduce the current state, `_get_patch`
+    must fall back to a correct one instead of propagating the bad patch."""
+    d = data_json
+    _set(d, {"tbl": {"columnsOptions": [{"tooltip": "a"}, {"type": "class"}], "total": 1}})
+    d._last = copy.deepcopy(dict(d))
+    _set(d, {"tbl": {"columnsOptions": [{"type": "class"}], "total": 2}})
+
+    # Force from_diff to return a deliberately broken patch: a remove of a key
+    # that does not exist after the preceding op — the real-world failure shape.
+    broken = jsonpatch.JsonPatch([
+        {"op": "remove", "path": "/tbl/columnsOptions/0"},
+        {"op": "remove", "path": "/tbl/columnsOptions/1/type"},  # index already shifted -> invalid
+    ])
+    monkeypatch.setattr(jsonpatch.JsonPatch, "from_diff", classmethod(lambda cls, *a, **k: broken))
+
+    patch = d._get_patch()
+    result = copy.deepcopy(d._last)
+    patch.apply(result, in_place=True)  # must not raise
+    assert result == dict(d)            # and must be correct
+
+
+def test_get_patch_uses_compact_diff_when_valid(monkeypatch, data_json):
+    """When from_diff yields a valid patch, it is used as-is (no fallback)."""
+    d = data_json
+    _set(d, {"tbl": {"total": 1}})
+    d._last = copy.deepcopy(dict(d))
+    _set(d, {"tbl": {"total": 2}})
+
+    sentinel = jsonpatch.JsonPatch([{"op": "replace", "path": "/tbl/total", "value": 2}])
+    monkeypatch.setattr(jsonpatch.JsonPatch, "from_diff", classmethod(lambda cls, *a, **k: sentinel))
+
+    assert d._get_patch() is sentinel
+
+
+def test_get_patch_handles_key_add_and_remove(data_json):
+    """Top-level keys added and removed between syncs round-trip correctly."""
+    d = data_json
+    _set(d, {"a": {"x": 1}, "b": {"y": 2}})
+    d._last = copy.deepcopy(dict(d))
+    _set(d, {"b": {"y": 3}, "c": {"z": 4}})  # 'a' removed, 'c' added, 'b' changed
+    assert _roundtrip(d) == dict(d)
+
+
+def test_get_patch_property_random_schemas(data_json):
+    """Property test: for many random old->new widget payloads (the adversarial
+    list-of-dicts shape), the patch from _get_patch always reproduces state."""
+    d = data_json
+    keys = ["tooltip", "type", "postfix", "maxValue", "subtitle"]
+    rnd = random.Random(20240601)
+
+    def opt():
+        return {k: ("t" if k == "tooltip" else 1) for k in keys if rnd.random() < 0.5}
+
+    def widget():
+        n = rnd.randint(2, 9)
+        return {
+            "w": {
+                "columns": [f"c{rnd.randint(0, 12)}" for _ in range(n)],
+                "columnsOptions": [opt() for _ in range(n)],
+                "data": [{"items": [rnd.randint(0, 3) for _ in range(n)]} for _ in range(rnd.randint(0, 4))],
+                "total": rnd.randint(0, 4),
+                "pageSize": 10,
+            }
+        }
+
+    for _ in range(2000):
+        _set(d, widget())
+        d._last = copy.deepcopy(dict(d))
+        _set(d, widget())
+        assert _roundtrip(d) == dict(d)
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])


### PR DESCRIPTION
## Summary

Fixes intermittent crashes and silent data corruption when a widget flushes a
complex payload to the frontend — most reproducibly `FastTable.read_json()` when
the column schema changes between calls (e.g. a UI toggle that switches the
metric set and therefore the columns).

Typical traceback:

```
fast_table.py  read_json -> DataJson().send_changes()
content.py     synchronize_changes -> _apply_patch -> patch.apply(self._last, in_place=True)
jsonpatch.py   apply -> del subobj[part]   KeyError: 'tooltip'
```

## Root cause

The failure is **not** in `read_json` — it is `jsonpatch.JsonPatch.from_diff`
producing a **self-inconsistent patch** (a patch that, applied back to the very
document it was diffed from, does not reproduce that document).

`jsonpatch`'s `DiffBuilder` (since jsonpatch **1.24**) folds an `add` and a
value-equal `remove` into a single `move` **even across unrelated subtrees**, and
rewrites list-index operations while doing so. Table payloads replace several
sibling lists at once (`columns`, `columnsOptions` — a list of dicts — and `data`
rows) and share many equal scalar values (`1`, `"%"`, `"class"`, short strings),
which is the maximal trigger. The builder "moves" a value out of one subtree
(e.g. a `data` cell) into another (e.g. a `columnsOptions` entry) and leaves the
trailing index-based ops pointing at indices that have already shifted:

```
move   /data/1/items/2     -> /columnsOptions/0/postfix   # a cell value pulled into column options
add    /columnsOptions/1/tooltip
remove /columnsOptions/2  x6                              # index-based removes on an already-shrunk list
```

The trailing ops then hit a non-existent element (`JsonPatchConflict` /
`list index out of range`) or a different element (silently wrong document).
Which one happens depends on `set`-based dict-key iteration order, i.e. on
`PYTHONHASHSEED` — so it appears and disappears across process restarts with no
code change.

## Version sensitivity (measured)

Same fuzzer (random old->new widget payloads with list-of-dicts
`columnsOptions`), per jsonpatch version:

| jsonpatch | apply crash | silent wrong result |
|-----------|-------------|---------------------|
| 1.20 – 1.23 | none | none |
| 1.24+ (incl. 1.32, 1.33) | present | present |

The regression entered in **jsonpatch 1.24** with the `DiffBuilder` move
optimization. Every version allowed by `setup.py` (`jsonpatch>=1.32,<2.0`) is
affected, including the latest 1.33; pinning within the allowed range does not
help, and `optimization=False` does not fix it (the broken list/index
bookkeeping is in the diff itself). The bug is identical across Python versions —
only the specific triggering hash seeds differ.

## Fix

In `_PatchableJson._get_patch` (`supervisely/app/content.py`): verify the
generated patch round-trips and fall back to an explicit per-top-level-key
`replace` when it does not.

- Normal updates keep using the compact diff — no behavior change.
- The fallback only fires on the rare broken diffs; it never does element-wise
  list diffing or move folding, so it is always self-consistent.
- Fixes both failure modes (crash and silent corruption) for **all** widgets,
  not just FastTable, independent of jsonpatch and Python versions.
- Cost: one extra whole-document `deepcopy` + `apply` per `send_changes` for
  verification (a `deepcopy` already happens in `_apply_patch`).

## Tests

`tests/unit/test_content_patch.py`:

- **Deterministic guard** (hash-seed independent): forces `from_diff` to return a
  broken patch and asserts `_get_patch` still round-trips. Fails on the old code,
  passes with the fix.
- Property test over 2000 random adversarial payloads.
- The exact FastTable `read_json` schema-change scenario, plus key add/remove and
  "valid diff is passed through unchanged" cases.

Full run (`tests/unit/` + `tests/test_widget_fast_table.py`): **162 passed**.
