### PR TITLE
Add video/volume support to entities collections

### DIFF
--- a/supervisely/api/entities_collection_api.py
+++ b/supervisely/api/entities_collection_api.py
@@ -15,11 +15,14 @@ from supervisely.api.module_api import (
     RemoveableModuleApi,
     UpdateableModule,
 )
+from supervisely.project.project_type import ProjectType
 from supervisely.sly_logger import logger
 
 if TYPE_CHECKING:
     from supervisely.api.api import Api
     from supervisely.api.image_api import ImageInfo
+    from supervisely.api.video.video_api import VideoInfo
+    from supervisely.api.volume.volume_api import VolumeInfo
 
 
 class CollectionType:
@@ -604,7 +607,7 @@ class EntitiesCollectionApi(UpdateableModule, RemoveableModuleApi):
         project_id: Optional[int] = None,
         ai_search_threshold: Optional[float] = None,
         ai_search_threshold_direction: AiSearchThresholdDirection = AiSearchThresholdDirection.ABOVE,
-    ) -> List[ImageInfo]:
+    ) -> Union[List[ImageInfo], List[VideoInfo], List[VolumeInfo]]:
         """
         Get items from Entities Collection.
 
@@ -618,9 +621,11 @@ class EntitiesCollectionApi(UpdateableModule, RemoveableModuleApi):
         :type ai_search_threshold: float, optional
         :param ai_search_threshold_direction: Direction for the AI search threshold. Optional, defaults to 'above'.
         :type ai_search_threshold_direction: str
-        :returns: List of ImageInfo objects.
-        :rtype: List[:class:`~supervisely.api.image_api.ImageInfo`]
+        :returns: List of ImageInfo objects for `images` projects, VideoInfo for `videos`, VolumeInfo for `volumes`.
+            AI_SEARCH collections only exist for `images` projects - the server rejects their creation otherwise.
+        :rtype: Union[List[:class:`~supervisely.api.image_api.ImageInfo`], List[:class:`~supervisely.api.video.video_api.VideoInfo`], List[:class:`~supervisely.api.volume.volume_api.VolumeInfo`]]
         :raises RuntimeError: If Entities Collection with given ID not found.
+        :raises NotImplementedError: If the collection's project type is not `images`, `videos` or `volumes`.
 
         :Usage Example:
 
@@ -650,6 +655,7 @@ class EntitiesCollectionApi(UpdateableModule, RemoveableModuleApi):
             project_id = info.project_id
 
         if collection_type == CollectionTypeFilter.AI_SEARCH:
+            # AI Search collections can only be created for `images` projects (server-enforced).
             return self._api.image.get_list(
                 project_id=project_id,
                 ai_search_collection_id=collection_id,
@@ -657,10 +663,26 @@ class EntitiesCollectionApi(UpdateableModule, RemoveableModuleApi):
                 ai_search_threshold=ai_search_threshold,
                 ai_search_threshold_direction=ai_search_threshold_direction,
             )
-        else:
+
+        project_type = self._api.project.get_info_by_id(project_id).type
+        if project_type == ProjectType.IMAGES.value:
             return self._api.image.get_list(
                 project_id=project_id,
                 entities_collection_id=collection_id,
+            )
+        elif project_type == ProjectType.VIDEOS.value:
+            return self._api.video.get_list(
+                project_id=project_id,
+                entities_collection_id=collection_id,
+            )
+        elif project_type == ProjectType.VOLUMES.value:
+            return self._api.volume.get_list(
+                project_id=project_id,
+                entities_collection_id=collection_id,
+            )
+        else:
+            raise NotImplementedError(
+                f"Entities Collection items are not supported for project type {project_type!r}."
             )
 
     def remove_items(self, id: int, items: List[int]) -> List[Dict[str, int]]:

--- a/supervisely/api/video/video_api.py
+++ b/supervisely/api/video/video_api.py
@@ -41,6 +41,7 @@ from supervisely._utils import (
     is_development,
     rand_str,
 )
+from supervisely.api.entities_collection_api import CollectionTypeFilter
 from supervisely.api.module_api import ApiField, RemoveableBulkModuleApi
 from supervisely.api.video.video_annotation_api import VideoAnnotationAPI
 from supervisely.api.video.video_figure_api import VideoFigureApi
@@ -331,17 +332,19 @@ class VideoApi(RemoveableBulkModuleApi):
 
     def get_list(
         self,
-        dataset_id: int,
+        dataset_id: Optional[int] = None,
         filters: Optional[List[Dict[str, str]]] = None,
         raw_video_meta: Optional[bool] = False,
         fields: Optional[List[str]] = None,
         force_metadata_for_links: Optional[bool] = False,
+        project_id: Optional[int] = None,
+        entities_collection_id: Optional[int] = None,
     ) -> List[VideoInfo]:
         """
-        Get list of information about all videos for a given dataset ID.
+        Get list of information about all videos for a given dataset or project ID.
 
