### PR TITLE
Fix DataJson/StateJson send_changes() race condition

### DIFF
--- a/supervisely/app/content.py
+++ b/supervisely/app/content.py
@@ -120,11 +120,12 @@ class _PatchableJson(dict):
         return patch
 
     async def _on_applied_locked(self, patch):
-        """Post-apply hook. Runs with `self._lock` already held -- do the
-        work directly, never acquire `self._lock` again here."""
+        """Subclass hook for post-apply side effects. Called while the lock is
+        already held - acquiring it again here will deadlock."""
 
     async def _sync_and_apply(self):
-        """Atomically diff, apply, and update `_last` under one lock."""
+        """Compute the diff and apply it while holding the lock, so no other
+        call can interleave between the two steps."""
         async with async_lock(self._lock):
             patch = self._get_patch()
             patch.apply(self._last, in_place=True)

--- a/supervisely/app/content.py
+++ b/supervisely/app/content.py
@@ -111,28 +111,33 @@ class _PatchableJson(dict):
 
     def get_changes(self, patch=None):
         if patch is None:
-            patch = self._get_patch()
+            with self._lock:
+                patch = self._get_patch()
         return {self._field: json.loads(patch.to_string())}
 
     def _get_patch(self):
         patch = jsonpatch.JsonPatch.from_diff(self._last, self)
         return patch
 
-    async def _apply_patch(self, patch):
+    async def _on_applied_locked(self, patch):
+        """Post-apply hook. Runs with `self._lock` already held -- do the
+        work directly, never acquire `self._lock` again here."""
+
+    async def _sync_and_apply(self):
+        """Atomically diff, apply, and update `_last` under one lock."""
         async with async_lock(self._lock):
+            patch = self._get_patch()
             patch.apply(self._last, in_place=True)
             self._last = copy.deepcopy(self._last)
+            await self._on_applied_locked(patch)
+            return patch
 
     async def synchronize_changes(self, user_id: Optional[Union[int, str]] = None):
-        patch = self._get_patch()
+        patch = await self._sync_and_apply()
         if user_id is not None:
             async with multi_user.async_session_context(user_id):
-                await self._apply_patch(patch)
-                await self._ws.broadcast(
-                    self.get_changes(patch), user_id=user_id
-                )
+                await self._ws.broadcast(self.get_changes(patch), user_id=user_id)
         else:
-            await self._apply_patch(patch)
             await self._ws.broadcast(self.get_changes(patch), user_id=user_id)
 
     async def send_changes_async(self):
@@ -155,17 +160,15 @@ class _PatchableJson(dict):
 class StateJson(_PatchableJson, metaclass=Singleton):
     """Singleton state store synchronized between backend and frontend via JSON patches."""
 
-    _global_lock: threading.Lock = None
-
     def __init__(self, *args, **kwargs):
-        if StateJson._global_lock is None:
-            StateJson._global_lock = threading.Lock()
         super().__init__(Field.STATE, *args, **kwargs)
 
-    async def _apply_patch(self, patch):
-        await super()._apply_patch(patch)
-        # @TODO: _replace_global to patching for optimization
-        await StateJson._replace_global(dict(self))
+    async def _on_applied_locked(self, patch):
+        # @TODO: this to patching for optimization
+        d = dict(self)
+        self.update(copy.deepcopy(d))
+        self._last = copy.deepcopy(d)
+        ContentOrigin().update(state=copy.deepcopy(d))
 
     @classmethod
     async def from_request(cls, request: Request, local: bool = True) -> StateJson:
@@ -183,9 +186,8 @@ class StateJson(_PatchableJson, metaclass=Singleton):
 
     @classmethod
     async def _replace_global(cls, d: dict):
-        # pylint: disable=not-async-context-manager
-        async with async_lock(cls._global_lock):
-            global_state = cls()
+        global_state = cls()
+        async with async_lock(global_state._lock):
             # !!! May cause problems with some apps !!!
             # global_state.clear()
             global_state.update(copy.deepcopy(d))
