### PR TITLE
Resume the artifacts upload of a crashed training run instead of retraining

### DIFF
--- a/supervisely/api/file_api.py
+++ b/supervisely/api/file_api.py
@@ -12,7 +12,7 @@ import tarfile
 import tempfile
 from pathlib import Path
 from time import time
-from typing import Callable, Dict, List, NamedTuple, Optional, Union
+from typing import Callable, Dict, List, NamedTuple, Optional, Tuple, Union
 
 import aiofiles
 import httpx
@@ -2343,6 +2343,66 @@ class FileApi(ModuleApiBase):
             if progress_cb is not None and progress_cb_type == "number":
                 progress_cb(1)
 
+    @staticmethod
+    def _report_progress(
+        progress_cb: Optional[Union[tqdm, Callable]],
+        value: int,
+    ) -> None:
+        """Report progress to either a tqdm-like object or a plain callable."""
+        if progress_cb is None:
+            return
+        if hasattr(progress_cb, "update"):
+            progress_cb.update(value)
+        else:
+            progress_cb(value)
+
+    def _remote_files_by_name(self, team_id: int, remote_dir: str) -> Dict[str, FileInfo]:
+        """Non-recursive listing of `remote_dir` as {file name: FileInfo}.
+        A missing directory yields an empty mapping; API errors are not suppressed."""
+        if not self.dir_exists(team_id, remote_dir):
+            return {}
+        infos = self.list(team_id, remote_dir, recursive=False, return_type="fileinfo")
+        return {get_file_name_with_ext(info.path.rstrip("/")): info for info in infos}
+
+    async def _matches_remote_file(self, src: str, info: FileInfo) -> bool:
+        """True if the local file is already on the server, compared by hash or, as a
+        fallback, by size."""
+        if info.hash is not None:
+            return info.hash == await get_file_hash_chunked_async(src)
+        if info.sizeb is not None:
+            logger.debug(f"Remote file {info.path} has no hash, comparing by size.")
+            return info.sizeb == get_file_size(src)
+        return False
+
+    async def _filter_uploaded_by_hash(
+        self,
+        team_id: int,
+        src_paths: List[str],
+        dst_paths: List[str],
+        progress_cb: Optional[Union[tqdm, Callable]] = None,
+        progress_cb_type: Literal["number", "size"] = "size",
+    ) -> Tuple[List[str], List[str]]:
+        """Drop the pairs whose destination already holds an identical file.
+        Skipped files are still reported to `progress_cb` so the bar reaches 100%."""
+        listed: Dict[str, Dict[str, FileInfo]] = {}
+        filtered_src, filtered_dst = [], []
+        skipped = 0
+        for src, dst in zip(src_paths, dst_paths):
+            remote_dir = os.path.dirname(dst)
+            if remote_dir not in listed:
+                listed[remote_dir] = self._remote_files_by_name(team_id, remote_dir)
+            info = listed[remote_dir].get(get_file_name_with_ext(dst))
+            if info is not None and await self._matches_remote_file(src, info):
+                value = get_file_size(src) if progress_cb_type == "size" else 1
+                self._report_progress(progress_cb, value)
+                skipped += 1
+                continue
+            filtered_src.append(src)
+            filtered_dst.append(dst)
+        if skipped > 0:
+            logger.info(f"Skipping {skipped} of {len(src_paths)} files already uploaded.")
+        return filtered_src, filtered_dst
+
     async def _check_uploaded_file(self, src: str, dst: str, response_body: bytes) -> None:
         """Verify that the file uploaded to `dst` matches the local file `src`,
         using hash (or size) from the upload response. Raises IOError on mismatch."""
@@ -2390,6 +2450,7 @@ class FileApi(ModuleApiBase):
         progress_cb: Optional[Union[tqdm, Callable]] = None,
         progress_cb_type: Literal["number", "size"] = "size",
         enable_fallback: Optional[bool] = True,
+        skip_existing_by_hash: bool = False,
     ) -> None:
         """
         Upload multiple files from local paths to Team Files asynchronously.
@@ -2415,6 +2476,11 @@ class FileApi(ModuleApiBase):
         :type progress_cb_type: Literal["number", "size"], optional
         :param enable_fallback: If True, the method will fallback to synchronous upload if an error occurs.
         :type enable_fallback: bool, optional
+        :param skip_existing_by_hash: If True, files whose destination already holds an identical
+            file (compared by hash, or by size when the server reports no hash) are not uploaded
+            again. Useful to resume an interrupted upload. Not supported by the synchronous
+            fallback, so combine it with ``enable_fallback=False``.
+        :type skip_existing_by_hash: bool, optional
         :returns: None
         :rtype: None
 
@@ -2449,6 +2515,16 @@ class FileApi(ModuleApiBase):
                     api.file.upload_bulk_async(8, paths_to_files, paths_to_save)
                 )
         """
+        # outside the try below on purpose: a failure to list the destination must not
+        # silently degrade into re-uploading everything
+        if skip_existing_by_hash:
+            src_paths, dst_paths = await self._filter_uploaded_by_hash(
+                team_id=team_id,
+                src_paths=src_paths,
+                dst_paths=dst_paths,
+                progress_cb=progress_cb,
+                progress_cb_type=progress_cb_type,
+            )
         try:
             if semaphore is None:
                 semaphore = self._api.get_default_semaphore()
@@ -2499,6 +2575,7 @@ class FileApi(ModuleApiBase):
         progress_size_cb: Optional[Union[tqdm, Callable]] = None,
         replace_if_conflict: Optional[bool] = False,
         enable_fallback: Optional[bool] = True,
+        skip_existing_by_hash: bool = False,
     ) -> str:
         """
         Upload Directory to Team Files from local path.
@@ -2518,6 +2595,10 @@ class FileApi(ModuleApiBase):
         :type replace_if_conflict: bool, optional
         :param enable_fallback: If True, the method will fallback to synchronous upload if an error occurs.
         :type enable_fallback: bool, optional
+        :param skip_existing_by_hash: If True, files already present at the destination with an
+            identical hash (or size, when the server reports no hash) are not uploaded again.
+            Not supported by the synchronous fallback.
+        :type skip_existing_by_hash: bool, optional
         :returns: Path to Directory in Team Files
         :rtype: str
 
@@ -2542,10 +2623,11 @@ class FileApi(ModuleApiBase):
 
                 api.file.upload_directory(8, local_path, path_to_dir)
         """
+        if not remote_dir.startswith("/"):
+            remote_dir = "/" + remote_dir
+        # bound before the first API call so the fallback below can always read it
+        res_remote_dir = remote_dir
         try:
-            if not remote_dir.startswith("/"):
-                remote_dir = "/" + remote_dir
-
             if self.dir_exists(team_id, remote_dir):
                 if change_name_if_conflict is True:
                     res_remote_dir = self.get_free_dir_name(team_id, remote_dir)
@@ -2569,6 +2651,8 @@ class FileApi(ModuleApiBase):
                 src_paths=local_files,
                 dst_paths=remote_files,
                 progress_cb=progress_size_cb,
+                enable_fallback=enable_fallback,
+                skip_existing_by_hash=skip_existing_by_hash,
             )
         except Exception as e:
             if enable_fallback:
@@ -2597,6 +2681,7 @@ class FileApi(ModuleApiBase):
         progress_cb: Optional[Union[tqdm, Callable]] = None,
         replace_if_conflict: Optional[bool] = False,
         enable_fallback: Optional[bool] = True,
+        skip_existing_by_hash: bool = False,
     ) -> str:
         """
         Upload Directory to Team Files from local path in fast mode.
@@ -2616,6 +2701,10 @@ class FileApi(ModuleApiBase):
         :type replace_if_conflict: bool, optional
         :param enable_fallback: If True, the method will fallback to synchronous upload if an error occurs.
         :type enable_fallback: bool, optional
+        :param skip_existing_by_hash: If True, files already present at the destination with an
+            identical hash (or size, when the server reports no hash) are not uploaded again.
+            Not supported by the synchronous fallback.
+        :type skip_existing_by_hash: bool, optional
         :returns: Path to Directory in Team Files
         :rtype: str
         """
@@ -2627,6 +2716,7 @@ class FileApi(ModuleApiBase):
             progress_size_cb=progress_cb,
             replace_if_conflict=replace_if_conflict,
             enable_fallback=enable_fallback,
+            skip_existing_by_hash=skip_existing_by_hash,
         )
         return run_coroutine(coroutine)
 
@@ -2639,6 +2729,7 @@ class FileApi(ModuleApiBase):
         progress_cb: Optional[Union[tqdm, Callable]] = None,
         progress_cb_type: Literal["number", "size"] = "size",
         enable_fallback: Optional[bool] = True,
+        skip_existing_by_hash: bool = False,
     ) -> None:
         """
         Upload multiple files from local paths to Team Files in fast mode.
@@ -2660,6 +2751,10 @@ class FileApi(ModuleApiBase):
         :type progress_cb_type: Literal["number", "size"], optional
         :param enable_fallback: If True, the method will fallback to synchronous upload if an error occurs.
         :type enable_fallback: bool, optional
+        :param skip_existing_by_hash: If True, files already present at the destination with an
+            identical hash (or size, when the server reports no hash) are not uploaded again.
+            Not supported by the synchronous fallback.
+        :type skip_existing_by_hash: bool, optional
         :returns: None
         :rtype: None
         """
@@ -2671,5 +2766,6 @@ class FileApi(ModuleApiBase):
             progress_cb=progress_cb,
             progress_cb_type=progress_cb_type,
             enable_fallback=enable_fallback,
+            skip_existing_by_hash=skip_existing_by_hash,
         )
         return run_coroutine(coroutine)

--- a/supervisely/api/file_api.py
+++ b/supervisely/api/file_api.py
@@ -2357,20 +2357,18 @@ class FileApi(ModuleApiBase):
             progress_cb(value)
 
     def _remote_files_by_name(self, team_id: int, remote_dir: str) -> Dict[str, FileInfo]:
-        """Non-recursive listing of `remote_dir` as {file name: FileInfo}.
-        A missing directory yields an empty mapping; API errors are not suppressed."""
+        """Listing of `remote_dir` as {name: FileInfo}. Missing dir gives {}, API errors raise."""
         if not self.dir_exists(team_id, remote_dir):
             return {}
         infos = self.list(team_id, remote_dir, recursive=False, return_type="fileinfo")
         return {get_file_name_with_ext(info.path.rstrip("/")): info for info in infos}
 
     async def _matches_remote_file(self, src: str, info: FileInfo) -> bool:
-        """True if the local file is already on the server, compared by hash or, as a
-        fallback, by size."""
+        """True if the local file is already on the server: by hash, or by size as a fallback."""
         if info.hash is not None:
             return info.hash == await get_file_hash_chunked_async(src)
         if info.sizeb is not None:
-            logger.debug(f"Remote file {info.path} has no hash, comparing by size.")
+            logger.debug(f"No hash for {info.path}, comparing by size")
             return info.sizeb == get_file_size(src)
         return False
 
@@ -2382,8 +2380,8 @@ class FileApi(ModuleApiBase):
         progress_cb: Optional[Union[tqdm, Callable]] = None,
         progress_cb_type: Literal["number", "size"] = "size",
     ) -> Tuple[List[str], List[str]]:
-        """Drop the pairs whose destination already holds an identical file.
-        Skipped files are still reported to `progress_cb` so the bar reaches 100%."""
+        """Drop pairs whose destination already holds the same file. Skipped files are still
+        reported to `progress_cb` so the bar reaches 100%."""
         listed: Dict[str, Dict[str, FileInfo]] = {}
         filtered_src, filtered_dst = [], []
         skipped = 0
@@ -2400,7 +2398,7 @@ class FileApi(ModuleApiBase):
             filtered_src.append(src)
             filtered_dst.append(dst)
         if skipped > 0:
-            logger.info(f"Skipping {skipped} of {len(src_paths)} files already uploaded.")
+            logger.info(f"Skipping {skipped}/{len(src_paths)} already uploaded files")
         return filtered_src, filtered_dst
 
     async def _check_uploaded_file(self, src: str, dst: str, response_body: bytes) -> None:
@@ -2515,8 +2513,7 @@ class FileApi(ModuleApiBase):
                     api.file.upload_bulk_async(8, paths_to_files, paths_to_save)
                 )
         """
-        # outside the try below on purpose: a failure to list the destination must not
-        # silently degrade into re-uploading everything
+        # outside the try: a listing error must not degrade into a full re-upload
         if skip_existing_by_hash:
             src_paths, dst_paths = await self._filter_uploaded_by_hash(
                 team_id=team_id,
@@ -2625,7 +2622,7 @@ class FileApi(ModuleApiBase):
         """
         if not remote_dir.startswith("/"):
             remote_dir = "/" + remote_dir