-        :param dataset_id: Dataset ID in Supervisely.
-        :type dataset_id: int
+        :param dataset_id: Dataset ID in Supervisely. Exactly one of `dataset_id`/`project_id` must be provided.
+        :type dataset_id: int, optional
         :param filters: List of parameters to sort output Videos. See: https://api.docs.supervisely.com/#tag/Videos/paths/~1videos.list/get
         :type filters: List[Dict[str, str]], optional
         :param raw_video_meta: Get normalized metadata from server if False.
@@ -350,7 +353,11 @@ class VideoApi(RemoveableBulkModuleApi):
         :type fields: List[str], optional
         :param force_metadata_for_links: Specify whether to force retrieving video metadata from the server.
         :type force_metadata_for_links: Optional[bool]
-        :returns: List of information about videos in given dataset.
+        :param project_id: Project ID in Supervisely. Exactly one of `dataset_id`/`project_id` must be provided.
+        :type project_id: int, optional
+        :param entities_collection_id: EntitiesCollection ID of `Default` type to which the videos belong.
+        :type entities_collection_id: int, optional
+        :returns: List of information about videos in given dataset or project.
         :rtype: :class:`List[VideoInfo]`
 
         :Usage Example:
@@ -378,7 +385,9 @@ class VideoApi(RemoveableBulkModuleApi):
                 print(filtered_video_infos)
                 # Output: [VideoInfo(id=19371139, ...)]
         """
+        self._validate_project_and_dataset_id(project_id, dataset_id)
         data = {
+            ApiField.PROJECT_ID: project_id,
             ApiField.DATASET_ID: dataset_id,
             ApiField.FILTER: filters or [],
             ApiField.RAW_VIDEO_META: raw_video_meta,
@@ -386,7 +395,26 @@ class VideoApi(RemoveableBulkModuleApi):
         }
         if fields is not None:
             data[ApiField.FIELDS] = fields
+        if entities_collection_id is not None:
+            data[ApiField.FILTERS] = [
+                {
+                    ApiField.TYPE: CollectionTypeFilter.DEFAULT,
+                    ApiField.DATA: {
+                        ApiField.COLLECTION_ID: entities_collection_id,
+                        ApiField.INCLUDE: True,
+                    },
+                }
+            ]
         return self.get_list_all_pages("videos.list", data)
+
+    def _validate_project_and_dataset_id(
+        self, project_id: Optional[int], dataset_id: Optional[int]
+    ) -> None:
+        """Check that exactly one of `project_id`/`dataset_id` is provided."""
+        if project_id is None and dataset_id is None:
+            raise ValueError("One of 'project_id' or 'dataset_id' should be provided.")
+        if project_id is not None and dataset_id is not None:
+            raise ValueError("Only one of 'project_id' and 'dataset_id' should be provided.")
 
     def get_list_generator(
         self,

--- a/supervisely/api/video/video_api.py
+++ b/supervisely/api/video/video_api.py
@@ -387,12 +387,14 @@ class VideoApi(RemoveableBulkModuleApi):
         """
         self._validate_project_and_dataset_id(project_id, dataset_id)
         data = {
-            ApiField.PROJECT_ID: project_id,
-            ApiField.DATASET_ID: dataset_id,
             ApiField.FILTER: filters or [],
             ApiField.RAW_VIDEO_META: raw_video_meta,
             ApiField.FORCE_METADATA_FOR_LINKS: force_metadata_for_links,
         }
+        if project_id is not None:
+            data[ApiField.PROJECT_ID] = project_id
+        if dataset_id is not None:
+            data[ApiField.DATASET_ID] = dataset_id
         if fields is not None:
             data[ApiField.FIELDS] = fields
         if entities_collection_id is not None:

--- a/supervisely/api/volume/volume_api.py
+++ b/supervisely/api/volume/volume_api.py
@@ -327,12 +327,14 @@ class VolumeApi(RemoveableBulkModuleApi):
         """
         self._validate_project_and_dataset_id(project_id, dataset_id)
         data = {
-            ApiField.PROJECT_ID: project_id,
-            ApiField.DATASET_ID: dataset_id,
             ApiField.FILTER: filters or [],
             ApiField.SORT: sort,
             ApiField.SORT_ORDER: sort_order,
         }
+        if project_id is not None:
+            data[ApiField.PROJECT_ID] = project_id
+        if dataset_id is not None:
+            data[ApiField.DATASET_ID] = dataset_id
         if entities_collection_id is not None:
             data[ApiField.FILTERS] = [
                 {

--- a/supervisely/api/volume/volume_api.py
+++ b/supervisely/api/volume/volume_api.py
@@ -11,6 +11,7 @@ from tqdm.contrib.logging import logging_redirect_tqdm
 import supervisely.volume.nrrd_encoder as nrrd_encoder
 from supervisely import logger, volume
 from supervisely._utils import batched, generate_free_name
+from supervisely.api.entities_collection_api import CollectionTypeFilter
 from supervisely.api.module_api import ApiField, RemoveableBulkModuleApi
 from supervisely.api.volume.volume_annotation_api import VolumeAnnotationAPI
 from supervisely.api.volume.volume_figure_api import VolumeFigureApi
@@ -262,23 +263,29 @@ class VolumeApi(RemoveableBulkModuleApi):
 
     def get_list(
         self,
-        dataset_id: int,
+        dataset_id: Optional[int] = None,
         filters=None,
         sort: Literal["id", "name", "description", "createdAt", "updatedAt"] = "id",
         sort_order: Literal["asc", "desc"] = "asc",
+        project_id: Optional[int] = None,
+        entities_collection_id: Optional[int] = None,
     ) -> List[VolumeInfo]:
         """
