### PR TITLE
Minor SDK bugfixes

### DIFF
--- a/PR_SUMMARY.md
+++ b/PR_SUMMARY.md
@@ -1,0 +1,9 @@
+Title: SDK: minor bugfixes
+
+Description:
+- Fix VideoApi file-size error handling for the newer `100mb` payload format.
+- Preserve `dataset_id` in empty point-cloud episode annotations.
+- Hydrate storage-backed point-cloud figure indices after figure download.
+- Resolve tag names from `tagId` when annotation payloads omit `name`.
+- Validate video tag frame ranges against video bounds.
+- Parse `maxModules` in team `UsageInfo`.

--- a/supervisely/annotation/tag.py
+++ b/supervisely/annotation/tag.py
@@ -27,8 +27,8 @@ class TagJsonFields:
     """"""
     ID = "id"
     """"""
-    # TAG_META_ID = 'tagId'
-    # """"""
+    TAG_META_ID = "tagId"
+    """"""
 
 
 class Tag(KeyObject):
@@ -274,7 +274,18 @@ class Tag(KeyObject):
             created_at = None
             sly_id = None
         else:
-            tag_name = data[TagJsonFields.TAG_NAME]
+            if TagJsonFields.TAG_NAME in data:
+                tag_name = data[TagJsonFields.TAG_NAME]
+            elif TagJsonFields.TAG_META_ID in data:
+                tag_meta_id = data[TagJsonFields.TAG_META_ID]
+                tag_meta = tag_meta_collection.get_by_id(tag_meta_id)
+                if tag_meta is None:
+                    raise KeyError(
+                        f"Tag meta with id={tag_meta_id!r} was not found in project meta"
+                    )
+                tag_name = tag_meta.name
+            else:
+                raise KeyError(TagJsonFields.TAG_NAME)
             value = data.get(TagJsonFields.VALUE, None)
             labeler_login = data.get(TagJsonFields.LABELER_LOGIN, None)
             updated_at = data.get(TagJsonFields.UPDATED_AT, None)

--- a/supervisely/api/module_api.py
+++ b/supervisely/api/module_api.py
@@ -719,6 +719,8 @@ class ApiField:
     """"""
     GUIDE_ID = "guideId"
     """"""
+    MAX_MODULES = "maxModules"
+    """"""
     SINGLE_SESSION_MODE = "singleSessionMode"
     """"""
     READ_ONLY_PROJECT_ID = "readOnlyProjectId"

--- a/supervisely/api/pointcloud/pointcloud_episode_annotation_api.py
+++ b/supervisely/api/pointcloud/pointcloud_episode_annotation_api.py
@@ -116,7 +116,9 @@ class PointcloudEpisodeAnnotationAPI(EntityAnnotationAPI):
         response = self._api.post(self._method_download, {ApiField.DATASET_ID: dataset_id})
         result = response.json()
         if len(result) == 0:
-            return PointcloudEpisodeAnnotation().to_json()
+            empty_ann = PointcloudEpisodeAnnotation().to_json()
+            empty_ann[ApiField.DATASET_ID] = dataset_id
+            return empty_ann
         ann_json = result[0]
         self._api.pointcloud_episode.figure.inject_geometries_into_annotations([ann_json])
         return ann_json

--- a/supervisely/api/pointcloud/pointcloud_figure_api.py
+++ b/supervisely/api/pointcloud/pointcloud_figure_api.py
@@ -274,7 +274,10 @@ class PointcloudFigureApi(FigureApi):
         """
         if kwargs.get("image_ids", False) is not False:
             pointcloud_ids = kwargs["image_ids"]  # backward compatibility
-        return super().download(dataset_id, pointcloud_ids, skip_geometry)
+        figures = super().download(dataset_id, pointcloud_ids, skip_geometry)
+        if skip_geometry:
+            return figures
+        return self.hydrate_figure_infos_dict(figures)
 
     def upload_indices_batch(self, figure_ids: List[int], indices_batch: List[List[int]]) -> None:
         """
@@ -335,6 +338,29 @@ class PointcloudFigureApi(FigureApi):
         if len(geometries) != len(figure_ids):
             raise RuntimeError("Not all point cloud geometries were downloaded")
         return [geometries[figure_id] for figure_id in figure_ids]