@@ -199,11 +201,8 @@ class DataJson(_PatchableJson, metaclass=Singleton):
     def __init__(self, *args, **kwargs):
         super().__init__(Field.DATA, *args, **kwargs)
 
-    async def _apply_patch(self, patch):
-        async with async_lock(self._lock):
-            patch.apply(self._last, in_place=True)
-            self._last = copy.deepcopy(self._last)
-            ContentOrigin().update(data_patch=copy.deepcopy(patch))
+    async def _on_applied_locked(self, patch):
+        ContentOrigin().update(data_patch=copy.deepcopy(patch))
 
 
 class ContentOrigin(metaclass=Singleton):

--- a/tests/manual/concurrency_race_demo/README.md
+++ b/tests/manual/concurrency_race_demo/README.md
@@ -1,0 +1,51 @@
+# Concurrency race — manual browser reproduction
+
+Companion to `tests/unit/test_concurrency_race.py` (same four scenarios,
+headless). This is the browser-interactive version, useful for visually
+confirming the bug and for verifying a future fix end-to-end.
+
+## Bug
+
+`_PatchableJson._get_patch()` (`supervisely/app/content.py`) computes a diff
+against `self._last` without holding any lock — only `_apply_patch()`
+(mutating `self._last`) is lock-protected. When two `send_changes()` calls
+run concurrently, both can read the same stale `_last` before either applies
+its patch. Whichever applies second ends up applying a patch computed
+against an already-stale baseline: `jsonpatch.JsonPatchConflict` or a
+silently dropped update.
+
+Reproduced identically with `jsonpatch` (current diffing library) and with
+`patchdiff` (an unreleased migration branch) — the race is in the missing
+lock, not in either diffing library.
+
+## Run
+
+```bash
+PYTHONPATH=. uvicorn tests.manual.concurrency_race_demo.main:app \
+    --host 0.0.0.0 --port 8000 --ws websockets --reload
+```
+
+Open `http://localhost:8000/`.
+
+## Scenarios
+
+1. **Two different users clicking at the same time** (multi-user mode) — `session_context()` only tags log/WS routing, it does not isolate `DataJson`/`StateJson` per user.
+2. **Progress-bar background task racing a click on another widget** — the officially recommended pattern for long-running work (`Progress` + a background thread) racing an unrelated click.
+3. **Two independently live-updating widgets** — e.g. two live charts, each driven by its own loop, with no coordination between them.
+4. **Rapid / double clicking by a single user** — ordinary fast clicking, or two widgets refreshing close together.
+
+Each section has:
+- a **single-try button** — click it by hand; timing-dependent, may or may not show a failure on any one attempt
+- a **STRESS xN button** — fires N concurrent repetitions server-side for a guaranteed, reliable reproduction
+
+Click each `STRESS` button and watch the status line turn red with a
+`JsonPatchConflict` error and a raised/total count. The app itself keeps
+running throughout (every crash is caught and reported, not left unhandled)
+— but the visible widget state is left corrupted or stale (e.g. Scenario 2's
+progress bar can freeze mid-count).
+
+## Suggested fix direction (not included in this PR)
+
+Hold a single lock around the whole get-patch-then-apply cycle in
+`synchronize_changes()`, not just inside `_apply_patch()`, so `_get_patch()`
+always diffs against the `_last` it will actually be applied to.

