### PR TITLE
Resolve the JSON-patch array-append token into an explicit index (to fix widgets stop updating without a page reload)

### DIFF
--- a/supervisely/app/content.py
+++ b/supervisely/app/content.py
@@ -102,6 +102,34 @@ def get_synced_data_dir():
     return dir
 
 
+def _resolve_append_tokens(src: dict, ops: list) -> list:
+    """Rewrite the RFC 6902 array-append token '-' into an explicit index.
+
+    patchdiff emits {"op": "add", "path": ".../-"} for a push to the end of a
+    list. The token is valid RFC 6902, but the frontend patch appliers shipped
+    with older instances choke on it and drop the whole websocket message, so
+    the UI silently stops updating (issues#5992). Indices are resolved against
+    the document as it looks when the op is applied, not against `src`.
+    """
+    doc = None
+    resolved = []
+    for op in ops:
+        path = op.get("path", "")
+        if path.endswith("/-") and op.get("op") == "add":
+            if doc is None:
+                doc = copy.deepcopy(src)
+                for previous in resolved:
+                    jsonpatch.JsonPatch([previous]).apply(doc, in_place=True)
+            target = jsonpointer.JsonPointer(path[: -len("/-")]).resolve(doc)
+            if not isinstance(target, list):
+                raise ValueError(f"append token on a non-list path: {path}")
+            op = dict(op, path=f"{path[: -len('-')]}{len(target)}")
+        resolved.append(op)
+        if doc is not None:
+            jsonpatch.JsonPatch([op]).apply(doc, in_place=True)
+    return resolved
+
+
 def _diff(src: dict, dst: dict) -> jsonpatch.JsonPatch:
     """Minimal RFC 6902 diff of `src` -> `dst`.
 
@@ -111,7 +139,7 @@ def _diff(src: dict, dst: dict) -> jsonpatch.JsonPatch:
     """
     if patchdiff is not None:
         ops, _ = patchdiff.diff(src, dst)
-        return jsonpatch.JsonPatch(to_str_paths(ops))
+        return jsonpatch.JsonPatch(_resolve_append_tokens(src, to_str_paths(ops)))
     patch = jsonpatch.JsonPatch.from_diff(src, dst)
     if patch.apply(src) != dst:
         raise ValueError("jsonpatch.from_diff produced an invalid patch")

--- a/tests/unit/test_jsonpatch_diff.py
+++ b/tests/unit/test_jsonpatch_diff.py
@@ -15,6 +15,7 @@ frontend applies them as-is. Run as `python -m pytest` from the repo root
 
 import copy
 import random
+from types import SimpleNamespace
 
 import jsonpatch
 import pytest
@@ -164,6 +165,60 @@ def test_safe_diff_prepend(diff_engine):
     assert patch.apply(pre) == post
     if diff_engine == "patchdiff":
         assert len(patch.patch) <= 3, f"prepend produced {len(patch.patch)} ops instead of ~1"
+
+
+def _append_token_ops(patch):
+    return [op for op in patch.patch if op["path"].endswith("/-")]
+
+
+def test_safe_diff_never_emits_append_token(doc_pairs, diff_engine):
+    # patchdiff pushes to a list as {"op": "add", "path": ".../-"}; frontend patch
+    # appliers of older instances break on that token and drop the whole message
+    for pre, post in doc_pairs:
+        assert not _append_token_ops(content._safe_diff(pre, post))
+
+
+def test_safe_diff_append_resolves_to_index(diff_engine):
+    pre = {"w": {"rows": ["a", "b"]}}
+    post = {"w": {"rows": ["a", "b", "c", "d"]}}
+    patch = content._safe_diff(pre, post)
+    assert not _append_token_ops(patch)
+    assert patch.apply(pre) == post
+    assert [op["path"] for op in patch.patch] == ["/w/rows/2", "/w/rows/3"]
+
+
+def test_safe_diff_append_index_accounts_for_earlier_removes(diff_engine):
+    # GridGallery.clean_up() + append(): the same lists shrink and grow within one
+    # diff, so an append index must be resolved against the mid-patch document
+    pre = {"g": {"layout": [["a1", "a2"], ["a3", "a4"]], "cells": {"a1": 1}}}
+    post = {"g": {"layout": [["b1"], ["b2", "b3"]], "cells": {"b1": 1}}}
+    patch = content._safe_diff(pre, post)
+    assert not _append_token_ops(patch)
+    assert patch.apply(pre) == post
+
+
+def test_safe_diff_appends_to_several_lists(diff_engine):
+    pre = {"g": {"layout": [[], [], []]}}
+    post = {"g": {"layout": [["x1", "x2"], [], ["x3"]]}}
+    patch = content._safe_diff(pre, post)
+    assert not _append_token_ops(patch)
+    assert patch.apply(pre) == post
+
+
+def test_safe_diff_falls_back_when_append_token_is_unresolvable(monkeypatch):
+    # a '-' path that does not point at a list is a bug in the diff engine: the
+    # resolver raises and _safe_diff degrades to a valid whole-key replace
+    monkeypatch.setattr(
+        content, "patchdiff", SimpleNamespace(diff=lambda src, dst: ([], None))
+    )
+    monkeypatch.setattr(
+        content, "to_str_paths", lambda ops: [{"op": "add", "path": "/w/rows/-", "value": "c"}]
+    )
+    pre = {"w": {"rows": "not-a-list"}}
+    post = {"w": {"rows": "changed"}}
+    patch = content._safe_diff(pre, post)
+    assert not _append_token_ops(patch)
+    assert patch.apply(pre) == post
 
 
 def test_fallback_patch_handles_all_key_ops():


### PR DESCRIPTION
Since 6.74.15 patches are built by patchdiff, which emits the RFC 6902 array-append token `-` (`/widget/content/layout/1/-`). Frontend patch appliers of older instances throw on that path and drop the whole websocket message, so widgets with list-backed data (GridGallery after `clean_up()` + `append()`) stop updating until the page is reloaded — supervisely/issues#5992.

The token is now resolved into an explicit index against the document as it looks when the op is applied, so no platform-side change is needed.

Reproduced and verified in a browser both ways; unit tests added in tests/unit/test_jsonpatch_diff.py.