+
+    def hydrate_figure_infos_dict(
+        self, figures_by_entity: Dict[int, List[FigureInfo]]
+    ) -> Dict[int, List[FigureInfo]]:
+        """
+        Hydrate separately stored point-cloud indices in downloaded figure mappings.
+        """
+        refs = []
+        for entity_id, figures in figures_by_entity.items():
+            for idx, figure in enumerate(figures):
+                if self._should_hydrate_figure_info(figure):
+                    refs.append((entity_id, idx, figure.id))
+
+        if len(refs) == 0:
+            return figures_by_entity
+
+        hydrated = {entity_id: list(figures) for entity_id, figures in figures_by_entity.items()}
+        indices_batch = self.download_indices_batch([figure_id for _, _, figure_id in refs])
+        for (entity_id, idx, _), indices in zip(refs, indices_batch):
+            hydrated[entity_id][idx] = hydrated[entity_id][idx]._replace(
+                geometry={INDICES: indices}
+            )
+        return hydrated
 
     def inject_geometries_into_annotations(self, anns_json: List[Dict]) -> List[Dict]:
         """
@@ -401,3 +427,9 @@ class PointcloudFigureApi(FigureApi):
         if isinstance(indices, list):
             return indices
         return None
+
+    @staticmethod
+    def _should_hydrate_figure_info(figure: FigureInfo) -> bool:
+        if figure.geometry_type != Pointcloud.geometry_name() or figure.id is None:
+            return False
+        return PointcloudFigureApi._extract_indices(figure.geometry) is None

--- a/supervisely/api/team_api.py
+++ b/supervisely/api/team_api.py
@@ -133,6 +133,19 @@ class UsageInfo(NamedTuple):
     """Team usage/plan information returned by the API."""
 
     plan: Optional[str]
+    max_modules: Optional[int]
+
+    @staticmethod
+    def info_sequence() -> List[str]:
+        return [ApiField.ACCOUNT_TYPE, ApiField.MAX_MODULES]
+
+    @classmethod
+    def from_json(cls, data: Optional[Dict[str, Optional[str]]]) -> Optional["UsageInfo"]:
+        if not data:
+            return None
+        mapping = dict(zip(cls._fields, cls.info_sequence()))
+        values = {attr: data.get(api_field) for attr, api_field in mapping.items()}
+        return cls(**values)
 
 
 class TeamInfo(NamedTuple):
@@ -584,5 +597,5 @@ class TeamApi(ModuleNoParent, UpdateableModule):
         res_dict = res._asdict()
         if isinstance(res_dict.get("usage"), dict):
             usage_dict = {f: res_dict["usage"].get(f) for f in UsageInfo._fields}
-            res_dict["usage"] = UsageInfo(**usage_dict)
+            res_dict["usage"] = UsageInfo.from_json(usage_dict)
         return TeamInfo(**res_dict)

--- a/supervisely/io/exception_handlers.py
+++ b/supervisely/io/exception_handlers.py
@@ -796,6 +796,7 @@ ERROR_PATTERNS = {
         r".*file-storage\.bulk\.upload.*File too large.*": ErrorHandler.API.FileSizeTooLarge,
         r".*images\.bulk\.upload.*FileSize.*\"sizeLimit\":1073741824.*": ErrorHandler.API.ImageFilesSizeTooLarge,
         r".*videos\.bulk\.upload.*FileSize.*sizeLimit\":314572800.*": ErrorHandler.API.VideoFilesSizeTooLarge,
+        r".*videos\.bulk\.upload.*FileSize.*sizeLimit\":\"100mb\".*": ErrorHandler.API.VideoFilesSizeTooLarge,
         r".*images\.bulk\.upload.*FileSize.*\"sizeLimit\":157286400.*": ErrorHandler.API.VolumeFilesSizeTooLarge,
         r".*images\.bulk\.upload.*FileSize.*\"sizeLimit\":\"25mb\".*": ErrorHandler.API.VolumeFilesSizeTooLarge,
         r".*Dataset with datasetId.*is either archived, doesn't exist or you don't have enough permissions to access.*": ErrorHandler.API.DatasetNotFound,

--- a/supervisely/pointcloud_annotation/pointcloud_episode_annotation.py
+++ b/supervisely/pointcloud_annotation/pointcloud_episode_annotation.py
@@ -401,7 +401,9 @@ class PointcloudEpisodeAnnotation:
         item_key = uuid.UUID(data[KEY]) if KEY in data else uuid.uuid4()
 
         if key_id_map is not None:
-            key_id_map.add_video(item_key, data.get(ApiField.DATASET_ID, None))
+            dataset_id = data.get(ApiField.DATASET_ID)
+            if dataset_id is not None:
+                key_id_map.add_video(item_key, dataset_id)
 
         description = data.get(DESCRIPTION, "")
         frames_count = data.get(FRAMES_COUNT, 0)

--- a/supervisely/video_annotation/video_annotation.py
+++ b/supervisely/video_annotation/video_annotation.py
@@ -183,6 +183,7 @@ class VideoAnnotation:
         self._key = take_with_default(key, uuid.uuid4())
 
         self.validate_figures_bounds()
+        self.validate_tag_ranges()
 
     @property
     def img_size(self) -> Tuple[int, int]:
@@ -549,6 +550,13 @@ class VideoAnnotation:
         """
         for frame in self.frames:
             frame.validate_figures_bounds(self.img_size)