-        # bound before the first API call so the fallback below can always read it
+        # bound before the first API call: the fallback below reads it
         res_remote_dir = remote_dir
         try:
             if self.dir_exists(team_id, remote_dir):

--- a/supervisely/app/fastapi/subapp.py
+++ b/supervisely/app/fastapi/subapp.py
@@ -1262,6 +1262,16 @@ def _init(
                 )
             return app.cached_template
 
+        def drop_cached_template():
+            # The app may render "/" before it is fully wired: Application.__init__ requests it
+            # in a thread to save the offline session. Widgets bake their handlers into the HTML
+            # (see Button._get_on_click), so a template cached at that moment can miss the
+            # handlers registered afterwards. Startup means the module is fully imported, so
+            # drop that early render and let the next request build the final markup.
+            app.cached_template = None
+
+        _add_event_handler(app, "startup", drop_cached_template)
+
         def shutdown():
             from supervisely.app.content import ContentOrigin
 

--- a/supervisely/app/fastapi/subapp.py
+++ b/supervisely/app/fastapi/subapp.py
@@ -1263,11 +1263,8 @@ def _init(
             return app.cached_template
 
         def drop_cached_template():
-            # The app may render "/" before it is fully wired: Application.__init__ requests it
-            # in a thread to save the offline session. Widgets bake their handlers into the HTML
-            # (see Button._get_on_click), so a template cached at that moment can miss the
-            # handlers registered afterwards. Startup means the module is fully imported, so
-            # drop that early render and let the next request build the final markup.
+            # Application.__init__ requests "/" in a thread, so the page can be cached before
+            # widget handlers are registered (they are baked into the HTML). Drop that render.
             app.cached_template = None
 
         _add_event_handler(app, "startup", drop_cached_template)

--- a/supervisely/nn/training/gui/training_process.py
+++ b/supervisely/nn/training/gui/training_process.py
@@ -81,7 +81,7 @@ class TrainingProcess:
         self.start_button = Button("Start")
         self.stop_button = Button("Stop", button_type="danger")
         self.stop_button.hide()  # @TODO: implement stop and hide stop button until training starts
-        # shown when this task is relaunched after a failed artifacts upload; Start is disabled then
+        # shown when the task is relaunched after a failed upload; Start is disabled then
         self.resume_button = Button(
             "Resume Upload", button_type="success", icon="zmdi zmdi-cloud-upload"
         )

--- a/supervisely/nn/training/gui/training_process.py
+++ b/supervisely/nn/training/gui/training_process.py
@@ -83,8 +83,12 @@ class TrainingProcess:
         self.stop_button = Button("Stop", button_type="danger")
         self.stop_button.hide()  # @TODO: implement stop and hide stop button until training starts
         # shown instead of Start when this task is relaunched after a failed artifacts upload
-        self.resume_button = Button("Resume Upload")
+        self.resume_button = Button(
+            "Resume Upload", button_type="success", icon="zmdi zmdi-cloud-upload"
+        )
         self.resume_button.hide()
+        self.resume_info_text = Text("")
+        self.resume_info_text.hide()
         button_container = Container(
             [self.start_button, self.resume_button, self.stop_button, Empty()],
             "horizontal",
@@ -125,6 +129,7 @@ class TrainingProcess:
             [
                 self.experiment_name_field,
                 self.debug_field,  # TODO REMOVE BEFORE MERGE
+                self.resume_info_text,
                 button_container,
                 self.validator_text,
             ]

--- a/supervisely/nn/training/gui/training_process.py
+++ b/supervisely/nn/training/gui/training_process.py
@@ -13,10 +13,12 @@ except ImportError:  # pragma: no cover
 from supervisely.app.widgets import (
     Button,
     Card,
+    Checkbox,
     Container,
     Empty,
     Field,
     Input,
+    InputNumber,
     SelectCudaDevice,
     Text,
 )
@@ -94,8 +96,38 @@ class TrainingProcess:
         self.validator_text = Text("")
         self.validator_text.hide()
 
+        # TODO REMOVE BEFORE MERGE: debug upload failure injection
+        self.debug_fail_async_checkbox = Checkbox(
+            "DEBUG: fail async upload (test sync fallback)"
+        )
+        self.debug_fail_sync_checkbox = Checkbox(
+            "DEBUG: fail async + sync upload (test task stop)"
+        )
+        self.debug_stop_after_checkbox = Checkbox(
+            "DEBUG: stop after N uploaded checkpoints (test resume skip-by-hash)"
+        )
+        self.debug_stop_after_input = InputNumber(value=1, min=1)
+        self.debug_field = Field(
+            title="Debug: upload failure injection",
+            description="Temporary testing controls. Must be removed before merge.",
+            content=Container(
+                [
+                    self.debug_fail_async_checkbox,
+                    self.debug_fail_sync_checkbox,
+                    self.debug_stop_after_checkbox,
+                    self.debug_stop_after_input,
+                ]
+            ),
+        )
+        # TODO REMOVE BEFORE MERGE: end
+
         self.display_widgets.extend(
-            [self.experiment_name_field, button_container, self.validator_text]
+            [
+                self.experiment_name_field,
+                self.debug_field,  # TODO REMOVE BEFORE MERGE
+                button_container,
+                self.validator_text,
+            ]
         )
 
         self.container = Container(self.display_widgets)

--- a/supervisely/nn/training/gui/training_process.py
+++ b/supervisely/nn/training/gui/training_process.py
@@ -13,12 +13,10 @@ except ImportError:  # pragma: no cover
 from supervisely.app.widgets import (
     Button,
     Card,
-    Checkbox,
     Container,
     Empty,
     Field,
     Input,
-    InputNumber,
     SelectCudaDevice,
     Text,
 )
@@ -43,6 +41,7 @@ class TrainingProcess:
         self.start_button = None
         self.stop_button = None
         self.resume_button = None
+        self.resume_info_text = None
         self.validator_text = None
         self.container = None
         self.card = None
@@ -82,7 +81,7 @@ class TrainingProcess:
         self.start_button = Button("Start")
         self.stop_button = Button("Stop", button_type="danger")
         self.stop_button.hide()  # @TODO: implement stop and hide stop button until training starts
-        # shown instead of Start when this task is relaunched after a failed artifacts upload
+        # shown when this task is relaunched after a failed artifacts upload; Start is disabled then
         self.resume_button = Button(
             "Resume Upload", button_type="success", icon="zmdi zmdi-cloud-upload"
         )
@@ -100,35 +99,9 @@ class TrainingProcess:
         self.validator_text = Text("")
         self.validator_text.hide()
 
-        # TODO REMOVE BEFORE MERGE: debug upload failure injection
-        self.debug_fail_async_checkbox = Checkbox(
-            "DEBUG: fail async upload (test sync fallback)"
-        )
-        self.debug_fail_sync_checkbox = Checkbox(
-            "DEBUG: fail async + sync upload (test task stop)"
-        )
-        self.debug_stop_after_checkbox = Checkbox(
-            "DEBUG: stop after N uploaded checkpoints (test resume skip-by-hash)"
-        )
-        self.debug_stop_after_input = InputNumber(value=1, min=1)
-        self.debug_field = Field(
-            title="Debug: upload failure injection",
-            description="Temporary testing controls. Must be removed before merge.",
-            content=Container(
-                [
-                    self.debug_fail_async_checkbox,
-                    self.debug_fail_sync_checkbox,
-                    self.debug_stop_after_checkbox,
-                    self.debug_stop_after_input,
-                ]
-            ),
-        )
-        # TODO REMOVE BEFORE MERGE: end
-
         self.display_widgets.extend(
             [
                 self.experiment_name_field,
-                self.debug_field,  # TODO REMOVE BEFORE MERGE
                 self.resume_info_text,
                 button_container,
                 self.validator_text,

--- a/supervisely/nn/training/gui/training_process.py
+++ b/supervisely/nn/training/gui/training_process.py
@@ -40,6 +40,7 @@ class TrainingProcess:
         self.experiment_name_field = None
         self.start_button = None
         self.stop_button = None
+        self.resume_button = None
         self.validator_text = None
         self.container = None
         self.card = None
@@ -79,11 +80,14 @@ class TrainingProcess:
         self.start_button = Button("Start")
         self.stop_button = Button("Stop", button_type="danger")
         self.stop_button.hide()  # @TODO: implement stop and hide stop button until training starts
+        # shown instead of Start when this task is relaunched after a failed artifacts upload
+        self.resume_button = Button("Resume Upload")
+        self.resume_button.hide()
         button_container = Container(
-            [self.start_button, self.stop_button, Empty()],
+            [self.start_button, self.resume_button, self.stop_button, Empty()],
             "horizontal",
             overflow="wrap",
-            fractions=[1, 1, 10],
+            fractions=[1, 1, 1, 10],
             gap=1,
         )
 

--- a/supervisely/nn/training/resume_manifest.py
+++ b/supervisely/nn/training/resume_manifest.py
@@ -1,0 +1,139 @@
+# coding: utf-8
+"""On-disk manifest that lets a crashed training run finish its artifacts upload.
+
+The manifest is written to ``work_dir`` (never to ``output_dir``, so it is not uploaded)
+right before the artifacts upload starts. When the upload fails the app exits non-zero,
+the agent keeps the task data dir on the host, and a relaunch of the SAME task id mounts
+that dir again — the manifest is then found and the app offers to resume the upload
+instead of training from scratch.
+
+All functions are best-effort: a write failure only disables resume, it never breaks
+training. A manifest that cannot be read, has an unknown version, or belongs to another
+task is treated as absent.
+"""
+
+import json
+import os
+from datetime import datetime
+from typing import Any, Dict, List, Optional
+
+import supervisely.io.fs as sly_fs
+from supervisely.sly_logger import logger
+
+MANIFEST_NAME = ".resume_upload.json"
+VERSION = 1
+
+
+def path(work_dir: str) -> str:
+    """Path of the manifest inside the given work dir."""
+    return os.path.join(work_dir, MANIFEST_NAME)
+
+
+def save(work_dir: str, task_id: int, **fields: Any) -> bool:
+    """Write the manifest, replacing any previous one. Returns False on failure."""
+    manifest = {
+        "version": VERSION,
+        "task_id": task_id,
+        "created_at": datetime.now().isoformat(timespec="seconds"),
+        "attempts": 0,
+        "finalize_done": [],
+    }
+    manifest.update(fields)
+    return _write(work_dir, manifest)
+
+
+def load(work_dir: str, task_id: Optional[int] = None) -> Optional[Dict[str, Any]]:
+    """Read the manifest, or None if it is absent, unreadable, of another version,
+    or belongs to another task."""
+    manifest_path = path(work_dir)
+    if not sly_fs.file_exists(manifest_path):
+        return None
+    try:
+        with open(manifest_path, "r") as f:
+            manifest = json.load(f)
+    except Exception:
+        logger.warning(
+            f"Resume manifest {manifest_path} is unreadable, ignoring it.", exc_info=True
+        )
+        return None
+    if not isinstance(manifest, dict):
+        logger.warning(f"Resume manifest {manifest_path} has unexpected content, ignoring it.")
+        return None
+    if manifest.get("version") != VERSION:
+        logger.warning(
+            f"Resume manifest {manifest_path} has version {manifest.get('version')}, "
+            f"expected {VERSION}. Ignoring it."
+        )
+        return None
+    if task_id is not None and manifest.get("task_id") != task_id:
+        logger.info(
+            f"Resume manifest {manifest_path} belongs to task {manifest.get('task_id')}, "
+            f"current task is {task_id}. Ignoring it."
+        )
+        return None
+    return manifest
+
+
+def update(work_dir: str, **fields: Any) -> Optional[Dict[str, Any]]:
+    """Merge the given fields into the existing manifest. Returns the new manifest."""
+    manifest = load(work_dir)
+    if manifest is None:
+        return None
+    manifest.update(fields)
+    _write(work_dir, manifest)
+    return manifest
+
+
+def mark_done(work_dir: str, step: str) -> None:
+    """Record a finalize step as completed, so a later resume does not repeat it."""
+    manifest = load(work_dir)
+    if manifest is None:
+        return
+    done: List[str] = manifest.get("finalize_done", [])
+    if step in done:
+        return
+    done.append(step)
+    manifest["finalize_done"] = done
+    _write(work_dir, manifest)
+
+
+def is_done(manifest: Optional[Dict[str, Any]], step: str) -> bool:
+    """True if the step was already completed by a previous attempt."""
+    if not manifest:
+        return False
+    return step in manifest.get("finalize_done", [])
+
+
+def bump_attempt(work_dir: str) -> int:
+    """Increment and return the resume attempt counter."""
+    manifest = load(work_dir)
+    if manifest is None:
+        return 0
+    attempts = int(manifest.get("attempts", 0)) + 1
+    manifest["attempts"] = attempts
+    _write(work_dir, manifest)
+    return attempts
+
+
+def remove(work_dir: str) -> None:
+    """Delete the manifest — the run is complete and must not be resumed."""
+    sly_fs.silent_remove(path(work_dir))
+
+
+def _write(work_dir: str, manifest: Dict[str, Any]) -> bool:
+    manifest_path = path(work_dir)
+    tmp_path = manifest_path + ".tmp"
+    try:
+        sly_fs.mkdir(work_dir)
+        with open(tmp_path, "w") as f:
+            json.dump(manifest, f, indent=2)
+        os.replace(tmp_path, manifest_path)
+        return True
+    except Exception:
+        logger.warning(
+            f"Failed to write resume manifest to {manifest_path}. "
+            "Resuming the upload will not be possible for this run.",
+            exc_info=True,
+        )
+        sly_fs.silent_remove(tmp_path)
+        return False

--- a/supervisely/nn/training/resume_manifest.py
+++ b/supervisely/nn/training/resume_manifest.py
@@ -1,15 +1,12 @@
 # coding: utf-8
 """On-disk manifest that lets a crashed training run finish its artifacts upload.
 
-The manifest is written to ``work_dir`` (never to ``output_dir``, so it is not uploaded)
-right before the artifacts upload starts. When the upload fails the app exits non-zero,
-the agent keeps the task data dir on the host, and a relaunch of the SAME task id mounts
-that dir again — the manifest is then found and the app offers to resume the upload
-instead of training from scratch.
+Written to ``work_dir`` (not ``output_dir``, so it is not uploaded) right before the upload
+starts. A failed upload exits non-zero, the agent keeps the task data dir on the host, and a
+relaunch of the same task finds the manifest and offers to resume instead of retraining.
 
-All functions are best-effort: a write failure only disables resume, it never breaks
-training. A manifest that cannot be read, has an unknown version, or belongs to another
-task is treated as absent.
+Every function is best-effort: a write failure only disables resume; an unreadable manifest,
+an unknown version or another task id is treated as absent.
 """
 
 import json
@@ -43,8 +40,7 @@ def save(work_dir: str, task_id: int, **fields: Any) -> bool:
 
 
 def load(work_dir: str, task_id: Optional[int] = None) -> Optional[Dict[str, Any]]:
-    """Read the manifest, or None if it is absent, unreadable, of another version,
-    or belongs to another task."""
+    """Read the manifest, or None if absent, unreadable, of another version or another task."""
     manifest_path = path(work_dir)
     if not sly_fs.file_exists(manifest_path):
         return None
@@ -52,23 +48,19 @@ def load(work_dir: str, task_id: Optional[int] = None) -> Optional[Dict[str, Any
         with open(manifest_path, "r") as f:
             manifest = json.load(f)
     except Exception:
-        logger.warning(
-            f"Resume manifest {manifest_path} is unreadable, ignoring it.", exc_info=True
-        )
+        logger.warning(f"Resume manifest {manifest_path} is unreadable, ignoring", exc_info=True)
         return None
     if not isinstance(manifest, dict):
-        logger.warning(f"Resume manifest {manifest_path} has unexpected content, ignoring it.")
+        logger.warning(f"Resume manifest {manifest_path} has unexpected content, ignoring")
         return None
     if manifest.get("version") != VERSION:
         logger.warning(
-            f"Resume manifest {manifest_path} has version {manifest.get('version')}, "
-            f"expected {VERSION}. Ignoring it."
+            f"Resume manifest version {manifest.get('version')} != {VERSION}, ignoring"
         )
         return None
     if task_id is not None and manifest.get("task_id") != task_id:
         logger.info(
-            f"Resume manifest {manifest_path} belongs to task {manifest.get('task_id')}, "
-            f"current task is {task_id}. Ignoring it."
+            f"Resume manifest belongs to task {manifest.get('task_id')}, current is {task_id}"
         )
         return None
     return manifest
@@ -85,7 +77,7 @@ def update(work_dir: str, **fields: Any) -> Optional[Dict[str, Any]]:
 
 
 def mark_done(work_dir: str, step: str) -> None:
-    """Record a finalize step as completed, so a later resume does not repeat it."""
+    """Mark a finalize step done, so a later resume does not repeat it."""
     manifest = load(work_dir)
     if manifest is None:
         return
@@ -116,7 +108,7 @@ def bump_attempt(work_dir: str) -> int:
 
 
 def remove(work_dir: str) -> None:
-    """Delete the manifest — the run is complete and must not be resumed."""
+    """Delete the manifest: the run is complete."""
     sly_fs.silent_remove(path(work_dir))
 
 
@@ -131,8 +123,7 @@ def _write(work_dir: str, manifest: Dict[str, Any]) -> bool:
         return True
     except Exception:
         logger.warning(
-            f"Failed to write resume manifest to {manifest_path}. "
-            "Resuming the upload will not be possible for this run.",
+            f"Failed to write {manifest_path}, resuming the upload will not be possible",
             exc_info=True,
         )
         sly_fs.silent_remove(tmp_path)

--- a/supervisely/nn/training/train_app.py
+++ b/supervisely/nn/training/train_app.py
@@ -3357,7 +3357,16 @@ class TrainApp:
             self._train_collection_id = manifest.get("train_collection_id")
             self._val_collection_id = manifest.get("val_collection_id")
             self._restore_splits_items(manifest)
-            self._read_project()
+            # finalize itself never reads sly_project, but an app-side export converter may,
+            # so open it when it is there and do not let a damaged project block the recovery
+            try:
+                self._read_project()
+            except Exception:
+                logger.warning(
+                    "Could not read the local project on resume. The upload does not need it, "
+                    "continuing.",
+                    exc_info=True,
+                )
             resume_manifest.bump_attempt(self.work_dir)
         except Exception as e:
             message = f"Error occurred during upload resume initialization. {check_logs_text}"

--- a/supervisely/nn/training/train_app.py
+++ b/supervisely/nn/training/train_app.py
@@ -6,6 +6,7 @@ import os
 import shutil
 import subprocess
 import time
+from collections import namedtuple
 from datetime import datetime
 from os import getcwd, listdir, walk
 from os.path import basename, dirname, exists, expanduser, isdir, isfile, join
@@ -25,6 +26,7 @@ import supervisely.io.json as sly_json
 from supervisely import (
     Api,
     Application,
+    __version__ as sly_version,
     Dataset,
     DatasetInfo,
     OpenMode,
@@ -58,6 +60,7 @@ from supervisely.nn.benchmark import (
 from supervisely.nn.inference import RuntimeType, SessionJSON
 from supervisely.nn.inference.inference import Inference, torch_load_safe
 from supervisely.nn.task_type import TaskType
+from supervisely.nn.training import resume_manifest
 from supervisely.nn.training.gui.gui import TrainGUI
 from supervisely.nn.training.gui.utils import generate_task_check_function_js
 from supervisely.nn.training.loggers import setup_train_logger, train_logger
@@ -72,6 +75,9 @@ from supervisely.project.download import (
     is_cached,
 )
 from supervisely.template.experiment.experiment_generator import ExperimentGenerator
+
+# minimal stand-in for a split item on resume: only these two fields are read by finalize
+_ResumeSplitItem = namedtuple("_ResumeSplitItem", ["dataset_name", "name"])
 
 
 class TrainApp:
@@ -194,6 +200,11 @@ class TrainApp:
         self.sly_project = None
         # -------------------------- #
 
+        # Resume upload: filled in below, once the GUI exists
+        self._resume_ctx: Optional[Dict[str, Any]] = None
+        self._is_resume_upload = False
+        # -------------------------- #
+
         # Train Val Splits
         self._train_split = []
         self._train_split_item_ids = set()
@@ -289,6 +300,9 @@ class TrainApp:
                     pass
             return {"status": status}
 
+        # Detect a relaunch of the same task that crashed while uploading artifacts
+        self._init_resume_upload()
+
         # Read GUI State when launched from experiment modal
         state = self.gui._extract_state_from_env()
         logger.debug(f"State: {state}")
@@ -297,7 +311,10 @@ class TrainApp:
         # Use for debugging guiState
         # gui_state_raw = self.__debug_gui_state()
 
-        if gui_state_raw is not None:
+        # On resume the platform re-sends the original modal.state, so guiState is present again.
+        # Loading it would be a second load_from_app_state call, and step callbacks are toggles:
+        # calling them twice re-locks the cards. The resume state already covers everything.
+        if gui_state_raw is not None and not self._is_resume_upload:
             logger.info("Loading GUI from state")
             logger.debug(f"GUI State: {gui_state_raw}")
             try:
@@ -466,6 +483,10 @@ class TrainApp:
         :returns: Device name.
         :rtype: str
         """
+        # the device widget cannot be restored from app_state, so on resume the value the
+        # training actually ran on comes from the manifest
+        if self._is_resume_upload and self._resume_ctx.get("device"):
+            return self._resume_ctx["device"]
         return self.gui.training_process.get_device()
 
     @property
@@ -666,6 +687,11 @@ class TrainApp:
         def decorator(func):
             self._train_func = timeit_with_result(func)
             self.gui.training_process.start_button.click(self._wrapped_start_training)
+            if self._is_resume_upload:
+                # the model is already trained: the only action left is finishing the upload
+                self.gui.training_process.resume_button.click(self._wrapped_resume_upload)
+                self.gui.training_process.resume_button.show()
+                self.gui.training_process.start_button.hide()
             return func
 
         return decorator
@@ -748,13 +774,198 @@ class TrainApp:
             return [int(p) for p in parts]
         return None
 
-    def _finalize(self, experiment_info: dict) -> None:
+    # Resume upload
+    def _init_resume_upload(self) -> None:
+        """
+        Detects a relaunch of the same task that crashed while uploading artifacts and
+        restores the GUI from the manifest that run left on the agent.
+        """
+        if self.task_id == -1:
+            return
+        manifest = resume_manifest.load(self.work_dir, self.task_id)
+        if manifest is None:
+            return
+        app_state = manifest.get("app_state")
+        if not app_state:
+            logger.warning("Resume manifest has no GUI state. Resuming the upload is not possible.")
+            return
+        try:
+            # click_cb=True is what unlocks the steps the user had already passed.
+            # Validation is off: the manifest is authoritative and re-validating against a
+            # possibly changed project would only lock the GUI again.
+            self.gui.load_from_app_state(app_state, click_cb=True, validate_steps=False)
+        except Exception:
+            logger.error("Failed to restore the GUI state for the upload resume.", exc_info=True)
+            return
+
+        self._resume_ctx = manifest
+        self._is_resume_upload = True
+        self._show_resume_banner(manifest)
+        logger.info(
+            "Artifacts of this task were not fully uploaded. Resume upload mode is enabled, "
+            f"previous attempts: {manifest.get('attempts', 0)}"
+        )
+
+    def _show_resume_banner(self, manifest: dict) -> None:
+        """Tells the user why the app reopened with the steps already filled in."""
+        text = (
+            "This session was restarted after the artifacts upload had failed. "
+            "The model is already trained, training will not be repeated. "
+            'Press "Resume Upload" to upload the remaining files and finish the experiment.'
+        )
+        attempts = manifest.get("attempts", 0)
+        if attempts:
+            text += f" Previous resume attempts: {attempts}."
+        try:
+            self.gui.input_selector.validator_text.set(text, "warning")
+            self.gui.input_selector.validator_text.show()
+            self.gui.stepper.set_active_step(
+                self.gui.steps.index(self.gui.training_process.card) + 1
+            )
+        except Exception:
+            logger.debug("Failed to render the resume banner.", exc_info=True)
+
+    def _get_resume_app_state(self, experiment_info: dict) -> dict:
+        """
+        Builds the GUI state to restore on resume. `get_app_state()` alone is not enough:
+        it carries neither the input step nor the experiment name.
+        """
+        app_state = self.get_app_state(experiment_info)
+        app_state["input"] = {"project_id": self.project_id}
+        app_state["start_training"] = False
+        try:
+            app_state["experiment_name"] = self.gui.training_process.get_experiment_name()
+        except Exception:
+            logger.debug("Experiment name is not available for the resume state.", exc_info=True)
+        return app_state
+
+    def _dump_resume_manifest(self, experiment_info: dict, train_splits_data: dict) -> None:
+        """
+        Persists everything the upload step and the steps after it need, so that a relaunch
+        can redo them without downloading the project or training again.
+        """
+        try:
+            resume_manifest.save(
+                self.work_dir,
+                task_id=self.task_id,
+                sdk_version=sly_version,
+                experiment_info=experiment_info,
+                train_splits_data=train_splits_data,
+                splits_items=self._dump_splits_items(),
+                train_collection_id=self._train_collection_id,
+                val_collection_id=self._val_collection_id,
+                training_duration=self._training_duration,
+                device=self._safe_gui_value(self.gui.training_process.get_device),
+                device_name=self._safe_gui_value(self.gui.training_process.get_device_name),
+                app_state=self._get_resume_app_state(experiment_info),
+            )
+        except Exception:
+            logger.warning(
+                "Failed to prepare the resume manifest. If the upload fails, the artifacts "
+                "will have to be uploaded by re-running the training.",
+                exc_info=True,
+            )
+
+    def _device_name(self) -> Optional[str]:
+        """Human-readable device the training ran on; taken from the manifest on resume."""
+        if self._is_resume_upload and self._resume_ctx.get("device_name"):
+            return self._resume_ctx["device_name"]
+        return self.gui.training_process.get_device_name()
+
+    @staticmethod
+    def _safe_gui_value(getter, default=None):
+        """GUI getters may be disabled by app options; a missing value must not break the dump."""
+        try:
+            return getter()
+        except Exception:
+            return default
+
+    def _dump_splits_items(self) -> dict:
+        """Stores only the fields the finalize steps read from split items."""
+
+        def dump(split: list) -> list:
+            return [
+                {
+                    "dataset_name": getattr(item, "dataset_name", None),
+                    "name": getattr(item, "name", None),
+                }
+                for item in split
+            ]
+
+        return {"train": dump(self._train_split), "val": dump(self._val_split)}
+
+    def _store_benchmark_results(
+        self,
+        lnk_file_info: Optional[FileInfo],
+        report_file_info: Optional[FileInfo],
+        report_id: Optional[int],
+        eval_metrics: dict,
+        primary_metric_name: Optional[str],
+        evaluation_report_link: Optional[str],
+    ) -> None:
+        """Remembers the benchmark outcome so a resume does not evaluate the model again."""
+        resume_manifest.update(
+            self.work_dir,
+            benchmark={
+                "lnk_path": getattr(lnk_file_info, "path", None),
+                "report_path": getattr(report_file_info, "path", None),
+                "report_id": report_id,
+                "eval_metrics": eval_metrics,
+                "primary_metric_name": primary_metric_name,
+                "evaluation_report_link": evaluation_report_link,
+            },
+        )
+        resume_manifest.mark_done(self.work_dir, "benchmark")
+
+    def _restore_benchmark_results(self) -> tuple:
+        """Restores the benchmark outcome stored by a previous attempt. The two FileInfos are
+        re-read from the server by their remote paths."""
+        benchmark = (self._resume_ctx or {}).get("benchmark", {})
+        logger.info("Model benchmark was already done by the previous attempt, reusing its results")
+        return (
+            self._file_info_by_path(benchmark.get("lnk_path")),
+            self._file_info_by_path(benchmark.get("report_path")),
+            benchmark.get("report_id"),
+            benchmark.get("eval_metrics", {}),
+            benchmark.get("primary_metric_name"),
+            benchmark.get("evaluation_report_link"),
+        )
+
+    def _file_info_by_path(self, remote_path: Optional[str]) -> Optional[FileInfo]:
+        if remote_path is None:
+            return None
+        try:
+            return self._api.file.get_info_by_path(self.team_id, remote_path)
+        except Exception:
+            logger.warning(f"Failed to get file info for '{remote_path}'", exc_info=True)
+            return None
+
+    def _restore_splits_items(self, manifest: dict) -> None:
+        """Rebuilds split items from the manifest. Only `dataset_name` and `name` are needed:
+        the finalize steps use them for counts and for the benchmark GT project split."""
+        splits_items = manifest.get("splits_items") or {}
+        self._train_split = [
+            _ResumeSplitItem(item.get("dataset_name"), item.get("name"))
+            for item in splits_items.get("train", [])
+        ]
+        self._val_split = [
+            _ResumeSplitItem(item.get("dataset_name"), item.get("name"))
+            for item in splits_items.get("val", [])
+        ]
+
+    # ----------------------------------------- #
+
+    def _finalize(self, experiment_info: dict, resume: bool = False) -> None:
         """
         Finalizes the training process by validating outputs, uploading artifacts,
         and updating the UI.
 
         :param experiment_info: Information about the experiment results that should be returned in user's training function.
         :type experiment_info: dict
+        :param resume: If True, the artifacts were produced by a previous run of this task and
+            are already on disk: preprocessing and split postprocessing are skipped, and the
+            steps completed by that run are not repeated.
+        :type resume: bool
         """
         logger.info("Finalizing training")
         # Step 1. Validate experiment TaskType
@@ -769,20 +980,41 @@ class TrainApp:
         model_meta = self.create_model_meta(experiment_info["task_type"])
 
         # Step 4. Preprocess artifacts
-        experiment_info = self._preprocess_artifacts(experiment_info, model_meta)
+        # On resume the previous run already moved the artifacts into output_dir and rewrote
+        # the checkpoints, doing it again would corrupt them.
+        if not resume:
+            experiment_info = self._preprocess_artifacts(experiment_info, model_meta)
 
         # Step 5. Postprocess splits
-        train_splits_data = self._postprocess_splits()
+        if resume:
+            train_splits_data = self._resume_ctx.get("train_splits_data", {})
+        else:
+            train_splits_data = self._postprocess_splits()
+            # Everything the steps below need is known now: persist it before the upload,
+            # which is the step that fails on a bad connection.
+            self._dump_resume_manifest(experiment_info, train_splits_data)
 
         # Step 6. Upload artifacts
         self._set_text_status("uploading")
-        remote_dir, session_link_file_info = self._upload_artifacts()
+        remote_dir, session_link_file_info = self._upload_artifacts(resume=resume)
+        if not resume:
+            resume_manifest.update(self.work_dir, remote_dir=remote_dir)
 
         # Step 7. [Optional] Run Model Benchmark
         mb_eval_lnk_file_info, mb_eval_report = None, None
         mb_eval_report_id, eval_metrics = None, {}
         evaluation_report_link, primary_metric_name = None, None
-        if self.is_model_benchmark_enabled:
+        if resume and resume_manifest.is_done(self._resume_ctx, "benchmark"):
+            # already evaluated by the crashed run: reuse it instead of running inference again
+            (
+                mb_eval_lnk_file_info,
+                mb_eval_report,
+                mb_eval_report_id,
+                eval_metrics,
+                primary_metric_name,
+                evaluation_report_link,
+            ) = self._restore_benchmark_results()
+        elif self.is_model_benchmark_enabled:
             try:
                 # Convert GT project
                 gt_project_id, bm_splits_data = None, train_splits_data
@@ -813,17 +1045,29 @@ class TrainApp:
                     evaluation_report_link = abs_url(
                         f"/model-benchmark?id={str(mb_eval_report_id)}"
                     )
+                self._store_benchmark_results(
+                    mb_eval_lnk_file_info,
+                    mb_eval_report,
+                    mb_eval_report_id,
+                    eval_metrics,
+                    primary_metric_name,
+                    evaluation_report_link,
+                )
             except Exception as e:
                 logger.error(f"Model benchmark failed: {e}")
 
         # Step 8. [Optional] Convert weights
         export_weights = {}
-        if self.gui.hyperparameters_selector.is_export_required():
+        if resume and resume_manifest.is_done(self._resume_ctx, "export"):
+            export_weights = self._resume_ctx.get("export_weights", {})
+        elif self.gui.hyperparameters_selector.is_export_required():
             try:
                 export_weights, export_classes_path = self._export_weights(experiment_info)
                 export_weights = self._upload_export_weights(
                     export_weights, export_classes_path, remote_dir
                 )
+                resume_manifest.update(self.work_dir, export_weights=export_weights)
+                resume_manifest.mark_done(self.work_dir, "export")
             except Exception as e:
                 logger.error(f"Export weights failed: {e}")
 
@@ -842,7 +1086,11 @@ class TrainApp:
         experiment_info = self._generate_hyperparameters(remote_dir, experiment_info)
         self._generate_train_val_splits(remote_dir, train_splits_data)
         self._generate_model_meta(remote_dir, model_meta)
-        self._upload_demo_files(remote_dir)
+        # the metadata files above are uploaded to fixed paths and simply overwritten on resume,
+        # but the demo dir would be duplicated with a suffix, so it is uploaded only once
+        if not (resume and resume_manifest.is_done(self._resume_ctx, "demo")):
+            self._upload_demo_files(remote_dir)
+            resume_manifest.mark_done(self.work_dir, "demo")
 
         # Step 10. Generate training output
         output_file_info, experiment_info = self._generate_experiment_output(
@@ -868,6 +1116,9 @@ class TrainApp:
                 mb_eval_lnk_file_info,
                 mb_eval_report_id,
             )
+
+        # Everything is uploaded and the experiment exists: nothing left to resume
+        resume_manifest.remove(self.work_dir)
 
     def _get_best_checkpoint_info(self, experiment_info: dict, remote_dir: str) -> FileInfo:
         """
@@ -2014,7 +2265,7 @@ class TrainApp:
             "evaluation_metrics": eval_metrics,
             "primary_metric": primary_metric_name,
             "logs": {"type": "tensorboard", "link": f"{remote_dir}logs/"},
-            "device": self.gui.training_process.get_device_name(),
+            "device": self._device_name(),
             "training_duration": self._training_duration,
             "train_collection_id": self._train_collection_id,
             "val_collection_id": self._val_collection_id,
@@ -2252,31 +2503,43 @@ class TrainApp:
                 "model_name": model_name,
             }
         elif self.model_source == ModelSource.CUSTOM:
+            # task_id and checkpoint must point at the experiment the weights came from,
+            # otherwise the state cannot be loaded back by _init_model
+            selector = self.gui.model_selector.experiment_selector
+            source_task_id = (self.model_info or {}).get("task_id", self.task_id)
+            checkpoint = selector.get_selected_checkpoint_name() or "custom checkpoint"
             return {
                 "source": ModelSource.CUSTOM,
-                "task_id": self.task_id,
-                "checkpoint": "custom checkpoint",
+                "task_id": source_task_id,
+                "checkpoint": checkpoint,
             }
 
     # ----------------------------------------- #
 
     # Upload artifacts
-    def _upload_artifacts(self) -> None:
+    def _upload_artifacts(self, resume: bool = False) -> None:
         """
         Uploads the training artifacts to Supervisely.
         Path is generated based on the project ID, task ID, and framework name.
 
         Path: /experiments/{project_id}_{project_name}/{task_id}_{framework_name}/
         Example path: /experiments/43192_Apples/68271_rt-detr/
+
+        :param resume: If True, upload into the directory a previous attempt of this task
+            started, skipping the files that already made it there.
+        :type resume: bool
         """
         task_id = self.task_id
 
         remote_artifacts_dir = f"/{self._experiments_dir_name}/{self.project_id}_{self.project_name}/{task_id}_{self.framework_name}/"
+        if resume:
+            # the previous attempt may have been given a suffixed name, that one is the target
+            remote_artifacts_dir = self._resume_ctx.get("remote_dir") or remote_artifacts_dir
         logger.info(
             f"Uploading artifacts directory: '{self.output_dir}' to Supervisely Team Files directory '{remote_artifacts_dir}'"
         )
         # Clean debug directory if exists
-        if task_id == -1:
+        if task_id == -1 and not resume:
             if self._api.file.dir_exists(self.team_id, f"{remote_artifacts_dir}/", True):
                 with self.progress_bar_main(
                     message=f"[Debug] Cleaning train artifacts: '{remote_artifacts_dir}/'",
@@ -2311,6 +2574,12 @@ class TrainApp:
                 local_dir=self.output_dir,
                 remote_dir=remote_artifacts_dir,
                 progress_cb=upload_artifacts_pbar.update,
+                # on resume: same dir, skip what is already there, and never fall back to the
+                # sync path — it cannot skip by hash and would re-send everything
+                change_name_if_conflict=not resume,
+                replace_if_conflict=resume,
+                skip_existing_by_hash=resume,
+                enable_fallback=not resume,
             )
             self.progress_bar_main.hide()
 
@@ -3014,6 +3283,52 @@ class TrainApp:
         finally:
             self.app.shutdown()
 
+    def _wrapped_resume_upload(self):
+        """
+        Finishes a run whose training succeeded but whose artifacts upload did not.
+        The artifacts are still in work_dir on the agent, so nothing is downloaded, nothing is
+        split again and the training function is not called.
+        """
+        check_logs_text = "Please check the logs for more details."
+        manifest = self._resume_ctx
+
+        try:
+            self._set_train_widgets_state_on_start()
+            self._init_logger()
+            # neither _prepare_working_dir() nor _prepare(): work_dir holds the artifacts and
+            # the manifest, and wiping or re-downloading it is exactly what must not happen
+            self._training_duration = manifest.get("training_duration")
+            self._train_collection_id = manifest.get("train_collection_id")
+            self._val_collection_id = manifest.get("val_collection_id")
+            self._restore_splits_items(manifest)
+            self._read_project()
+            resume_manifest.bump_attempt(self.work_dir)
+        except Exception as e:
+            message = f"Error occurred during upload resume initialization. {check_logs_text}"
+            self._show_error(message, e)
+            self._set_ws_progress_status("reset")
+            self.app.shutdown()
+            raise e
+
+        try:
+            self._set_text_status("finalizing")
+            self._set_ws_progress_status("finalizing")
+            self._finalize(manifest["experiment_info"], resume=True)
+            self.gui.training_process.resume_button.loading = False
+
+            if is_production() and self.gui.training_logs.tensorboard_offline_button is not None:
+                self.gui.training_logs.tensorboard_button.hide()
+                self.gui.training_logs.tensorboard_offline_button.show()
+
+            time.sleep(1)
+        except Exception as e:
+            message = f"Error occurred during uploading training artifacts. {check_logs_text}"
+            self._show_error(message, e)
+            self._set_ws_progress_status("reset")
+            raise e
+        finally:
+            self.app.shutdown()
+
     def _show_error(self, message: str, e=None):
         if e is not None:
             logger.error(f"{message}: {repr(e)}", exc_info=True)
@@ -3022,6 +3337,7 @@ class TrainApp:
         self.gui.training_process.validator_text.set(message, "error")
         self.gui.training_process.validator_text.show()
         self.gui.training_process.start_button.loading = False
+        self.gui.training_process.resume_button.loading = False
         self._restore_train_widgets_state_on_error()
         show_dialog(title="Error", description=message, status="error")
 
@@ -3040,9 +3356,13 @@ class TrainApp:
 
         self.gui.training_logs.card.unlock()
         self.gui.stepper.set_active_step(7)
-        self.gui.training_process.validator_text.set("Training has been started...", "info")
+        if self._is_resume_upload:
+            self.gui.training_process.validator_text.set("Resuming the upload...", "info")
+            self.gui.training_process.resume_button.loading = True
+        else:
+            self.gui.training_process.validator_text.set("Training has been started...", "info")
+            self.gui.training_process.start_button.loading = True
         self.gui.training_process.validator_text.show()
-        self.gui.training_process.start_button.loading = True
 
     def _restore_train_widgets_state_on_error(self):
         self.gui.training_logs.card.lock()

--- a/supervisely/nn/training/train_app.py
+++ b/supervisely/nn/training/train_app.py
@@ -845,18 +845,26 @@ class TrainApp:
         )
 
     def _show_resume_banner(self, manifest: dict) -> None:
-        """Tells the user why the app reopened with the steps already filled in."""
-        text = (
+        """Tells the user why the app reopened with the steps already filled in, and what to
+        press. The banner sits on the first card, the call to action next to the button."""
+        banner = (
             "This session was restarted after the artifacts upload had failed. "
-            "The model is already trained, training will not be repeated. "
-            'Press "Resume Upload" to upload the remaining files and finish the experiment.'
+            "The model is already trained, training will not be repeated."
         )
         attempts = manifest.get("attempts", 0)
         if attempts:
-            text += f" Previous resume attempts: {attempts}."
+            banner += f" Previous resume attempts: {attempts}."
+        call_to_action = (
+            "The previous run of this task finished training but failed to upload its artifacts. "
+            "The checkpoints are still on the agent and the training settings below are restored "
+            'from that run. Press "Resume Upload" to upload the remaining files and create the '
+            "experiment — the model will not be trained again."
+        )
         try:
-            self.gui.input_selector.validator_text.set(text, "warning")
+            self.gui.input_selector.validator_text.set(banner, "warning")
             self.gui.input_selector.validator_text.show()
+            self.gui.training_process.resume_info_text.set(call_to_action, "info")
+            self.gui.training_process.resume_info_text.show()
             self.gui.stepper.set_active_step(
                 self.gui.steps.index(self.gui.training_process.card) + 1
             )
@@ -3461,6 +3469,7 @@ class TrainApp:
         self.gui.training_logs.card.unlock()
         self.gui.stepper.set_active_step(7)
         if self._is_resume_upload:
+            self.gui.training_process.resume_info_text.hide()
             self.gui.training_process.validator_text.set("Resuming the upload...", "info")
             self.gui.training_process.resume_button.loading = True
         else:

--- a/supervisely/nn/training/train_app.py
+++ b/supervisely/nn/training/train_app.py
@@ -2517,6 +2517,57 @@ class TrainApp:
     # ----------------------------------------- #
 
     # Upload artifacts
+    # TODO REMOVE BEFORE MERGE: debug upload failure injection
+    def _maybe_inject_upload_failures(self):
+        """
+        Monkeypatches the upload calls so an upload failure can be reproduced on demand.
+        Returns a callable restoring the original methods, or None if nothing is enabled.
+        """
+        tp = self.gui.training_process
+        fail_async = tp.debug_fail_async_checkbox.is_checked()
+        fail_sync = tp.debug_fail_sync_checkbox.is_checked()
+        stop_after = tp.debug_stop_after_checkbox.is_checked()
+        n_limit = int(tp.debug_stop_after_input.get_value()) if stop_after else 0
+        if not (fail_async or fail_sync or stop_after):
+            return None
+
+        original_upload_async = self._api.file.upload_async
+        original_post = self._api.post
+        uploaded = {"count": 0}
+
+        async def patched_upload_async(*args, **kwargs):
+            if stop_after:
+                if uploaded["count"] >= n_limit:
+                    raise RuntimeError("DEBUG: forced stop after N uploaded files")
+                uploaded["count"] += 1
+                return await original_upload_async(*args, **kwargs)
+            raise RuntimeError("DEBUG: forced async upload failure")
+
+        def patched_post(method, *args, **kwargs):
+            # only the upload endpoints: listing must keep working, skip-by-hash relies on it
+            if isinstance(method, str) and (
+                "bulk.upload" in method or "file-storage.upload" in method
+            ):
+                raise RuntimeError("DEBUG: forced sync upload failure")
+            return original_post(method, *args, **kwargs)
+
+        self._api.file.upload_async = patched_upload_async
+        if fail_sync or stop_after:
+            self._api.post = patched_post
+        logger.warning(
+            "DEBUG upload failure injection is active: "
+            f"fail_async={fail_async}, fail_sync={fail_sync}, "
+            f"stop_after={n_limit if stop_after else None}"
+        )
+
+        def restore():
+            self._api.file.upload_async = original_upload_async
+            self._api.post = original_post
+
+        return restore
+
+    # TODO REMOVE BEFORE MERGE: end
+
     def _upload_artifacts(self, resume: bool = False) -> None:
         """
         Uploads the training artifacts to Supervisely.
@@ -2569,18 +2620,23 @@ class TrainApp:
             unit_divisor=1024,
         ) as upload_artifacts_pbar:
             self.progress_bar_main.show()
-            remote_dir = self._api.file.upload_directory_fast(
-                team_id=self.team_id,
-                local_dir=self.output_dir,
-                remote_dir=remote_artifacts_dir,
-                progress_cb=upload_artifacts_pbar.update,
-                # on resume: same dir, skip what is already there, and never fall back to the
-                # sync path — it cannot skip by hash and would re-send everything
-                change_name_if_conflict=not resume,
-                replace_if_conflict=resume,
-                skip_existing_by_hash=resume,
-                enable_fallback=not resume,
-            )
+            restore_upload = self._maybe_inject_upload_failures()  # TODO REMOVE BEFORE MERGE
+            try:
+                remote_dir = self._api.file.upload_directory_fast(
+                    team_id=self.team_id,
+                    local_dir=self.output_dir,
+                    remote_dir=remote_artifacts_dir,
+                    progress_cb=upload_artifacts_pbar.update,
+                    # on resume: same dir, skip what is already there, and never fall back to the
+                    # sync path — it cannot skip by hash and would re-send everything
+                    change_name_if_conflict=not resume,
+                    replace_if_conflict=resume,
+                    skip_existing_by_hash=resume,
+                    enable_fallback=not resume,
+                )
+            finally:  # TODO REMOVE BEFORE MERGE
+                if restore_upload is not None:
+                    restore_upload()
             self.progress_bar_main.hide()
 
         file_info = self._api.file.get_info_by_path(self.team_id, join(remote_dir, "open_app.lnk"))

--- a/supervisely/nn/training/train_app.py
+++ b/supervisely/nn/training/train_app.py
@@ -2572,57 +2572,6 @@ class TrainApp:
     # ----------------------------------------- #
 
     # Upload artifacts
-    # TODO REMOVE BEFORE MERGE: debug upload failure injection
-    def _maybe_inject_upload_failures(self):
-        """
-        Monkeypatches the upload calls so an upload failure can be reproduced on demand.
-        Returns a callable restoring the original methods, or None if nothing is enabled.
-        """
-        tp = self.gui.training_process
-        fail_async = tp.debug_fail_async_checkbox.is_checked()
-        fail_sync = tp.debug_fail_sync_checkbox.is_checked()
-        stop_after = tp.debug_stop_after_checkbox.is_checked()
-        n_limit = int(tp.debug_stop_after_input.get_value()) if stop_after else 0
-        if not (fail_async or fail_sync or stop_after):
-            return None
-
-        original_upload_async = self._api.file.upload_async
-        original_post = self._api.post
-        uploaded = {"count": 0}
-
-        async def patched_upload_async(*args, **kwargs):
-            if stop_after:
-                if uploaded["count"] >= n_limit:
-                    raise RuntimeError("DEBUG: forced stop after N uploaded files")
-                uploaded["count"] += 1
-                return await original_upload_async(*args, **kwargs)
-            raise RuntimeError("DEBUG: forced async upload failure")
-
-        def patched_post(method, *args, **kwargs):
-            # only the upload endpoints: listing must keep working, skip-by-hash relies on it
-            if isinstance(method, str) and (
-                "bulk.upload" in method or "file-storage.upload" in method
-            ):
-                raise RuntimeError("DEBUG: forced sync upload failure")
-            return original_post(method, *args, **kwargs)
-
-        self._api.file.upload_async = patched_upload_async
-        if fail_sync or stop_after:
-            self._api.post = patched_post
-        logger.warning(
-            "DEBUG upload failure injection is active: "
-            f"fail_async={fail_async}, fail_sync={fail_sync}, "
-            f"stop_after={n_limit if stop_after else None}"
-        )
-
-        def restore():
-            self._api.file.upload_async = original_upload_async
-            self._api.post = original_post
-
-        return restore
-
-    # TODO REMOVE BEFORE MERGE: end
-
     def _upload_artifacts(self, resume: bool = False) -> None:
         """
         Uploads the training artifacts to Supervisely.
@@ -2675,23 +2624,18 @@ class TrainApp:
             unit_divisor=1024,
         ) as upload_artifacts_pbar:
             self.progress_bar_main.show()
-            restore_upload = self._maybe_inject_upload_failures()  # TODO REMOVE BEFORE MERGE
-            try:
-                remote_dir = self._api.file.upload_directory_fast(
-                    team_id=self.team_id,
-                    local_dir=self.output_dir,
-                    remote_dir=remote_artifacts_dir,
-                    progress_cb=upload_artifacts_pbar.update,
-                    # on resume: same dir, skip what is already there, and never fall back to the
-                    # sync path — it cannot skip by hash and would re-send everything
-                    change_name_if_conflict=not resume,
-                    replace_if_conflict=resume,
-                    skip_existing_by_hash=resume,
-                    enable_fallback=not resume,
-                )
-            finally:  # TODO REMOVE BEFORE MERGE
-                if restore_upload is not None:
-                    restore_upload()
+            remote_dir = self._api.file.upload_directory_fast(
+                team_id=self.team_id,
+                local_dir=self.output_dir,
+                remote_dir=remote_artifacts_dir,
+                progress_cb=upload_artifacts_pbar.update,
+                # on resume: same dir, skip what is already there, and never fall back to the
+                # sync path — it cannot skip by hash and would re-send everything
+                change_name_if_conflict=not resume,
+                replace_if_conflict=resume,
+                skip_existing_by_hash=resume,
+                enable_fallback=not resume,
+            )
             self.progress_bar_main.hide()
 
         file_info = self._api.file.get_info_by_path(self.team_id, join(remote_dir, "open_app.lnk"))

--- a/supervisely/nn/training/train_app.py
+++ b/supervisely/nn/training/train_app.py
@@ -163,6 +163,9 @@ class TrainApp:
         self._experiments_dir_name = "experiments"
         self._default_work_dir_name = "work_dir"
         self._export_dir_name = "export"
+        self._benchmark_dir_name = "benchmark"
+        # produced inside output_dir by the finalize steps that run after the upload
+        self._post_upload_dir_names = (self._benchmark_dir_name,)
         self._tensorboard_port = 6006
 
         if is_production():
@@ -2572,6 +2575,28 @@ class TrainApp:
     # ----------------------------------------- #
 
     # Upload artifacts
+    def _drop_post_upload_files(self, local_files: List[str]) -> List[str]:
+        """
+        Removes from the list everything that lives in a directory produced after the upload step.
+        A normal run uploads output_dir before those directories exist; on resume they are already
+        on disk, and the benchmark working directory in particular holds the downloaded GT and DT
+        projects and the visualizations, which have no place in the experiment.
+        """
+        skipped_prefixes = tuple(
+            join(self.output_dir, name) + os.sep for name in self._post_upload_dir_names
+        )
+        kept = [path for path in local_files if not path.startswith(skipped_prefixes)]
+        if len(kept) != len(local_files):
+            logger.debug(
+                f"Skipping {len(local_files) - len(kept)} files from "
+                f"{list(self._post_upload_dir_names)} while resuming the upload."
+            )
+        return kept
+
+    def _remote_artifact_path(self, local_path: str, remote_dir: str) -> str:
+        """Destination of a local artifact inside the remote experiment directory."""
+        return remote_dir.rstrip("/") + "/" + os.path.relpath(local_path, self.output_dir)
+
     def _upload_artifacts(self, resume: bool = False) -> None:
         """
         Uploads the training artifacts to Supervisely.
@@ -2590,9 +2615,7 @@ class TrainApp:
         if resume:
             # the previous attempt may have been given a suffixed name, that one is the target
             remote_artifacts_dir = self._resume_ctx.get("remote_dir") or remote_artifacts_dir
-        logger.info(
-            f"Uploading artifacts directory: '{self.output_dir}' to Supervisely Team Files directory '{remote_artifacts_dir}'"
-        )
+
         # Clean debug directory if exists
         if task_id == -1 and not resume:
             if self._api.file.dir_exists(self.team_id, f"{remote_artifacts_dir}/", True):
@@ -2605,6 +2628,20 @@ class TrainApp:
                     upload_artifacts_pbar.update(1)
                     self.progress_bar_main.hide()
 
+        if not resume:
+            # Resolve the final directory name before a single byte is uploaded and remember it:
+            # if this task already has an experiment directory, the upload would silently get a
+            # suffixed name, and a later resume must not send the rest into the original one.
+            if self._api.file.dir_exists(self.team_id, remote_artifacts_dir):
+                remote_artifacts_dir = self._api.file.get_free_dir_name(
+                    self.team_id, remote_artifacts_dir
+                )
+            resume_manifest.update(self.work_dir, remote_dir=remote_artifacts_dir)
+
+        logger.info(
+            f"Uploading artifacts directory: '{self.output_dir}' to Supervisely Team Files directory '{remote_artifacts_dir}'"
+        )
+
         # Generate link file
         if is_production():
             app_url = f"/apps/sessions/{task_id}"
@@ -2615,6 +2652,8 @@ class TrainApp:
             print(app_url, file=text_file)
 
         local_files = sly_fs.list_files_recursively(self.output_dir)
+        if resume:
+            local_files = self._drop_post_upload_files(local_files)
         total_size = sum([sly_fs.get_file_size(file_path) for file_path in local_files])
         with self.progress_bar_main(
             message="Uploading train artifacts to Team Files",
@@ -2624,18 +2663,27 @@ class TrainApp:
             unit_divisor=1024,
         ) as upload_artifacts_pbar:
             self.progress_bar_main.show()
-            remote_dir = self._api.file.upload_directory_fast(
-                team_id=self.team_id,
-                local_dir=self.output_dir,
-                remote_dir=remote_artifacts_dir,
-                progress_cb=upload_artifacts_pbar.update,
-                # on resume: same dir, skip what is already there, and never fall back to the
-                # sync path — it cannot skip by hash and would re-send everything
-                change_name_if_conflict=not resume,
-                replace_if_conflict=resume,
-                skip_existing_by_hash=resume,
-                enable_fallback=not resume,
-            )
+            if resume:
+                # a file list instead of the whole directory: the working directories of the
+                # steps that run after the upload must stay out of the experiment
+                remote_dir = remote_artifacts_dir
+                self._api.file.upload_bulk_fast(
+                    team_id=self.team_id,
+                    src_paths=local_files,
+                    dst_paths=[self._remote_artifact_path(p, remote_dir) for p in local_files],
+                    progress_cb=upload_artifacts_pbar.update,
+                    # never fall back to the sync path: it cannot skip by hash and would re-send
+                    # everything that already made it to the server
+                    skip_existing_by_hash=True,
+                    enable_fallback=False,
+                )
+            else:
+                remote_dir = self._api.file.upload_directory_fast(
+                    team_id=self.team_id,
+                    local_dir=self.output_dir,
+                    remote_dir=remote_artifacts_dir,
+                    progress_cb=upload_artifacts_pbar.update,
+                )
             self.progress_bar_main.hide()
 
         file_info = self._api.file.get_info_by_path(self.team_id, join(remote_dir, "open_app.lnk"))
@@ -2849,7 +2897,7 @@ class TrainApp:
 
             port = 8000
             session = SessionJSON(self._api, session_url=f"http://localhost:{port}")
-            benchmark_dir = join(local_artifacts_dir, "benchmark")
+            benchmark_dir = join(local_artifacts_dir, self._benchmark_dir_name)
             sly_fs.mkdir(benchmark_dir, True)
 
             # 1. Init benchmark
@@ -3273,6 +3321,18 @@ class TrainApp:
         """
         experiment_info = None
         check_logs_text = "Please check the logs for more details."
+
+        # The Start button is disabled in resume mode, but this method is also reachable from
+        # /train_from_api and from start_in_thread(). Training wipes work_dir, which is where the
+        # artifacts waiting to be uploaded live, so refuse instead of destroying them.
+        if self._is_resume_upload:
+            message = (
+                "This task is in resume-upload mode: its trained artifacts are still waiting to be "
+                "uploaded. Starting the training would erase them. Press 'Resume Upload' to finish "
+                "the upload, or run a new task to train again."
+            )
+            logger.error(message)
+            raise RuntimeError(message)
 
         try:
             self._set_train_widgets_state_on_start()

--- a/supervisely/nn/training/train_app.py
+++ b/supervisely/nn/training/train_app.py
@@ -692,10 +692,11 @@ class TrainApp:
             self._train_func = timeit_with_result(func)
             self.gui.training_process.start_button.click(self._wrapped_start_training)
             if self._is_resume_upload:
-                # the model is already trained: the only action left is finishing the upload
+                # the model is already trained: the only action left is finishing the upload.
+                # Start stays visible but disabled, so the button row keeps its layout.
                 self.gui.training_process.resume_button.click(self._wrapped_resume_upload)
                 self.gui.training_process.resume_button.show()
-                self.gui.training_process.start_button.hide()
+                self.gui.training_process.start_button.disable()
             return func
 
         return decorator

--- a/supervisely/nn/training/train_app.py
+++ b/supervisely/nn/training/train_app.py
@@ -77,7 +77,7 @@ from supervisely.project.download import (
 )
 from supervisely.template.experiment.experiment_generator import ExperimentGenerator
 
-# minimal stand-in for a split item on resume: only these two fields are read by finalize
+# split item stand-in for resume: finalize reads only these two fields
 _ResumeSplitItem = namedtuple("_ResumeSplitItem", ["dataset_name", "name"])
 
 
@@ -164,7 +164,7 @@ class TrainApp:
         self._default_work_dir_name = "work_dir"
         self._export_dir_name = "export"
         self._benchmark_dir_name = "benchmark"
-        # produced inside output_dir by the finalize steps that run after the upload
+        # created in output_dir by the steps that run after the upload
         self._post_upload_dir_names = (self._benchmark_dir_name,)
         self._tensorboard_port = 6006
 
@@ -242,7 +242,7 @@ class TrainApp:
 
         self.app = Application(layout=self.gui.layout)
         self._server = self.app.get_server()
-        # registered after Application(), so it runs after the framework shutdown handlers
+        # registered after Application(), so it runs last on shutdown
         _add_event_handler(self._server, "shutdown", self._exit_with_requested_code)
         self._train_func = None
         self._training_duration = None
@@ -318,9 +318,8 @@ class TrainApp:
         # Use for debugging guiState
         # gui_state_raw = self.__debug_gui_state()
 
-        # On resume the platform re-sends the original modal.state, so guiState is present again.
-        # Loading it would be a second load_from_app_state call, and step callbacks are toggles:
-        # calling them twice re-locks the cards. The resume state already covers everything.
+        # On resume the platform re-sends guiState, and a second load_from_app_state would
+        # re-lock the cards: step callbacks are toggles. The resume state already covers it.
         if gui_state_raw is not None and not self._is_resume_upload:
             logger.info("Loading GUI from state")
             logger.debug(f"GUI State: {gui_state_raw}")
@@ -490,8 +489,7 @@ class TrainApp:
         :returns: Device name.
         :rtype: str
         """
-        # the device widget cannot be restored from app_state, so on resume the value the
-        # training actually ran on comes from the manifest
+        # app_state cannot carry the device, so on resume it comes from the manifest
         if self._is_resume_upload and self._resume_ctx.get("device"):
             return self._resume_ctx["device"]
         return self.gui.training_process.get_device()
@@ -695,8 +693,7 @@ class TrainApp:
             self._train_func = timeit_with_result(func)
             self.gui.training_process.start_button.click(self._wrapped_start_training)
             if self._is_resume_upload:
-                # the model is already trained: the only action left is finishing the upload.
-                # Start stays visible but disabled, so the button row keeps its layout.
+                # only the upload is left; Start stays visible but disabled to keep the layout
                 self.gui.training_process.resume_button.click(self._wrapped_resume_upload)
                 self.gui.training_process.resume_button.show()
                 self.gui.training_process.start_button.disable()
@@ -785,26 +782,18 @@ class TrainApp:
     # Resume upload
     def _request_non_zero_exit(self) -> None:
         """
-        Ask the process to exit with a non-zero code, but only if a resume is actually possible.
-
-        The agent deletes the task data dir on the host as soon as the container exits with 0
-        (`agent/worker/task_app.py`, success-only cleanup at the end of `main_step`). A failure
-        raised inside a GUI button handler is answered with HTTP 500 and then a graceful uvicorn
-        shutdown, so without this the process still exits 0 and the artifacts a resume needs are
-        wiped.
+        Exit non-zero, but only if a resume is possible: the agent deletes the task data dir as
+        soon as the container exits with 0, and a failure inside a button handler otherwise ends
+        in a graceful shutdown with code 0.
         """
         if resume_manifest.load(self.work_dir, self.task_id) is None:
-            # nothing to resume from, keep the previous behaviour and let the dir be cleaned
+            # nothing to resume from: let the agent clean the dir as before
             return
         self._exit_code = 1
-        logger.info(
-            "Artifacts are kept on the agent for a resume upload: "
-            "the task will finish with a non-zero exit code."
-        )
+        logger.info("Artifacts kept on the agent for a resume upload, exiting non-zero")
 
     def _exit_with_requested_code(self) -> None:
-        """Shutdown hook: registered last, so state and logs are flushed by the framework
-        handlers before the process is terminated."""
+        """Shutdown hook, registered last so the framework flushes state and logs first."""
         if self._exit_code == 0:
             return
         logger.info(f"Exiting with code {self._exit_code}")
@@ -818,10 +807,7 @@ class TrainApp:
         os._exit(self._exit_code)
 
     def _init_resume_upload(self) -> None:
-        """
-        Detects a relaunch of the same task that crashed while uploading artifacts and
-        restores the GUI from the manifest that run left on the agent.
-        """
+        """Detect a relaunch of a task that crashed while uploading and restore its GUI."""
         if self.task_id == -1:
             return
         manifest = resume_manifest.load(self.work_dir, self.task_id)
@@ -829,28 +815,26 @@ class TrainApp:
             return
         app_state = manifest.get("app_state")
         if not app_state:
-            logger.warning("Resume manifest has no GUI state. Resuming the upload is not possible.")
+            logger.warning("Resume manifest has no GUI state, cannot resume the upload")
             return
         try:
-            # click_cb=True is what unlocks the steps the user had already passed.
-            # Validation is off: the manifest is authoritative and re-validating against a
-            # possibly changed project would only lock the GUI again.
+            # click_cb=True unlocks the passed steps; validation is off because the manifest
+            # is authoritative and re-validating a changed project would lock the GUI again
             self.gui.load_from_app_state(app_state, click_cb=True, validate_steps=False)
         except Exception:
-            logger.error("Failed to restore the GUI state for the upload resume.", exc_info=True)
+            logger.error("Failed to restore the GUI state for the resume", exc_info=True)
             return
 
         self._resume_ctx = manifest
         self._is_resume_upload = True
         self._show_resume_banner(manifest)
         logger.info(
-            "Artifacts of this task were not fully uploaded. Resume upload mode is enabled, "
-            f"previous attempts: {manifest.get('attempts', 0)}"
+            f"Resume upload mode is enabled, previous attempts: {manifest.get('attempts', 0)}"
         )
 
     def _show_resume_banner(self, manifest: dict) -> None:
-        """Tells the user why the app reopened with the steps already filled in, and what to
-        press. The banner sits on the first card, the call to action next to the button."""
+        """Explain why the steps are already filled in: banner on the first card, call to
+        action next to the button."""
         banner = (
             "This session was restarted after the artifacts upload had failed. "
             "The model is already trained, training will not be repeated."
@@ -873,27 +857,23 @@ class TrainApp:
                 self.gui.steps.index(self.gui.training_process.card) + 1
             )
         except Exception:
-            logger.debug("Failed to render the resume banner.", exc_info=True)
+            logger.debug("Failed to render the resume banner", exc_info=True)
 
     def _get_resume_app_state(self, experiment_info: dict) -> dict:
-        """
-        Builds the GUI state to restore on resume. `get_app_state()` alone is not enough:
-        it carries neither the input step nor the experiment name.
-        """
+        """GUI state to restore on resume: `get_app_state()` carries neither the input step
+        nor the experiment name."""
         app_state = self.get_app_state(experiment_info)
         app_state["input"] = {"project_id": self.project_id}
         app_state["start_training"] = False
         try:
             app_state["experiment_name"] = self.gui.training_process.get_experiment_name()
         except Exception:
-            logger.debug("Experiment name is not available for the resume state.", exc_info=True)
+            logger.debug("No experiment name for the resume state", exc_info=True)
         return app_state
 
     def _dump_resume_manifest(self, experiment_info: dict, train_splits_data: dict) -> None:
-        """
-        Persists everything the upload step and the steps after it need, so that a relaunch
-        can redo them without downloading the project or training again.
-        """
+        """Persist what the upload and the steps after it need, so a relaunch can redo them
+        without downloading the project or training again."""
         try:
             resume_manifest.save(
                 self.work_dir,
@@ -911,27 +891,26 @@ class TrainApp:
             )
         except Exception:
             logger.warning(
-                "Failed to prepare the resume manifest. If the upload fails, the artifacts "
-                "will have to be uploaded by re-running the training.",
+                "Failed to write the resume manifest, a failed upload will not be resumable",
                 exc_info=True,
             )
 
     def _device_name(self) -> Optional[str]:
-        """Human-readable device the training ran on; taken from the manifest on resume."""
+        """Device the training ran on; from the manifest on resume."""
         if self._is_resume_upload and self._resume_ctx.get("device_name"):
             return self._resume_ctx["device_name"]
         return self.gui.training_process.get_device_name()
 
     @staticmethod
     def _safe_gui_value(getter, default=None):
-        """GUI getters may be disabled by app options; a missing value must not break the dump."""
+        """App options may disable a getter; a missing value must not break the dump."""
         try:
             return getter()
         except Exception:
             return default
 
     def _dump_splits_items(self) -> dict:
-        """Stores only the fields the finalize steps read from split items."""
+        """Store only the split item fields finalize reads."""
 
         def dump(split: list) -> list:
             return [
@@ -953,7 +932,7 @@ class TrainApp:
         primary_metric_name: Optional[str],
         evaluation_report_link: Optional[str],
     ) -> None:
-        """Remembers the benchmark outcome so a resume does not evaluate the model again."""
+        """Remember the benchmark outcome so a resume does not evaluate the model again."""
         resume_manifest.update(
             self.work_dir,
             benchmark={
@@ -968,10 +947,9 @@ class TrainApp:
         resume_manifest.mark_done(self.work_dir, "benchmark")
 
     def _restore_benchmark_results(self) -> tuple:
-        """Restores the benchmark outcome stored by a previous attempt. The two FileInfos are
-        re-read from the server by their remote paths."""
+        """Benchmark outcome of a previous attempt; the FileInfos are re-read by remote path."""
         benchmark = (self._resume_ctx or {}).get("benchmark", {})
-        logger.info("Model benchmark was already done by the previous attempt, reusing its results")
+        logger.info("Benchmark was already done by the previous attempt, reusing its results")
         return (
             self._file_info_by_path(benchmark.get("lnk_path")),
             self._file_info_by_path(benchmark.get("report_path")),
@@ -991,8 +969,8 @@ class TrainApp:
             return None
 
     def _restore_splits_items(self, manifest: dict) -> None:
-        """Rebuilds split items from the manifest. Only `dataset_name` and `name` are needed:
-        the finalize steps use them for counts and for the benchmark GT project split."""
+        """Rebuild split items from the manifest: finalize needs only `dataset_name` and
+        `name`, for counts and for the benchmark GT split."""
         splits_items = manifest.get("splits_items") or {}
         self._train_split = [
             _ResumeSplitItem(item.get("dataset_name"), item.get("name"))
@@ -1018,9 +996,8 @@ class TrainApp:
         :type resume: bool
         """
         logger.info("Finalizing training")
-        # Steps 1-2 are skipped on resume: the manifest holds the already validated and
-        # preprocessed experiment_info, where checkpoint paths are absolute — a shape the
-        # validator (which expects what the user's train function returned) would reject.
+        # Skipped on resume: the manifest holds an already validated and preprocessed
+        # experiment_info, whose absolute checkpoint paths the validator would reject.
         if not resume:
             # Step 1. Validate experiment TaskType
             experiment_info = self._validate_experiment_task_type(experiment_info)
@@ -1034,12 +1011,11 @@ class TrainApp:
         model_meta = self.create_model_meta(experiment_info["task_type"])
 
         # Step 4. Preprocess artifacts
-        # On resume the previous run already moved the artifacts into output_dir and rewrote
-        # the checkpoints, doing it again would corrupt them.
+        # the previous run already moved the artifacts and rewrote the checkpoints
         if not resume:
             experiment_info = self._preprocess_artifacts(experiment_info, model_meta)
         elif self.is_model_benchmark_enabled:
-            # preprocessing is what normally fills these, and the benchmark may still have to run
+            # normally filled by preprocessing, and the benchmark may still have to run
             self._benchmark_params["model_files"] = dict(experiment_info.get("model_files") or {})
             self._benchmark_params["model_files"]["checkpoint"] = experiment_info["best_checkpoint"]
 
@@ -1048,8 +1024,7 @@ class TrainApp:
             train_splits_data = self._resume_ctx.get("train_splits_data", {})
         else:
             train_splits_data = self._postprocess_splits()
-            # Everything the steps below need is known now: persist it before the upload,
-            # which is the step that fails on a bad connection.
+            # persist before the upload: that is the step that fails on a bad connection
             self._dump_resume_manifest(experiment_info, train_splits_data)
 
         # Step 6. Upload artifacts
@@ -1063,7 +1038,7 @@ class TrainApp:
         mb_eval_report_id, eval_metrics = None, {}
         evaluation_report_link, primary_metric_name = None, None
         if resume and resume_manifest.is_done(self._resume_ctx, "benchmark"):
-            # already evaluated by the crashed run: reuse it instead of running inference again
+            # already evaluated by the crashed run: reuse instead of inferring again
             (
                 mb_eval_lnk_file_info,
                 mb_eval_report,
@@ -1144,8 +1119,7 @@ class TrainApp:
         experiment_info = self._generate_hyperparameters(remote_dir, experiment_info)
         self._generate_train_val_splits(remote_dir, train_splits_data)
         self._generate_model_meta(remote_dir, model_meta)
-        # the metadata files above are uploaded to fixed paths and simply overwritten on resume,
-        # but the demo dir would be duplicated with a suffix, so it is uploaded only once
+        # the files above are overwritten on resume, but a demo dir would get a suffix
         if not (resume and resume_manifest.is_done(self._resume_ctx, "demo")):
             self._upload_demo_files(remote_dir)
             resume_manifest.mark_done(self.work_dir, "demo")
@@ -1175,7 +1149,7 @@ class TrainApp:
                 mb_eval_report_id,
             )
 
-        # Everything is uploaded and the experiment exists: nothing left to resume
+        # everything is uploaded and the experiment exists
         resume_manifest.remove(self.work_dir)
 
     def _get_best_checkpoint_info(self, experiment_info: dict, remote_dir: str) -> FileInfo:
@@ -2561,8 +2535,7 @@ class TrainApp:
                 "model_name": model_name,
             }
         elif self.model_source == ModelSource.CUSTOM:
-            # task_id and checkpoint must point at the experiment the weights came from,
-            # otherwise the state cannot be loaded back by _init_model
+            # must point at the source experiment, else _init_model cannot load it back
             selector = self.gui.model_selector.experiment_selector
             source_task_id = (self.model_info or {}).get("task_id", self.task_id)
             checkpoint = selector.get_selected_checkpoint_name() or "custom checkpoint"
@@ -2577,24 +2550,20 @@ class TrainApp:
     # Upload artifacts
     def _drop_post_upload_files(self, local_files: List[str]) -> List[str]:
         """
-        Removes from the list everything that lives in a directory produced after the upload step.
-        A normal run uploads output_dir before those directories exist; on resume they are already
-        on disk, and the benchmark working directory in particular holds the downloaded GT and DT
-        projects and the visualizations, which have no place in the experiment.
+        Drop files from directories produced after the upload step. A normal run uploads
+        output_dir before they exist; the benchmark one holds downloaded GT/DT projects and
+        visualizations, which have no place in the experiment.
         """
         skipped_prefixes = tuple(
             join(self.output_dir, name) + os.sep for name in self._post_upload_dir_names
         )
         kept = [path for path in local_files if not path.startswith(skipped_prefixes)]
         if len(kept) != len(local_files):
-            logger.debug(
-                f"Skipping {len(local_files) - len(kept)} files from "
-                f"{list(self._post_upload_dir_names)} while resuming the upload."
-            )
+            logger.debug(f"Resume upload skips {len(local_files) - len(kept)} post-upload files")
         return kept
 
     def _remote_artifact_path(self, local_path: str, remote_dir: str) -> str:
-        """Destination of a local artifact inside the remote experiment directory."""
+        """Destination of a local artifact in the remote experiment dir."""
         return remote_dir.rstrip("/") + "/" + os.path.relpath(local_path, self.output_dir)
 
     def _upload_artifacts(self, resume: bool = False) -> None:
@@ -2629,9 +2598,8 @@ class TrainApp:
                     self.progress_bar_main.hide()
 
         if not resume:
-            # Resolve the final directory name before a single byte is uploaded and remember it:
-            # if this task already has an experiment directory, the upload would silently get a
-            # suffixed name, and a later resume must not send the rest into the original one.
+            # Resolve and store the target before uploading: an occupied dir would silently
+            # get a suffix, and a later resume must not send the rest into the original one.
             if self._api.file.dir_exists(self.team_id, remote_artifacts_dir):
                 remote_artifacts_dir = self._api.file.get_free_dir_name(
                     self.team_id, remote_artifacts_dir
@@ -2664,16 +2632,14 @@ class TrainApp:
         ) as upload_artifacts_pbar:
             self.progress_bar_main.show()
             if resume:
-                # a file list instead of the whole directory: the working directories of the
-                # steps that run after the upload must stay out of the experiment
+                # a file list, not the whole dir: post-upload working dirs must stay out
                 remote_dir = remote_artifacts_dir
                 self._api.file.upload_bulk_fast(
                     team_id=self.team_id,
                     src_paths=local_files,
                     dst_paths=[self._remote_artifact_path(p, remote_dir) for p in local_files],
                     progress_cb=upload_artifacts_pbar.update,
-                    # never fall back to the sync path: it cannot skip by hash and would re-send
-                    # everything that already made it to the server
+                    # no sync fallback: it cannot skip by hash and would re-send everything
                     skip_existing_by_hash=True,
                     enable_fallback=False,
                 )
@@ -3322,9 +3288,8 @@ class TrainApp:
         experiment_info = None
         check_logs_text = "Please check the logs for more details."
 
-        # The Start button is disabled in resume mode, but this method is also reachable from
-        # /train_from_api and from start_in_thread(). Training wipes work_dir, which is where the
-        # artifacts waiting to be uploaded live, so refuse instead of destroying them.
+        # Also reachable from /train_from_api and start_in_thread(), where the disabled button
+        # does not help. Training wipes work_dir, where the pending artifacts live.
         if self._is_resume_upload:
             message = (
                 "This task is in resume-upload mode: its trained artifacts are still waiting to be "
@@ -3401,9 +3366,8 @@ class TrainApp:
 
     def _wrapped_resume_upload(self):
         """
-        Finishes a run whose training succeeded but whose artifacts upload did not.
-        The artifacts are still in work_dir on the agent, so nothing is downloaded, nothing is
-        split again and the training function is not called.
+        Finish a run whose training succeeded but whose upload did not. The artifacts are still
+        in work_dir, so nothing is downloaded, re-split or trained again.
         """
         check_logs_text = "Please check the logs for more details."
         manifest = self._resume_ctx
@@ -3411,28 +3375,22 @@ class TrainApp:
         try:
             self._set_train_widgets_state_on_start()
             self._init_logger()
-            # neither _prepare_working_dir() nor _prepare(): work_dir holds the artifacts and
-            # the manifest, and wiping or re-downloading it is exactly what must not happen
+            # no _prepare_working_dir() / _prepare(): that would wipe or re-download work_dir
             self._training_duration = manifest.get("training_duration")
             self._train_collection_id = manifest.get("train_collection_id")
             self._val_collection_id = manifest.get("val_collection_id")
             self._restore_splits_items(manifest)
-            # finalize itself never reads sly_project, but an app-side export converter may,
-            # so open it when it is there and do not let a damaged project block the recovery
+            # finalize never reads sly_project, but an app export converter may
             try:
                 self._read_project()
             except Exception:
-                logger.warning(
-                    "Could not read the local project on resume. The upload does not need it, "
-                    "continuing.",
-                    exc_info=True,
-                )
+                logger.warning("Could not read the local project, the upload does not need it")
             resume_manifest.bump_attempt(self.work_dir)
         except Exception as e:
             message = f"Error occurred during upload resume initialization. {check_logs_text}"
             self._show_error(message, e)
             self._set_ws_progress_status("reset")
-            # the artifacts are still on disk: keep them for another attempt
+            # the artifacts are still on disk: keep them
             self._request_non_zero_exit()
             self.app.shutdown()
             raise e

--- a/supervisely/nn/training/train_app.py
+++ b/supervisely/nn/training/train_app.py
@@ -5,6 +5,7 @@ High-level wrapper for building Supervisely training applications.
 import os
 import shutil
 import subprocess
+import sys
 import time
 from collections import namedtuple
 from datetime import datetime
@@ -203,6 +204,7 @@ class TrainApp:
         # Resume upload: filled in below, once the GUI exists
         self._resume_ctx: Optional[Dict[str, Any]] = None
         self._is_resume_upload = False
+        self._exit_code = 0
         # -------------------------- #
 
         # Train Val Splits
@@ -237,6 +239,8 @@ class TrainApp:
 
         self.app = Application(layout=self.gui.layout)
         self._server = self.app.get_server()
+        # registered after Application(), so it runs after the framework shutdown handlers
+        _add_event_handler(self._server, "shutdown", self._exit_with_requested_code)
         self._train_func = None
         self._training_duration = None
 
@@ -775,6 +779,40 @@ class TrainApp:
         return None
 
     # Resume upload
+    def _request_non_zero_exit(self) -> None:
+        """
+        Ask the process to exit with a non-zero code, but only if a resume is actually possible.
+
+        The agent deletes the task data dir on the host as soon as the container exits with 0
+        (`agent/worker/task_app.py`, success-only cleanup at the end of `main_step`). A failure
+        raised inside a GUI button handler is answered with HTTP 500 and then a graceful uvicorn
+        shutdown, so without this the process still exits 0 and the artifacts a resume needs are
+        wiped.
+        """
+        if resume_manifest.load(self.work_dir, self.task_id) is None:
+            # nothing to resume from, keep the previous behaviour and let the dir be cleaned
+            return
+        self._exit_code = 1
+        logger.info(
+            "Artifacts are kept on the agent for a resume upload: "
+            "the task will finish with a non-zero exit code."
+        )
+
+    def _exit_with_requested_code(self) -> None:
+        """Shutdown hook: registered last, so state and logs are flushed by the framework
+        handlers before the process is terminated."""
+        if self._exit_code == 0:
+            return
+        logger.info(f"Exiting with code {self._exit_code}")
+        for handler in logger.handlers:
+            try:
+                handler.flush()
+            except Exception:
+                pass
+        sys.stdout.flush()
+        sys.stderr.flush()
+        os._exit(self._exit_code)
+
     def _init_resume_upload(self) -> None:
         """
         Detects a relaunch of the same task that crashed while uploading artifacts and
@@ -3343,6 +3381,7 @@ class TrainApp:
             message = f"Error occurred during finalizing and uploading training artifacts. {check_logs_text}"
             self._show_error(message, e)
             self._set_ws_progress_status("reset")
+            self._request_non_zero_exit()
             raise e
         finally:
             self.app.shutdown()
@@ -3389,6 +3428,7 @@ class TrainApp:
             message = f"Error occurred during uploading training artifacts. {check_logs_text}"
             self._show_error(message, e)
             self._set_ws_progress_status("reset")
+            self._request_non_zero_exit()
             raise e
         finally:
             self.app.shutdown()

--- a/supervisely/nn/training/train_app.py
+++ b/supervisely/nn/training/train_app.py
@@ -3372,6 +3372,8 @@ class TrainApp:
             message = f"Error occurred during upload resume initialization. {check_logs_text}"
             self._show_error(message, e)
             self._set_ws_progress_status("reset")
+            # the artifacts are still on disk: keep them for another attempt
+            self._request_non_zero_exit()
             self.app.shutdown()
             raise e
 

--- a/supervisely/nn/training/train_app.py
+++ b/supervisely/nn/training/train_app.py
@@ -968,13 +968,17 @@ class TrainApp:
         :type resume: bool
         """
         logger.info("Finalizing training")
-        # Step 1. Validate experiment TaskType
-        experiment_info = self._validate_experiment_task_type(experiment_info)
+        # Steps 1-2 are skipped on resume: the manifest holds the already validated and
+        # preprocessed experiment_info, where checkpoint paths are absolute — a shape the
+        # validator (which expects what the user's train function returned) would reject.
+        if not resume:
+            # Step 1. Validate experiment TaskType
+            experiment_info = self._validate_experiment_task_type(experiment_info)
 
-        # Step 2. Validate experiment_info
-        success, reason = self._validate_experiment_info(experiment_info)
-        if not success:
-            raise ValueError(f"{reason}. Failed to upload artifacts")
+            # Step 2. Validate experiment_info
+            success, reason = self._validate_experiment_info(experiment_info)
+            if not success:
+                raise ValueError(f"{reason}. Failed to upload artifacts")
 
         # Step 3. Create model meta according to model CV task type
         model_meta = self.create_model_meta(experiment_info["task_type"])
@@ -984,6 +988,10 @@ class TrainApp:
         # the checkpoints, doing it again would corrupt them.
         if not resume:
             experiment_info = self._preprocess_artifacts(experiment_info, model_meta)
+        elif self.is_model_benchmark_enabled:
+            # preprocessing is what normally fills these, and the benchmark may still have to run
+            self._benchmark_params["model_files"] = dict(experiment_info.get("model_files") or {})
+            self._benchmark_params["model_files"]["checkpoint"] = experiment_info["best_checkpoint"]
 
         # Step 5. Postprocess splits
         if resume:

--- a/supervisely/nn/training/train_app.py
+++ b/supervisely/nn/training/train_app.py
@@ -256,15 +256,14 @@ class TrainApp:
         if self._tensorrt_supported:
             self._convert_tensorrt_func = None
 
-        # Benchmark parameters
-        if self.is_model_benchmark_enabled:
-            self._benchmark_params = {
-                "model_files": {},
-                "model_source": ModelSource.CUSTOM,
-                "model_info": {},
-                "device": None,
-                "runtime": RuntimeType.PYTORCH,
-            }
+        # Benchmark parameters: always created, the checkbox can be switched on after startup
+        self._benchmark_params = {
+            "model_files": {},
+            "model_source": ModelSource.CUSTOM,
+            "model_info": {},
+            "device": None,
+            "runtime": RuntimeType.PYTORCH,
+        }
         # -------------------------- #
 
         # Train endpoints


### PR DESCRIPTION
### Problem

Training apps upload all artifacts to Team Files in one go at the end of training. If that upload fails on a slow or unstable connection, the app dies and the only way out is to train the model again.

<img width="2100" height="756" alt="image" src="https://github.com/user-attachments/assets/cb92d2aa-0ecb-49f3-a56f-2368c2f78a81" />

### What changed

The upload can now be finished without retraining:

1. Before uploading, TrainApp saves a manifest next to the artifacts in `work_dir` with everything the remaining steps need.
2. If the upload fails, the app exits with a non-zero code, so the agent keeps the task data on the host instead of deleting it.
3. Relaunching the same task finds that manifest, restores the training settings into the GUI and shows a **Resume Upload** button instead of Start.
4. The button uploads only the files missing on the server (compared by hash), finishes the remaining steps and creates the experiment.

<img width="755" height="269" alt="image" src="https://github.com/user-attachments/assets/f3e15487-32a7-4949-a3e7-7a1a61b9a43b" />


If it fails again, the data stays on the agent — the user can retry as many times as needed. Steps that must not run twice (model benchmark, weights export, demo files) are recorded in the manifest and reused.

Successful runs behave exactly as before: the manifest is deleted at the end and the agent cleans up the task data dir.

### (not specific to training apps)

Fixes one crash on the way, unrelated to resuming: `_benchmark_params` was created only when the benchmark checkbox happened to be enabled at startup, so switching it on later — or launching from an experiment that had it off — made finalize fail with `AttributeError`. It is now always created.

### Side changes

**`api/file_api.py`** — new `skip_existing_by_hash` option for the async upload methods (`upload_bulk_async`, `upload_directory_async`, `upload_directory_fast`, `upload_bulk_fast`).

- skips files whose destination already holds an identical file: by hash, or by size when the server reports no hash;
- skipped bytes are still reported to the progress bar, so it reaches 100%;
- an error while listing the destination is raised instead of silently turning into a full re-upload;
- fixes `UnboundLocalError` in `upload_directory_async` when `dir_exists` itself fails — the fallback crashed instead of uploading.

**`app/fastapi/subapp.py`** — the page rendered on the first request to `/` was cached for the whole session, and `Application.__init__` already requests `/` in a background thread. Widgets bake their click handlers into the HTML, so a handler registered after that early request was missing from the cached page: the button rendered fine, but clicking it did nothing. The cache is now dropped on the startup event, when the app module is fully imported, so the first real request builds the final markup. This was a latent race for any app with slow initialization.