--- a/tests/manual/concurrency_race_demo/main.py
+++ b/tests/manual/concurrency_race_demo/main.py
@@ -1,0 +1,297 @@
+"""
+End-to-end reproduction of DataJson/StateJson concurrency races, for manual
+verification in a real browser.
+
+Root cause: `_PatchableJson._get_patch()` (diff generation) is not protected
+by any lock -- only `_apply_patch()` (mutating `self._last`) is. When two
+concurrent calls to `send_changes()` both read the shared state before either
+one applies its patch, the second one to apply ends up applying a patch
+computed against an already-stale baseline: crash or silently dropped update.
+
+This file has one section per REALISTIC scenario where that race fires
+WITHOUT any "incorrect" app code -- multi-user apps, Progress-driven
+background tasks, independently live-updating widgets, and ordinary rapid
+clicking. Each section has:
+  - a "single try" button -- click it by hand, timing-dependent, may or may
+    not show a failure on any single attempt
+  - a "STRESS xN" button -- fires N concurrent repetitions server-side for a
+    reliable, guaranteed-to-reproduce demonstration
+
+See tests/unit/test_concurrency_race.py for the automated (headless, no
+browser) version of the same four scenarios.
+
+Run (from the repo root):
+    PYTHONPATH=. uvicorn tests.manual.concurrency_race_demo.main:app \
+        --host 0.0.0.0 --port 8000 --ws websockets --reload
+Then open http://localhost:8000/ and click through each scenario's buttons.
+"""
+import os
+import random
+import threading
+import time
+
+os.environ.setdefault("SUPERVISELY_MULTIUSER_APP_MODE", "true")
+
+import supervisely as sly
+from supervisely.app.content import DataJson
+from supervisely.app.fastapi import multi_user
+from supervisely.app.widgets import Button, Card, Container, Progress, Text
+
+# ---------------------------------------------------------------------------
+# Scenario 1 -- two different users, each doing one normal click, at the
+# same time (multi-user apps do NOT get isolated DataJson/StateJson: it is
+# one shared singleton for the whole process, `session_context` only tags
+# log/WS routing).
+# ---------------------------------------------------------------------------
+s1_widget_a = Text("User A: 0 updates", status="text")
+s1_widget_b = Text("User B: 0 updates", status="text")
+s1_status = Text("Ready.", status="text")
+s1_btn_single = Button("Scenario 1 · fire User A + User B once, simultaneously")
+s1_btn_stress = Button("Scenario 1 · STRESS x20 simultaneous pairs")
+
+
+def _s1_user_action(user_id, widget, counter_key, n_items):
+    with multi_user.session_context(user_id):
+        wid = widget.widget_id
+        DataJson()[wid]["items"] = [random.randint(0, 50) for _ in range(n_items)]
+        DataJson()[wid]["text"] = f"User {user_id}: {counter_key} updates"
+        DataJson().send_changes()
+
+
+def _s1_fire_pair(n_items_a, n_items_b, results, idx):
+    errors = []
+    threads = [
+        threading.Thread(target=lambda: _try(errors, "A", lambda: _s1_user_action("A", s1_widget_a, idx, n_items_a))),
+        threading.Thread(target=lambda: _try(errors, "B", lambda: _s1_user_action("B", s1_widget_b, idx, n_items_b))),
+    ]
+    for t in threads:
+        t.start()
+    for t in threads:
+        t.join()
+    results.extend(errors)
+
+
+def _try(errors_list, label, fn):
+    try:
+        fn()
+    except Exception as e:
+        errors_list.append(f"{label}: {type(e).__name__}: {e}")
+
+
+@s1_btn_single.click
+def s1_do_single():
+    results = []
+    _s1_fire_pair(random.randint(5, 15), random.randint(5, 15), results, 0)
+    if results:
+        s1_status.set(f"Scenario 1 (single try): CRASHED -- {results[0]}", status="error")
+    else:
+        s1_status.set("Scenario 1 (single try): clean this time (timing-dependent -- use STRESS for a guaranteed repro).", status="success")
+
+
+@s1_btn_stress.click
+def s1_do_stress():
+    # Fire all 40 (20 pairs x User A/B) threads at once instead of pair-by-pair
+    # -- sequential pairs barely overlap, so the race window is too narrow to
+    # reliably hit. Real concurrent users don't politely wait their turn either.
+    results = []
+    threads = []
+    for i in range(20):
+        threads.append(threading.Thread(target=lambda i=i: _try(results, "A", lambda: _s1_user_action("A", s1_widget_a, i, random.randint(5, 15)))))
+        threads.append(threading.Thread(target=lambda i=i: _try(results, "B", lambda: _s1_user_action("B", s1_widget_b, i, random.randint(5, 15)))))
+    for t in threads:
+        t.start()
+    for t in threads:
+        t.join()
+    if results:
+        s1_status.set(f"Scenario 1 STRESS: {len(results)}/40 calls raised. First: {results[0]}", status="error")
+    else:
+        s1_status.set("Scenario 1 STRESS: 0/20 raised. Clean.", status="success")
+
+
+scenario_1 = Card(
+    title="Scenario 1 -- two different users clicking at the same time (multi-user mode)",
+    content=Container(widgets=[s1_widget_a, s1_widget_b, s1_status, Container(widgets=[s1_btn_single, s1_btn_stress], direction="horizontal")]),
+)
+
+# ---------------------------------------------------------------------------
+# Scenario 2 -- a Progress-driven background task (the officially recommended
+# pattern for long-running work) racing with a click on a completely
+# unrelated widget while it runs.
+# ---------------------------------------------------------------------------
+s2_progress = Progress("Long task", show_percents=True)
+s2_other_widget = Text("Other widget: untouched", status="text")
+s2_status = Text("Ready.", status="text")
+s2_btn_start_task = Button("Scenario 2 · start background task (10 x 0.1s progress ticks)")
+s2_btn_click_other = Button("Scenario 2 · click ME while the task above is running")
+s2_btn_stress = Button("Scenario 2 · STRESS x15 (task + 15 rapid clicks while it runs)")
+
+_s2_errors = []
+_s2_errors_lock = threading.Lock()
+
+
+def _s2_run_task(n_ticks=10, tick_s=0.1):
+    try:
+        with s2_progress(message="Processing...", total=n_ticks) as pbar:
+            for i in range(n_ticks):
+                time.sleep(tick_s)
+                # Varying-length list under the progress widget's OWN key --
+                # same shape as the "other widget" mutation, so both sides of
+                # the race are hitting index-based list ops.
+                wid = s2_progress.widget_id
+                DataJson()[wid]["log"] = [random.randint(0, 50) for _ in range(random.randint(5, 15))]
+                DataJson().send_changes()
+                pbar.update(1)
+    except Exception as e:
+        with _s2_errors_lock:
+            _s2_errors.append(f"progress: {type(e).__name__}: {e}")
+
+
+def _s2_click_other(i):
+    try:
+        # A varying-length list is what exposes the index-based race (a plain
+        # scalar .set() call is benign even under the same race window).
+        wid = s2_other_widget.widget_id
+        DataJson()[wid]["items"] = [random.randint(0, 50) for _ in range(random.randint(5, 15))]
+        s2_other_widget.set(f"Other widget: click #{i}", status="info")
+    except Exception as e:
+        with _s2_errors_lock:
+            _s2_errors.append(f"other_widget: {type(e).__name__}: {e}")
+
+
+@s2_btn_start_task.click
+def s2_do_start_task():
+    t = threading.Thread(target=_s2_run_task, args=(10, 0.1))
+    t.start()
+    s2_status.set("Background task started -- click the other button NOW while it runs.", status="info")
+
+
+@s2_btn_click_other.click
+def s2_do_click_other():
+    _s2_click_other(0)
+    s2_status.set("Clicked other widget.", status="success")
+
+
+@s2_btn_stress.click
+def s2_do_stress():
+    _s2_errors.clear()
+    task_thread = threading.Thread(target=_s2_run_task, args=(15, 0.05))
+    task_thread.start()
+    click_threads = [threading.Thread(target=_s2_click_other, args=(i,)) for i in range(15)]
+    for t in click_threads:
+        t.start()
+    for t in click_threads:
+        t.join()
+    task_thread.join()
+    if _s2_errors:
+        s2_status.set(f"Scenario 2 STRESS: {len(_s2_errors)} calls raised. First: {_s2_errors[0]}", status="error")
+    else:
+        s2_status.set("Scenario 2 STRESS: 0 calls raised. Clean.", status="success")
+
+
+scenario_2 = Card(
+    title="Scenario 2 -- Progress-bar background task racing a click on another widget",
+    content=Container(widgets=[s2_progress, s2_other_widget, s2_status, Container(widgets=[s2_btn_start_task, s2_btn_click_other, s2_btn_stress], direction="horizontal")]),
+)
+
+# ---------------------------------------------------------------------------
+# Scenario 3 -- two independently live-updating widgets on the same page
+# (e.g. two live charts), each driven by its own background loop, with no
+# explicit coordination between them -- exactly what "live" dashboards do.
+# ---------------------------------------------------------------------------
+s3_feed_a = Text("Feed A: idle", status="text")
+s3_feed_b = Text("Feed B: idle", status="text")
+s3_status = Text("Ready.", status="text")
+s3_btn_start = Button("Scenario 3 · start both live feeds (independent loops, 20 ticks each)")
+
+_s3_errors = []
+_s3_errors_lock = threading.Lock()
+
+
+def _s3_feed_loop(widget, label, n_ticks):
+    wid = widget.widget_id
+    for i in range(n_ticks):
+        try:
+            # Varying-length list, same as the other scenarios -- a plain
+            # scalar .set() is benign even under this exact race window.
+            DataJson()[wid]["points"] = [random.randint(0, 1000) for _ in range(random.randint(5, 15))]
+            widget.set(f"{label}: tick {i}", status="text")
+            time.sleep(0.01)
+        except Exception as e:
+            with _s3_errors_lock:
+                _s3_errors.append(f"{label} tick={i} {type(e).__name__}: {e}")
+
+
+@s3_btn_start.click
+def s3_do_start():
+    _s3_errors.clear()
+    threads = [
+        threading.Thread(target=_s3_feed_loop, args=(s3_feed_a, "Feed A", 20)),
+        threading.Thread(target=_s3_feed_loop, args=(s3_feed_b, "Feed B", 20)),
+    ]
+    for t in threads:
+        t.start()
+    for t in threads:
+        t.join()
+    if _s3_errors:
+        s3_status.set(f"Scenario 3: {len(_s3_errors)}/40 ticks raised. First: {_s3_errors[0]}", status="error")
+    else:
+        s3_status.set("Scenario 3: 0/40 ticks raised. Clean.", status="success")
+
+
+scenario_3 = Card(
+    title="Scenario 3 -- two independently live-updating widgets (e.g. two live charts)",
+    content=Container(widgets=[s3_feed_a, s3_feed_b, s3_status, s3_btn_start]),
+)
+
+# ---------------------------------------------------------------------------
+# Scenario 4 -- ordinary rapid / double clicking on a single button by one
+# user, with a list-valued widget (the shape that makes a stale patch fatal
+# instead of a harmless no-op).
+# ---------------------------------------------------------------------------
+s4_widget = Text("Rapid-click target: 0", status="text")
+s4_status = Text("Ready.", status="text")
+s4_btn_target = Button("Scenario 4 · click me (try double/rapid-clicking by hand!)")
+s4_btn_stress = Button("Scenario 4 · STRESS x25 rapid clicks (simulated)")
+
+_s4_click_count = {"n": 0}
+
+
+def _s4_action():
+    _s4_click_count["n"] += 1
+    wid = s4_widget.widget_id
+    DataJson()[wid]["items"] = [random.randint(0, 50) for _ in range(random.randint(5, 15))]
+    DataJson()[wid]["text"] = f"Rapid-click target: {_s4_click_count['n']}"
+    DataJson().send_changes()
+
+
+@s4_btn_target.click
+def s4_do_click():
+    try:
+        _s4_action()
+        s4_status.set(f"Click #{_s4_click_count['n']} OK. Try clicking FAST several times in a row.", status="success")
+    except Exception as e:
+        s4_status.set(f"CRASHED on click: {type(e).__name__}: {e}", status="error")
+
+
+@s4_btn_stress.click
+def s4_do_stress():
+    errors = []
+    threads = [threading.Thread(target=lambda: _try(errors, "click", _s4_action)) for _ in range(25)]
+    for t in threads:
+        t.start()
+    for t in threads:
+        t.join()
+    if errors:
+        s4_status.set(f"Scenario 4 STRESS: {len(errors)}/25 raised. First: {errors[0]}", status="error")
+    else:
+        s4_status.set("Scenario 4 STRESS: 0/25 raised. Clean.", status="success")
+
+
+scenario_4 = Card(
+    title="Scenario 4 -- rapid / double clicking by a single user",
+    content=Container(widgets=[s4_widget, s4_status, Container(widgets=[s4_btn_target, s4_btn_stress], direction="horizontal")]),
+)
+
+# ---------------------------------------------------------------------------
+layout = Container(widgets=[scenario_1, scenario_2, scenario_3, scenario_4])
+app = sly.Application(layout=layout)