+
+    def validate_tag_ranges(self) -> None:
+        """
+        Checks if video tags reference valid frame bounds.
+        """
+        for tag in self.tags:
+            tag.validate_frame_range_bounds(self.frames_count)
 
     def to_json(self, key_id_map: Optional[KeyIdMap] = None) -> Dict:
         """

--- a/supervisely/video_annotation/video_tag.py
+++ b/supervisely/video_annotation/video_tag.py
@@ -169,6 +169,13 @@ class VideoTag(Tag):
             raise ValueError("frame_range has to be a tuple or a list with 2 int values.")
         return list(frame_range)
 
+    def validate_frame_range_bounds(self, frames_count: int) -> None:
+        if self.frame_range is not None:
+            if self.frame_range[0] < 0 or self.frame_range[1] >= frames_count:
+                raise ValueError(
+                    f"Frame range {self.frame_range} is out of bounds for video with {frames_count} frames."
+                )
+
     def to_json(self, key_id_map: Optional[KeyIdMap] = None) -> Dict:
         """
         Convert the VideoTag to a json dict. Read more about `Supervisely format <https://docs.supervisely.com/data-organization/00_ann_format_navi>`_.

--- a/tests/geometry_tests/test_pointcloud_indices.py
+++ b/tests/geometry_tests/test_pointcloud_indices.py
@@ -9,6 +9,9 @@ import numpy as np
 sdk_path = os.path.abspath(os.path.join(os.path.dirname(__file__), "..", ".."))
 sys.path.insert(0, sdk_path)
 
+from supervisely.api.entity_annotation.figure_api import FigureInfo
+from supervisely.api.pointcloud.pointcloud_figure_api import PointcloudFigureApi
+from supervisely.geometry.constants import INDICES
 from supervisely.geometry.pointcloud import Pointcloud
 from supervisely.io.fs import decode_uint32_le, encode_uint32_le
 
@@ -66,6 +69,72 @@ class TestPointcloudBytes(unittest.TestCase):
     def test_empty_indices_roundtrip(self):
         pcd = Pointcloud([])
         self.assertEqual(Pointcloud.from_bytes(pcd.to_bytes()).indices, [])
