### PR TITLE
Fix restore crash on duplicate image tags; restore project settings

### DIFF
--- a/supervisely/project/project.py
+++ b/supervisely/project/project.py
@@ -10,7 +10,7 @@ import os
 import pickle
 import random
 import shutil
-from collections import defaultdict, namedtuple
+from collections import Counter, defaultdict, namedtuple
 from enum import Enum
 from pathlib import Path
 from typing import (
@@ -4038,7 +4038,12 @@ class Project:
                 new_file_infos.extend(new_file_infos_link)
             # ----------------------------------------------- - ---------------------------------------------- #
 
-            # image_lists_by_tags -> tagId: {tagValue: [imageId]}
+            # image_lists_by_tags -> tagId: {tagValue: [imageId, ...]}
+            # A project with "Multiple tags mode" (allowDuplicateTags) enabled lets
+            # the same tag+value be applied to one image more than once - keep the
+            # list as-is (with repeats) so that count survives the restore; it's
+            # peeled off into duplicate-free batches below, since the bulk endpoint
+            # rejects a batch containing the same image id twice.
             image_lists_by_tags = defaultdict(lambda: defaultdict(list))
             alpha_figures = []
             other_figures = []
@@ -4111,7 +4116,16 @@ class Project:
             api.image.figure.upload_geometries_batch(new_alpha_figure_ids, ordered_alpha_geometries)
             for tag, value in image_lists_by_tags.items():
                 for value, image_ids in value.items():
-                    api.image.add_tag_batch(image_ids, tag, value, batch_size=200)
+                    # Peel off one occurrence per image per call: level 1 covers every
+                    # image that has this tag+value at least once, level 2 only those
+                    # that had it twice, and so on - each call's ids are unique, and
+                    # the total number of calls an image appears in equals its count.
+                    remaining = Counter(image_ids)
+                    while remaining:
+                        api.image.add_tag_batch(list(remaining), tag, value, batch_size=200)
+                        remaining = Counter(
+                            {img_id: n - 1 for img_id, n in remaining.items() if n > 1}
+                        )
             # all_figure_ids is ordered "every other figure, then every alpha figure",
             # while all_figure_tags was filled per image (that image's other figures,
             # then its alpha ones). Pairing them positionally shifted every tag after

--- a/supervisely/project/project.py
+++ b/supervisely/project/project.py
@@ -10,7 +10,7 @@ import os
 import pickle
 import random
 import shutil
-from collections import Counter, defaultdict, namedtuple
+from collections import defaultdict, namedtuple
 from enum import Enum
 from pathlib import Path
 from typing import (
@@ -3903,6 +3903,19 @@ class Project:
         old_new_tags_mapping = dict(
             map(lambda old_tag, new_tag: (old_tag["id"], new_tag["id"]), old_tags, new_tags)
         )
+
+        # Restore project-level settings from the backup. The server silently
+        # ignores any key here it doesn't support, so it's safe to pass the whole
+        # block through as-is. groupImagesByTagId is remapped like every other tag
+        # reference, since it points at a tag id from the source project.
+        if project_info.settings:
+            new_settings = dict(project_info.settings)
+            if new_settings.get("groupImagesByTagId") is not None:
+                new_settings["groupImagesByTagId"] = old_new_tags_mapping.get(
+                    new_settings["groupImagesByTagId"]
+                )
+            api.project.update_settings(new_project_info.id, new_settings)
+
         # remap classes
         old_classes = meta.obj_classes.to_json()
         new_classes = new_meta.obj_classes.to_json()
@@ -4038,13 +4051,7 @@ class Project:
                 new_file_infos.extend(new_file_infos_link)
             # ----------------------------------------------- - ---------------------------------------------- #
 
-            # image_lists_by_tags -> tagId: {tagValue: [imageId, ...]}
-            # A project with "Multiple tags mode" (allowDuplicateTags) enabled lets
-            # the same tag+value be applied to one image more than once - keep the
-            # list as-is (with repeats) so that count survives the restore; it's
-            # peeled off into duplicate-free batches below, since the bulk endpoint
-            # rejects a batch containing the same image id twice.
-            image_lists_by_tags = defaultdict(lambda: defaultdict(list))
+            image_tags_list = []  # to append tags to images in bulk
             alpha_figures = []
             other_figures = []
             all_figure_tags = defaultdict(list)  # figure_id: List of (tagId, value)
@@ -4059,7 +4066,13 @@ class Project:
             for old_file_info, new_file_info in zip(values["infos"], new_file_infos):
                 for tag in old_file_info.tags:
                     new_tag_id = old_new_tags_mapping[tag.get("tagId")]
-                    image_lists_by_tags[new_tag_id][tag.get("value")].append(new_file_info.id)
+                    image_tags_list.append(
+                        {
+                            "tagId": new_tag_id,
+                            "entityId": new_file_info.id,
+                            "value": tag.get("value"),
+                        }
+                    )
                 image_figures = figures.get(old_file_info.id, [])
                 if len(image_figures) > 0:
                     alpha_figure_jsons = []
@@ -4114,18 +4127,17 @@ class Project:
             all_figure_ids.extend(new_alpha_figure_ids)
             ordered_alpha_geometries = list(map(alpha_geometries.get, old_alpha_figure_ids))
             api.image.figure.upload_geometries_batch(new_alpha_figure_ids, ordered_alpha_geometries)
-            for tag, value in image_lists_by_tags.items():
-                for value, image_ids in value.items():
-                    # Peel off one occurrence per image per call: level 1 covers every
-                    # image that has this tag+value at least once, level 2 only those
-                    # that had it twice, and so on - each call's ids are unique, and
-                    # the total number of calls an image appears in equals its count.
-                    remaining = Counter(image_ids)
-                    while remaining:
-                        api.image.add_tag_batch(list(remaining), tag, value, batch_size=200)
-                        remaining = Counter(
-                            {img_id: n - 1 for img_id, n in remaining.items() if n > 1}
-                        )
+            # add_tag_batch's endpoint (image-tags.bulk.add-to-image) requires unique
+            # image ids per call, which can't represent the same tag+value applied to
+            # one image more than once (allowed when allowDuplicateTags is enabled -
+            # restored above). add_to_entities_json posts a plain list of
+            # {tagId, entityId, value} dicts instead, so repeats are just more entries.
+            api.image.tag.add_to_entities_json(
+                new_project_info.id,
+                image_tags_list,
+                batch_size=300,
+                log_progress=True if ds_progress is not None else False,
+            )
             # all_figure_ids is ordered "every other figure, then every alpha figure",
             # while all_figure_tags was filled per image (that image's other figures,
             # then its alpha ones). Pairing them positionally shifted every tag after

--- a/supervisely/project/project.py
+++ b/supervisely/project/project.py
@@ -3906,45 +3906,47 @@ class Project:
 
         # Detect duplicate tag applications in the backup - the same tag
         # (regardless of value) applied more than once to one image or one
-        # figure/object. This can exist even when "Multiple tags mode" is off on
-        # the source project, since uploading annotations doesn't enforce that
-        # check (only adding a single tag through the UI/API does). If the
-        # restored project doesn't allow duplicates, the server rejects the
-        # write outright - so point out exactly where each one is, for the user
-        # to review by hand, and force the setting on below so nothing is lost.
-        tag_id_to_name = {t["id"]: t["name"] for t in old_tags}
-        dataset_name_by_id = {d.id: d.name for d in dataset_infos}
-        image_name_by_id = {img.id: img.name for img in image_infos}
+        # figure/object. Only worth checking when the source doesn't already
+        # allow it: if it does, the restored project inherits that below and
+        # there's nothing to force or warn about. This can still happen with
+        # the setting off, since uploading an annotation doesn't enforce the
+        # check that adding a single tag does - so point out exactly where
+        # each one is, for the user to review by hand, and force the setting
+        # on below so nothing is lost.
         has_duplicate_tags = False
-        for image_info in image_infos:
-            for tag_id, count in Counter(t.get("tagId") for t in image_info.tags).items():
-                if count > 1:
-                    has_duplicate_tags = True
-                    logger.warning(
-                        f"Duplicate tag '{tag_id_to_name.get(tag_id, tag_id)}' is applied "
-                        f"{count} times to image '{image_info.name}' (dataset "
-                        f"'{dataset_name_by_id.get(image_info.dataset_id, image_info.dataset_id)}') "
-                        "in the backup."
-                    )
-        for image_id, image_figures in figures.items():
-            for figure in image_figures:
-                for tag_id, count in Counter(t.get("tagId") for t in figure.tags).items():
+        if not (project_info.settings or {}).get("allowDuplicateTags"):
+            tag_id_to_name = {t["id"]: t["name"] for t in old_tags}
+            dataset_name_by_id = {d.id: d.name for d in dataset_infos}
+            image_name_by_id = {img.id: img.name for img in image_infos}
+            for image_info in image_infos:
+                for tag_id, count in Counter(t.get("tagId") for t in image_info.tags).items():
                     if count > 1:
                         has_duplicate_tags = True
                         logger.warning(
                             f"Duplicate tag '{tag_id_to_name.get(tag_id, tag_id)}' is applied "
-                            f"{count} times to an object on image "
-                            f"'{image_name_by_id.get(image_id, image_id)}' (dataset "
-                            f"'{dataset_name_by_id.get(figure.dataset_id, figure.dataset_id)}') "
+                            f"{count} times to image '{image_info.name}' (dataset "
+                            f"'{dataset_name_by_id.get(image_info.dataset_id, image_info.dataset_id)}') "
                             "in the backup."
                         )
-        if has_duplicate_tags:
-            logger.warning(
-                "The backup contains images/objects with the same tag applied "
-                "more than once - 'Multiple tags mode' will be enabled on the "
-                "restored project so nothing is lost. Review the items listed "
-                "above and decide by hand whether any of them need cleanup."
-            )
+            for image_id, image_figures in figures.items():
+                for figure in image_figures:
+                    for tag_id, count in Counter(t.get("tagId") for t in figure.tags).items():
+                        if count > 1:
+                            has_duplicate_tags = True
+                            logger.warning(
+                                f"Duplicate tag '{tag_id_to_name.get(tag_id, tag_id)}' is applied "
+                                f"{count} times to an object on image "
+                                f"'{image_name_by_id.get(image_id, image_id)}' (dataset "
+                                f"'{dataset_name_by_id.get(figure.dataset_id, figure.dataset_id)}') "
+                                "in the backup."
+                            )
+            if has_duplicate_tags:
+                logger.warning(
+                    "The backup contains images/objects with the same tag applied "
+                    "more than once - 'Multiple tags mode' will be enabled on the "
+                    "restored project so nothing is lost. Review the items listed "
+                    "above and decide by hand whether any of them need cleanup."
+                )
 
         # Restore project-level settings from the backup. The server silently
         # ignores any key here it doesn't support, so it's safe to pass the whole

--- a/supervisely/project/project.py
+++ b/supervisely/project/project.py
@@ -10,7 +10,7 @@ import os
 import pickle
 import random
 import shutil
-from collections import defaultdict, namedtuple
+from collections import Counter, defaultdict, namedtuple
 from enum import Enum
 from pathlib import Path
 from typing import (
@@ -3904,16 +3904,63 @@ class Project:
             map(lambda old_tag, new_tag: (old_tag["id"], new_tag["id"]), old_tags, new_tags)
         )
 
+        # Detect duplicate tag applications in the backup - the same tag
+        # (regardless of value) applied more than once to one image or one
+        # figure/object. This can exist even when "Multiple tags mode" is off on
+        # the source project, since uploading annotations doesn't enforce that
+        # check (only adding a single tag through the UI/API does). If the
+        # restored project doesn't allow duplicates, the server rejects the
+        # write outright - so point out exactly where each one is, for the user
+        # to review by hand, and force the setting on below so nothing is lost.
+        tag_id_to_name = {t["id"]: t["name"] for t in old_tags}
+        dataset_name_by_id = {d.id: d.name for d in dataset_infos}
+        image_name_by_id = {img.id: img.name for img in image_infos}
+        has_duplicate_tags = False
+        for image_info in image_infos:
+            for tag_id, count in Counter(t.get("tagId") for t in image_info.tags).items():
+                if count > 1:
+                    has_duplicate_tags = True
+                    logger.warning(
+                        f"Duplicate tag '{tag_id_to_name.get(tag_id, tag_id)}' is applied "
+                        f"{count} times to image '{image_info.name}' (dataset "
+                        f"'{dataset_name_by_id.get(image_info.dataset_id, image_info.dataset_id)}') "
+                        "in the backup."
+                    )
+        for image_id, image_figures in figures.items():
+            for figure in image_figures:
+                for tag_id, count in Counter(t.get("tagId") for t in figure.tags).items():
+                    if count > 1:
+                        has_duplicate_tags = True
+                        logger.warning(
+                            f"Duplicate tag '{tag_id_to_name.get(tag_id, tag_id)}' is applied "
+                            f"{count} times to an object on image "
+                            f"'{image_name_by_id.get(image_id, image_id)}' (dataset "
+                            f"'{dataset_name_by_id.get(figure.dataset_id, figure.dataset_id)}') "
+                            "in the backup."
+                        )
+        if has_duplicate_tags:
+            logger.warning(
+                "The backup contains images/objects with the same tag applied "
+                "more than once - 'Multiple tags mode' will be enabled on the "
+                "restored project so nothing is lost. Review the items listed "
+                "above and decide by hand whether any of them need cleanup."
+            )
+
         # Restore project-level settings from the backup. The server silently
         # ignores any key here it doesn't support, so it's safe to pass the whole
         # block through as-is. groupImagesByTagId is remapped like every other tag
         # reference, since it points at a tag id from the source project.
-        if project_info.settings:
-            new_settings = dict(project_info.settings)
+        # allowDuplicateTags is forced on if duplicates were found above,
+        # regardless of what the source had it set to - otherwise the restore
+        # would fail even though the source project's data already had them.
+        if project_info.settings or has_duplicate_tags:
+            new_settings = dict(project_info.settings or {})
             if new_settings.get("groupImagesByTagId") is not None:
                 new_settings["groupImagesByTagId"] = old_new_tags_mapping.get(
                     new_settings["groupImagesByTagId"]
                 )
+            if has_duplicate_tags:
+                new_settings["allowDuplicateTags"] = True
             api.project.update_settings(new_project_info.id, new_settings)
 
         # remap classes

--- a/supervisely/project/project.py
+++ b/supervisely/project/project.py
@@ -3952,11 +3952,17 @@ class Project:
         # ignores any key here it doesn't support, so it's safe to pass the whole
         # block through as-is. groupImagesByTagId is remapped like every other tag
         # reference, since it points at a tag id from the source project.
+        # labelingInterface is dropped: it's already restored via ProjectMeta/
+        # update_meta above, and re-sending it here as an explicit null makes the
+        # server coerce it to the literal string "default" instead of leaving it
+        # unset - ProjectSettings.to_json() avoids this by omitting the key
+        # entirely when it's None, so mirror that here rather than resending it.
         # allowDuplicateTags is forced on if duplicates were found above,
         # regardless of what the source had it set to - otherwise the restore
         # would fail even though the source project's data already had them.
         if project_info.settings or has_duplicate_tags:
             new_settings = dict(project_info.settings or {})
+            new_settings.pop("labelingInterface", None)
             if new_settings.get("groupImagesByTagId") is not None:
                 new_settings["groupImagesByTagId"] = old_new_tags_mapping.get(
                     new_settings["groupImagesByTagId"]


### PR DESCRIPTION
## Summary
Real production crash, seen in a customer log while restoring a Data Version: `image-tags.bulk.add-to-image` rejects the request with `"ids" position N contains a duplicate value"`.

**Root cause:** the same tag can be applied to one image or figure more than once (regardless of value) even on a project where "Multiple tags mode" (`settings.allowDuplicateTags`) is off, because uploading an annotation doesn't enforce the duplicate check — only the dedicated single-tag-add endpoints do (see `AddTagToItems.js` / `AddEntityTags.js` / `AddTagsToFigures.js`). So a project can carry duplicate tag rows in its data without that setting ever having been enabled. `Project.upload_bin()` collected image ids per `(tag, value)` into a plain list while restoring, then handed it straight to `add_tag_batch`, whose endpoint requires unique ids per call — any repeat crashed the whole restore.

**Fix, three parts:**

1. `upload_bin` created the restored project with only name/description/readme — `ProjectInfo.settings` was captured in every backup but never read on restore. Now the whole settings block is passed to `update_settings` (the server silently ignores keys it doesn't support). `groupImagesByTagId` is remapped like every other tag reference, since tag ids are not stable across restore. `labelingInterface` is excluded from the copy: it is already restored through `ProjectMeta`/`update_meta`, and re-sending it as an explicit null makes the server coerce it into the literal string `"default"` — which then takes a different path through the grouping auto-correction in `UpdateProjectSettings.js`, since that branches on the value being truthy.

2. Switched image tag restoration from `add_tag_batch` (`image-tags.bulk.add-to-image`) to `add_to_entities_json` (`entities.tags.bulk.add`). The former's schema enforces unique ids per call unconditionally. The latter takes a plain list of `{tagId, entityId, value}` dicts, so a repeated tag application is just another list entry.

3. Copying `allowDuplicateTags` verbatim from the source isn't sufficient by itself — if the source project has it off but already contains duplicate rows (via the annotation-upload path above), the restore would still be rejected, just by a different check (`"Some tags have duplicates in payload"` in `AddEntityTags.js`/`AddTagsToFigures.js`, which both key duplicates by tag+entity, not value). So if the source has it off, `upload_bin` now scans the backup for any tag id applied more than once to the same image or object, logs a warning identifying the exact image/object and tag so it can be reviewed by hand, and forces `allowDuplicateTags` on for the restored project when that's found. If the source already has it on, the scan is skipped entirely — there's nothing to force or warn about in that case.

**Known limitation:** if a source project combines a multi-view-family `labelingInterface` (`multi_view`, `multispectral`, `medical_imaging_single`) with `groupImages` disabled, the server's own consistency logic resets the interface to `default` when the settings are written. That state is already unstable in the source project — any grouping-related settings change through the UI resets it the same way.

Branches off current `master` (already includes the merged #1777).