--- a/tests/unit/test_concurrency_race.py
+++ b/tests/unit/test_concurrency_race.py
@@ -1,0 +1,215 @@
+"""
+Reproduction tests for the DataJson/StateJson `send_changes()` race
+condition.
+
+`_PatchableJson._get_patch()` (diff generation) is not protected by any lock
+-- only `_apply_patch()` (mutating `self._last`) is:
+
+    async def synchronize_changes(self, user_id=None):
+        patch = self._get_patch()          # <-- unprotected read of self._last
+        ...
+        await self._apply_patch(patch)     # <-- lock-protected mutation
+
+When two calls to `send_changes()` run concurrently, both can read the same
+`_last` baseline before either applies its patch. Whichever applies second
+ends up applying a patch computed against an already-stale baseline --
+`jsonpatch.JsonPatchConflict` ("can't remove/replace ...") or a silently
+dropped update. This is a pre-existing issue independent of which diffing
+library computes the patch (reproduced identically on `jsonpatch` and on an
+unreleased `patchdiff`-based migration branch).
+
+Each test below reproduces one REALISTIC scenario where this fires WITHOUT
+any "incorrect" app code:
+
+  1. Two different users, each doing one normal click, in a multi-user app
+     (`session_context()` only tags log/WS routing -- it does not isolate
+     DataJson/StateJson per user; there is a single shared singleton).
+  2. A `Progress`-driven background task (the officially recommended pattern
+     for long-running work) racing a click on an unrelated widget.
+  3. Two independently live-updating widgets (e.g. two live charts), each
+     driven by its own loop with no coordination between them.
+  4. Ordinary rapid / double clicking by a single user on one widget.
+
+These tests assert zero errors across N concurrent repetitions -- the
+correct invariant once the race is fixed (e.g. by locking the whole
+get-patch-then-apply cycle). They are expected to FAIL on the current
+codebase; a fix should make them pass without lowering N or adding retries.
+
+See tests/manual/concurrency_race_demo/ for the same four scenarios,
+reproducible by hand in an actual browser against a running app.
+"""
+
+import random
+import threading
+
+import pytest
+
+from supervisely.app.content import DataJson
+from supervisely.app.fastapi import multi_user
+from supervisely.app.widgets import Progress, Text
+
+
+@pytest.fixture
+def data_json():
+    d = DataJson()
+    d.clear()
+    d._last = {}
+    yield d
+    d.clear()
+    d._last = {}
+
+
+def _run_concurrently(targets):
+    """Run each zero-arg callable in its own thread; return exceptions raised."""
+    errors = []
+    lock = threading.Lock()
+
+    def _wrap(fn):
+        try:
+            fn()
+        except Exception as e:
+            with lock:
+                errors.append(f"{type(e).__name__}: {e}")
+
+    threads = [threading.Thread(target=_wrap, args=(fn,)) for fn in targets]
+    for t in threads:
+        t.start()
+    for t in threads:
+        t.join()
+    return errors
+
+
+def _mutate_list(widget, n_items=None):
+    """Replace a widget's own list-valued key with a new, differently-sized
+    list. This is the shape that turns a stale patch fatal: a scalar replace
+    is a harmless no-op even under the exact same race window, because it
+    isn't expressed as index-based add/remove operations."""
+    n = n_items if n_items is not None else random.randint(5, 15)
+    DataJson()[widget.widget_id]["items"] = [random.randint(0, 50) for _ in range(n)]
+    DataJson().send_changes()
+
+
+# ---------------------------------------------------------------------------
+# Scenario 1 -- two different users clicking at the same time (multi-user app)
+# ---------------------------------------------------------------------------
+
+
+def test_two_different_users_concurrent_actions(data_json):
+    """Two users, each doing one independent, individually-correct action at
+    the same time in a multi-user app, must not corrupt each other's state."""
+    widget_a = Text("User A", status="text")
+    widget_b = Text("User B", status="text")
+
+    def user_a_action():
+        with multi_user.session_context("user-a"):
+            _mutate_list(widget_a)
+
+    def user_b_action():
+        with multi_user.session_context("user-b"):
+            _mutate_list(widget_b)
+
+    errors = []
+    for _ in range(20):
+        errors += _run_concurrently([user_a_action, user_b_action])
+
+    assert errors == [], f"{len(errors)} concurrent multi-user actions raised: {errors[:3]}"
+
+
+# ---------------------------------------------------------------------------
+# Scenario 2 -- Progress-bar background task racing a click on another widget
+# ---------------------------------------------------------------------------
+
+
+def test_progress_background_task_races_other_widget(data_json):
+    """A Progress-driven background task (the recommended pattern for
+    long-running work) must not corrupt state when the user interacts with a
+    different widget while it runs.
+
+    Drives the progress widget's DataJson entry directly (matching what each
+    `pbar.update()` call does under the hood) rather than through
+    Progress.__call__'s context manager, which pulls in async/websocket
+    machinery that assumes a running application -- irrelevant to the race
+    itself and not available in a plain unit test process."""
+    progress = Progress("Long task", show_percents=True)
+    other_widget = Text("Other widget", status="text")
+
+    def run_task():
+        for _ in range(15):
+            _mutate_list(progress)
+
+    def click_other(i):
+        _mutate_list(other_widget)
+
+    errors = []
+    lock = threading.Lock()
+
+    def _wrap(fn, *a):
+        try:
+            fn(*a)
+        except Exception as e:
+            with lock:
+                errors.append(f"{type(e).__name__}: {e}")
+
+    task_thread = threading.Thread(target=_wrap, args=(run_task,))
+    click_threads = [threading.Thread(target=_wrap, args=(click_other, i)) for i in range(15)]
+
+    task_thread.start()
+    for t in click_threads:
+        t.start()
+    for t in click_threads:
+        t.join()
+    task_thread.join()
+
+    assert errors == [], f"{len(errors)} calls raised during background task + concurrent click: {errors[:3]}"
+
+
+# ---------------------------------------------------------------------------
+# Scenario 3 -- two independently live-updating widgets, no coordination
+# ---------------------------------------------------------------------------
+
+
+def test_two_independent_live_widgets(data_json):
+    """Two widgets updated by independent loops (e.g. two live charts) with
+    no coordination between them must not corrupt each other's state."""
+    feed_a = Text("Feed A", status="text")
+    feed_b = Text("Feed B", status="text")
+
+    def feed_loop(widget, n_ticks, errors, lock):
+        for _ in range(n_ticks):
+            try:
+                _mutate_list(widget)
+            except Exception as e:
+                with lock:
+                    errors.append(f"{type(e).__name__}: {e}")
+
+    errors = []
+    lock = threading.Lock()
+    threads = [
+        threading.Thread(target=feed_loop, args=(feed_a, 20, errors, lock)),
+        threading.Thread(target=feed_loop, args=(feed_b, 20, errors, lock)),
+    ]
+    for t in threads:
+        t.start()
+    for t in threads:
+        t.join()
+
+    assert errors == [], f"{len(errors)}/40 ticks raised across two independent live widgets: {errors[:3]}"
+
+
+# ---------------------------------------------------------------------------
+# Scenario 4 -- rapid / double clicking by a single user on one widget
+# ---------------------------------------------------------------------------
+
+
+def test_rapid_clicks_same_widget(data_json):
+    """Ordinary rapid clicking (or two near-simultaneous requests) on a
+    single widget must not corrupt its own state."""
+    widget = Text("Rapid-click target", status="text")
+
+    errors = _run_concurrently([lambda: _mutate_list(widget) for _ in range(25)])
+
+    assert errors == [], f"{len(errors)}/25 rapid clicks raised: {errors[:3]}"
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])