-        Get list of information about all volumes for a given dataset ID.
+        Get list of information about all volumes for a given dataset or project ID.
 
-        :param dataset_id: Dataset ID in Supervisely.
-        :type dataset_id: int
+        :param dataset_id: Dataset ID in Supervisely. Exactly one of `dataset_id`/`project_id` must be provided.
+        :type dataset_id: int, optional
         :param filters: List of parameters to sort output Volumes. See: https://api.docs.supervisely.com/#tag/Volumes/paths/~1volumes.list/get
         :type filters: List[Dict[str, str]], optional
         :param sort: Attribute to sort the list by. The default is "id". Valid values are "id", "name", "description", "createdAt", "updatedAt".
         :type sort: str
         :param sort_order: Order in which to sort the list. The default is "asc". Valid values are "asc" (ascending) and "desc" (descending).
         :type sort_order: str
-        :returns: List of information about volumes in given dataset.
+        :param project_id: Project ID in Supervisely. Exactly one of `dataset_id`/`project_id` must be provided.
+        :type project_id: int, optional
+        :param entities_collection_id: EntitiesCollection ID of `Default` type to which the volumes belong.
+        :type entities_collection_id: int, optional
+        :returns: List of information about volumes in given dataset or project.
         :rtype: List[:class:`~supervisely.api.volume.volume_api.VolumeInfo`]
 
         :Usage Example:
@@ -310,16 +317,34 @@ class VolumeApi(RemoveableBulkModuleApi):
                 print(filtered_volume_infos)
                 # Output: [VolumeInfo(id=19581135, ...)]
         """
+        self._validate_project_and_dataset_id(project_id, dataset_id)
+        data = {
+            ApiField.PROJECT_ID: project_id,
+            ApiField.DATASET_ID: dataset_id,
+            ApiField.FILTER: filters or [],
+            ApiField.SORT: sort,
+            ApiField.SORT_ORDER: sort_order,
+        }
+        if entities_collection_id is not None:
+            data[ApiField.FILTERS] = [
+                {
+                    ApiField.TYPE: CollectionTypeFilter.DEFAULT,
+                    ApiField.DATA: {
+                        ApiField.COLLECTION_ID: entities_collection_id,
+                        ApiField.INCLUDE: True,
+                    },
+                }
+            ]
+        return self.get_list_all_pages("volumes.list", data)
 
-        return self.get_list_all_pages(
-            "volumes.list",
-            {
-                ApiField.DATASET_ID: dataset_id,
-                ApiField.FILTER: filters or [],
-                ApiField.SORT: sort,
-                ApiField.SORT_ORDER: sort_order,
-            },
-        )
+    def _validate_project_and_dataset_id(
+        self, project_id: Optional[int], dataset_id: Optional[int]
+    ) -> None:
+        """Check that exactly one of `project_id`/`dataset_id` is provided."""
+        if project_id is None and dataset_id is None:
+            raise ValueError("One of 'project_id' or 'dataset_id' should be provided.")
+        if project_id is not None and dataset_id is not None:
+            raise ValueError("Only one of 'project_id' and 'dataset_id' should be provided.")
 
     def get_info_by_id(self, id: int):
         """

--- a/supervisely/api/volume/volume_api.py
+++ b/supervisely/api/volume/volume_api.py
@@ -255,6 +255,14 @@ class VolumeApi(RemoveableBulkModuleApi):
 
         return "VolumeInfo"
 
+    def _remove_batch_api_method_name(self):
+        """Private method. Returns API method name used for batch removal of volumes."""
+        return "images.bulk.remove"
+
+    def _remove_batch_field_name(self):
+        """Private method. Returns constant string that represents API field name that contains the IDs of the volumes."""
+        return ApiField.IMAGE_IDS
+
     def _convert_json_info(self, info: dict, skip_missing=True):
         """Private method. Convert volume information from json to VolumeInfo."""
 


### PR DESCRIPTION
## Summary
- `image_api.get_list()` already supports filtering by `entities_collection_id`; `video_api.get_list()` and `volume_api.get_list()` now support the same `project_id` + `entities_collection_id` params, since the server already accepts this filter for `videos.list`/`volumes.list`.
- `EntitiesCollectionApi.get_items()` no longer assumes images — it dispatches to `image`/`video`/`volume` based on the collection's project type. AI Search collections remain images-only (server-enforced).
- `VolumeApi` extended `RemoveableBulkModuleApi` but never implemented `remove_batch`, so calling it raised `NotImplementedError`. Implemented it using the same generic `images.bulk.remove` endpoint `VideoApi` already relies on.