+
+
+class FakePointcloudFigureApi(PointcloudFigureApi):
+    def __init__(self, indices_by_figure_id):
+        super().__init__(None)
+        self.indices_by_figure_id = indices_by_figure_id
+        self.requested_sync = []
+
+    def download_indices_batch(self, figure_ids, progress_cb=None):
+        self.requested_sync.extend(figure_ids)
+        return [self.indices_by_figure_id[figure_id] for figure_id in figure_ids]
+
+
+def make_figure_info(figure_id, geometry_type, geometry, entity_id=1):
+    return FigureInfo(
+        id=figure_id,
+        class_id=1,
+        updated_at="",
+        created_at="",
+        entity_id=entity_id,
+        object_id=1,
+        project_id=1,
+        dataset_id=1,
+        frame_index=0,
+        geometry_type=geometry_type,
+        geometry=geometry,
+        geometry_meta=None,
+        tags=[],
+        meta={},
+        area=None,
+    )
+
+
+class TestPointcloudFigureHydration(unittest.TestCase):
+    def test_hydrates_missing_pointcloud_indices_in_figure_dict(self):
+        api = FakePointcloudFigureApi({10: [1], 20: [2, 3]})
+        inline = make_figure_info(11, Pointcloud.geometry_name(), {INDICES: [7, 8]}, entity_id=100)
+        regular = make_figure_info(12, "cuboid_3d", {}, entity_id=100)
+        figures_by_entity = {
+            100: [
+                make_figure_info(10, Pointcloud.geometry_name(), {}, entity_id=100),
+                inline,
+                regular,
+            ],
+            200: [make_figure_info(20, Pointcloud.geometry_name(), {}, entity_id=200)],
+        }
+
+        hydrated = api.hydrate_figure_infos_dict(figures_by_entity)
+
+        self.assertEqual(api.requested_sync, [10, 20])
+        self.assertEqual(hydrated[100][0].geometry, {INDICES: [1]})
+        self.assertEqual(hydrated[100][1].geometry, {INDICES: [7, 8]})
+        self.assertEqual(hydrated[100][2].geometry, {})
+        self.assertEqual(hydrated[200][0].geometry, {INDICES: [2, 3]})
+        self.assertEqual(figures_by_entity[100][0].geometry, {})
+
+    def test_returns_same_dict_when_nothing_needs_hydration(self):
+        api = FakePointcloudFigureApi({})
+        figures_by_entity = {
+            100: [make_figure_info(10, Pointcloud.geometry_name(), {INDICES: []})]
+        }
+
+        hydrated = api.hydrate_figure_infos_dict(figures_by_entity)
+
+        self.assertIs(hydrated, figures_by_entity)
+        self.assertEqual(api.requested_sync, [])
 
 
 if __name__ == "__main__":

--- a/tests/test_sdk_minor_bugfixes.py
+++ b/tests/test_sdk_minor_bugfixes.py
@@ -1,0 +1,50 @@
+import types
+
+import pytest
+
+from supervisely.annotation.tag import Tag
+from supervisely.annotation.tag_meta import TagMeta, TagValueType
+from supervisely.annotation.tag_meta_collection import TagMetaCollection
+from supervisely.api.team_api import TeamApi, UsageInfo
+from supervisely.video_annotation.frame_collection import FrameCollection
+from supervisely.video_annotation.video_annotation import VideoAnnotation
+from supervisely.video_annotation.video_tag import VideoTag
+from supervisely.video_annotation.video_tag_collection import VideoTagCollection
+
+
+def test_tag_from_json_can_resolve_name_via_tag_id():
+    tag_meta = TagMeta("quality", TagValueType.NONE, sly_id=17)
+    tag = Tag.from_json({"tagId": 17}, TagMetaCollection([tag_meta]))
+
+    assert tag.meta.name == "quality"
+
+
+def test_usage_info_from_json_reads_max_modules():
+    usage = UsageInfo.from_json({"accountType": "pro", "maxModules": 12})
+
+    assert usage == UsageInfo(plan="pro", max_modules=12)
+
+
+def test_team_api_convert_json_info_uses_usage_parser():
+    api = TeamApi(types.SimpleNamespace())
+    team = api._convert_json_info(
+        {
+            "id": 1,
+            "name": "Team",
+            "description": "",
+            "role": "admin",
+            "createdAt": "2026-01-01T00:00:00Z",
+            "updatedAt": "2026-01-01T00:00:00Z",
+            "usage": {"accountType": "pro", "maxModules": 5},
+        }
+    )
+
+    assert team.usage == UsageInfo(plan="pro", max_modules=5)
+
+
+def test_video_annotation_rejects_out_of_bounds_tag_ranges():
+    tag_meta = TagMeta("phase", TagValueType.NONE)
+    tag = VideoTag(tag_meta, frame_range=(0, 5))
+
+    with pytest.raises(ValueError):
+        VideoAnnotation((100, 100), 5, tags=VideoTagCollection([tag]), frames=FrameCollection())


### PR DESCRIPTION
- Fix VideoApi file-size error handling for the newer 100mb payload format.
- Preserve dataset_id in empty point-cloud episode annotations.
- Append storage-backed point-cloud figure indices after figure download.
- Resolve tag names from tagId when annotation payloads omit name.
- Validate video tag frame ranges against video bounds.
- Parse maxModules in team UsageInfo.