### PR DESCRIPTION
## Summary

Fixes a real `DataJson`/`StateJson` concurrency race, with regression tests covering four realistic scenarios that trigger it without any "incorrect" app code.

## The bug

`_PatchableJson._get_patch()` (`supervisely/app/content.py`) used to compute a diff against `self._last` **without holding any lock** — only the apply step was lock-protected:

```python
async def synchronize_changes(self, user_id=None):
    patch = self._get_patch()          # unprotected read of self._last
    ...
    await self._apply_patch(patch)     # lock-protected mutation
```

When two `send_changes()` calls ran concurrently, both could read the same stale `_last` before either applied its patch. Whichever applied second ended up applying a patch computed against an already-stale baseline: `jsonpatch.JsonPatchConflict` ("can't remove/replace...", "list index out of range"), or a silently dropped update with no error at all.

Reproduced identically with `jsonpatch` (current) and with `patchdiff` (an unreleased diffing-library migration branch) — this was about the missing lock, not either diffing library.

## Four realistic scenarios (no "incorrect" app code required)

1. **Two different users clicking at the same time** in a multi-user app — `session_context()` only tags log/WS routing, it does not isolate `DataJson`/`StateJson` per user; there is one shared singleton for the whole process.
2. **A `Progress`-driven background task racing a click on an unrelated widget** — the officially recommended pattern for long-running work.
3. **Two independently live-updating widgets** (e.g. two live charts), each driven by its own loop with no coordination between them.
4. **Ordinary rapid / double clicking** by a single user on one widget.

