### PR TITLE
Save and restore dataset custom_data and description from a version backup

### DIFF
--- a/supervisely/project/project.py
+++ b/supervisely/project/project.py
@@ -3744,7 +3744,11 @@ class Project:
         project_info = api.project.get_info_by_id(project_id)
         meta = ProjectMeta.from_json(api.project.get_meta(project_id, with_settings=True))
 
-        dataset_infos = api.dataset.get_list(project_id, filters=ds_filters, recursive=True)
+        # include_custom_data is off by default, so without it a dataset's custom_data
+        # never reaches the backup at all and can't be restored later.
+        dataset_infos = api.dataset.get_list(
+            project_id, filters=ds_filters, recursive=True, include_custom_data=True
+        )
 
         image_infos = []
         figures = {}
@@ -3996,7 +4000,11 @@ class Project:
                     f"Parent dataset for dataset '{dataset_info.name}' not found. Will be added to project root."
                 )
             new_dataset_info = api.dataset.create(
-                new_project_info.id, dataset_info.name, parent_id=new_parent_id
+                new_project_info.id,
+                dataset_info.name,
+                description=dataset_info.description,
+                parent_id=new_parent_id,
+                custom_data=dataset_info.custom_data if with_custom_data else None,
             )
             if new_dataset_info is None:
                 raise RuntimeError(f"Failed to restore dataset {dataset_info.name}")

--- a/supervisely/project/project.py
+++ b/supervisely/project/project.py
@@ -3882,7 +3882,13 @@ class Project:
         if project_name is None:
             project_name = project_info.name
 
-        project_description = project_description or project_info.description
+        # An explicit description (e.g. the "Restored from version N" note that
+        # DataVersion.restore passes in) goes first, followed by whatever the backup
+        # itself carried - otherwise the project's own description is silently lost.
+        if project_description and project_info.description:
+            project_description = f"{project_description}\n\n{project_info.description}"
+        else:
+            project_description = project_description or project_info.description
         new_project_info = api.project.create(
             workspace_id,
             project_name,

--- a/supervisely/project/project.py
+++ b/supervisely/project/project.py
@@ -3744,8 +3744,6 @@ class Project:
         project_info = api.project.get_info_by_id(project_id)
         meta = ProjectMeta.from_json(api.project.get_meta(project_id, with_settings=True))
 
-        # include_custom_data is off by default, so without it a dataset's custom_data
-        # never reaches the backup at all and can't be restored later.
         dataset_infos = api.dataset.get_list(
             project_id, filters=ds_filters, recursive=True, include_custom_data=True
         )
@@ -3882,9 +3880,6 @@ class Project:
         if project_name is None:
             project_name = project_info.name
 
-        # An explicit description (e.g. the "Restored from version N" note that
-        # DataVersion.restore passes in) goes first, followed by whatever the backup
-        # itself carried - otherwise the project's own description is silently lost.
         if project_description and project_info.description:
             project_description = f"{project_description}\n\n{project_info.description}"
         else:


### PR DESCRIPTION
Image projects lost both fields on every restore, and custom_data was lost on the way *into* the backup as well:

- download_bin listed datasets without include_custom_data, which defaults to off, so custom_data never reached the pickle at all - restore had nothing to put back. 
- upload_bin created datasets with name and parent_id only, dropping description (which *was* present in the backup) and custom_data.

Video and volume projects already do both (video_project.py, volume_project.py); this brings images in line, including gating custom_data on with_custom_data the same way volume does.

Old backups carry no custom_data for datasets, so they stay empty after this change - CustomUnpickler pads the missing NamedTuple field with None and dataset.create simply omits it. Their description is present and does get restored.