## Fix

`_sync_and_apply()` now runs get-patch → apply → update `_last` as a single atomic step under one lock per document (`supervisely/app/content.py`). Subclass post-apply side effects (`StateJson`'s global-state replacement, `DataJson`'s `ContentOrigin` update) run through a new `_on_applied_locked()` hook while that same lock is already held, replacing the old `_apply_patch()` override — so there's exactly one lock acquisition per `synchronize_changes()` call, never a nested one.

`StateJson._global_lock` is removed: `_replace_global` now reuses the singleton's own lock instead of a second, independently-ordered one, removing any risk of a cross-lock ordering deadlock.

Kept `threading.Lock`, not `RLock`: `async_lock()` acquires the lock via a threadpool worker thread but releases it on the coroutine's own thread. `RLock.release()` requires its owning thread and raises otherwise — an exception `run_sync()` silently swallows, leaving the lock stuck forever (confirmed by hitting this exact hang while iterating on the fix). The final design never re-enters the same lock, so plain `Lock` is correct and sufficient. Broadcasting over the websocket stays outside the lock so a slow/stalled connection can't stall other widgets' updates.

## What's in this PR

- **`supervisely/app/content.py`** — the fix.
- **`tests/unit/test_concurrency_race.py`** — automated, headless pytest tests for all four scenarios. Previously failed on `master`; now pass.
- **`tests/manual/concurrency_race_demo/`** — the same four scenarios as a runnable Supervisely app, for visual/manual confirmation in an actual browser.

## How to run

Automated tests:
```bash
PYTHONPATH=. pytest tests/unit/test_concurrency_race.py -v
```

Manual browser demo:
```bash
PYTHONPATH=. uvicorn tests.manual.concurrency_race_demo.main:app \
    --host 0.0.0.0 --port 8000 --ws websockets --reload
```
Open `http://localhost:8000/` and click each scenario's `STRESS xN` button — all four now report 0 raised (previously 12-28 out of 15-40). See `tests/manual/concurrency_race_demo/README.md`.
