### PR TITLE
Verify ecosystem archive integrity on upload and download

### DIFF
--- a/supervisely/api/app_api.py
+++ b/supervisely/api/app_api.py
@@ -3,6 +3,7 @@
 
 from __future__ import annotations
 
+import gzip
 import json
 import time
 from dataclasses import dataclass
@@ -28,7 +29,7 @@ from supervisely import env, logger
 from supervisely.api.dataset_api import DatasetInfo
 from supervisely.api.file_api import FileInfo
 from supervisely.api.project_api import ProjectInfo
-from supervisely.io.fs import ensure_base_path, str_is_url
+from supervisely.io.fs import ensure_base_path, silent_remove, str_is_url
 from supervisely.io.json import validate_json
 from supervisely.task.progress import Progress
 
@@ -1468,26 +1469,37 @@ class AppApi(TaskApi):
 
         response = self._api.post("ecosystem.file.download", payload, stream=True)
         progress = None
+        expected_length = None
+        if "Content-Length" in response.headers:
+            expected_length = int(response.headers["Content-Length"])
         if log_progress:
             if ext_logger is None:
                 ext_logger = logger
-
-            length = None
-            # Content-Length
-            if "Content-Length" in response.headers:
-                length = int(response.headers["Content-Length"])
-            progress = Progress("Downloading: ", length, ext_logger=ext_logger, is_size=True)
+            progress = Progress(
+                "Downloading: ", expected_length, ext_logger=ext_logger, is_size=True
+            )
 
         mb1 = 1024 * 1024
         ensure_base_path(save_path)
+        total_written = 0
         with open(save_path, "wb") as fd:
             log_size = 0
             for chunk in response.iter_content(chunk_size=mb1):
                 fd.write(chunk)
+                total_written += len(chunk)
                 log_size += len(chunk)
                 if log_progress and log_size > mb1 and progress is not None:
                     progress.iters_done_report(log_size)
                     log_size = 0
+
+        if expected_length is not None and total_written != expected_length:
+            silent_remove(save_path)
+            raise IOError(
+                f"Download of file_path={file_path!r}, file_key={file_key!r} for "
+                f"module_id={module_id!r}, app_id={app_id!r}, version={version!r} is "
+                f"incomplete: expected {expected_length} bytes (per Content-Length), "
+                f"received {total_written}."
+            )
 
     def download_git_archive(
         self,
@@ -1510,26 +1522,51 @@ class AppApi(TaskApi):
 
         response = self._api.post("ecosystem.file.download", payload, stream=True)
         progress = None
+        expected_length = None
+        if "Content-Length" in response.headers:
+            expected_length = int(response.headers["Content-Length"])
         if log_progress:
             if ext_logger is None:
                 ext_logger = logger
-
-            length = None
-            # Content-Length
-            if "Content-Length" in response.headers:
-                length = int(response.headers["Content-Length"])
-            progress = Progress("Downloading: ", length, ext_logger=ext_logger, is_size=True)
+            progress = Progress(
+                "Downloading: ", expected_length, ext_logger=ext_logger, is_size=True
+            )
 
         mb1 = 1024 * 1024
         ensure_base_path(save_path)
+        total_written = 0
         with open(save_path, "wb") as fd:
             log_size = 0
             for chunk in response.iter_content(chunk_size=mb1):
                 fd.write(chunk)
+                total_written += len(chunk)
                 log_size += len(chunk)
                 if log_progress and log_size > mb1 and progress is not None:
                     progress.iters_done_report(log_size)
                     log_size = 0
+
+        if expected_length is not None and total_written != expected_length:
+            silent_remove(save_path)
+            raise IOError(
+                f"Archive download for ecosystem_item_id={ecosystem_item_id!r}, "
+                f"app_id={app_id!r}, version={version!r} is incomplete: expected "
+                f"{expected_length} bytes (per Content-Length), received {total_written}. "
+                "The server-side stored archive is likely corrupted/truncated - "
+                "try re-releasing this version."
+            )
+        if save_path.endswith(".gz"):
+            try:
+                with gzip.open(save_path, "rb") as gz:
+                    while gz.read(mb1):
+                        pass
+            except (EOFError, OSError) as e:
+                silent_remove(save_path)
+                raise IOError(
+                    f"Archive download for ecosystem_item_id={ecosystem_item_id!r}, "
+                    f"app_id={app_id!r}, version={version!r} downloaded {total_written} bytes "
+                    f"but is not a valid gzip stream ({e}). The server-side stored archive is "
+                    "likely corrupted/truncated - try re-releasing this version."
+                ) from e
 
     def get_info(self, module_id, version=None):
         """get_info"""

--- a/supervisely/cli/release/release.py
+++ b/supervisely/cli/release/release.py
@@ -1,4 +1,6 @@
 import datetime
+import gzip
+import io
 import json
 import os
 import random
@@ -155,6 +157,66 @@ def get_app_from_instance(appKey: str, token, server):
     return r.json()
 
 
+def _download_archive_bytes(server_address, api_token, ecosystem_item_id, version):
+    """Download the just-uploaded archive back into memory, for post-upload verification."""
+    payload = {
+        "moduleId": ecosystem_item_id,
+        "version": version,
+        "isArchive": True,
+    }
+    resp = requests.post(
+        f"{server_address.rstrip('/')}/public/api/v3/ecosystem.file.download",
+        json=payload,
+        headers={"x-api-key": api_token},
+        stream=True,
+    )
+    if resp.status_code != 200:
+        return None, None, f"HTTP {resp.status_code} while reading back the uploaded archive"
+    expected_length = resp.headers.get("Content-Length")
+    expected_length = int(expected_length) if expected_length is not None else None
+    buf = io.BytesIO()
+    for chunk in resp.iter_content(chunk_size=1024 * 1024):
+        buf.write(chunk)
+    data = buf.getvalue()
+    if expected_length is not None and len(data) != expected_length:
+        return (
+            data,
+            expected_length,
+            f"expected {expected_length} bytes (Content-Length), received {len(data)}",
+        )
+    return data, expected_length, None
+
+
+def _verify_uploaded_archive(server_address, api_token, appKey, version, archive_name):
+    """
+    Read the just-uploaded archive back from the server and confirm it is a complete,
+    valid gzip/tar stream. Neither the upload endpoint nor the download endpoint
+    validate transfer completeness on their own - a connection that drops mid-transfer
+    can still result in a "successful" HTTP response with a truncated file stored
+    server-side, which then only surfaces much later as an opaque error deep inside
+    tarfile/gzip on whichever agent tries to use it. Returns (is_valid, error_message).
+    """
+    app_info = get_app_from_instance(appKey, api_token, server_address)
+    if app_info is None or "id" not in app_info:
+        return False, "could not resolve ecosystem item id for appKey after upload"
+    ecosystem_item_id = app_info["id"]
+
+    data, expected_length, err = _download_archive_bytes(
+        server_address, api_token, ecosystem_item_id, version
+    )
+    if err is not None:
+        return False, err
+
+    if archive_name.endswith(".tar.gz"):
+        try:
+            with gzip.GzipFile(fileobj=io.BytesIO(data)) as gz:
+                while gz.read(1024 * 1024):
+                    pass
+        except (EOFError, OSError) as e:
+            return False, f"downloaded archive is not a valid gzip stream: {e}"
+    return True, None
+
+
 def upload_archive(
     archive_path,
     server_address,
@@ -169,51 +231,87 @@ def upload_archive(
     subapp_path,
     share_app,
     files,
+    max_attempts=3,
 ):
-    f = open(archive_path, "rb")
     archive_name = os.path.basename(archive_path)
-    fields = {
-        "appKey": appKey,
-        "subAppPath": subapp_path,
-        "release": json.dumps(release),
-        "config": json.dumps(config),
-        "readme": readme,
-        "modalTemplate": modal_template,
-        "archive": (
-            archive_name,
-            f,
-            "application/gzip" if archive_name.endswith(".tar.gz") else "application/x-tar",
-        ),
-    }
-    if slug:
-        fields["slug"] = slug
-    if user_id:
-        fields["userId"] = str(user_id)
-    if share_app:
-        fields["isShared"] = "true"
-    if files:
-        files_contents = {}
-        fields["files"] = files_contents
-        for file_name, file_path in files.items():
-            files_contents[file_name] = Path(file_path).read_text(encoding="utf-8")
-        fields["files"] = json.dumps(files_contents)
+    version = release.get("version")
+    response = None
 
-    e = MultipartEncoder(fields=fields)
-    encoder_len = e.len
-    with tqdm(
-        total=encoder_len,
-        unit="B",
-        unit_scale=True,
-        unit_divisor=1024,
-    ) as bar:
-        m = MultipartEncoderMonitor(e, lambda monitor: bar.update(monitor.bytes_read - bar.n))
-        response = requests.post(
-            f"{server_address.rstrip('/')}/public/api/v3/ecosystem.release",
-            data=m,
-            headers={"Content-Type": m.content_type, "x-api-key": api_token},
+    for attempt in range(1, max_attempts + 1):
+        f = open(archive_path, "rb")
+        fields = {
+            "appKey": appKey,
+            "subAppPath": subapp_path,
+            "release": json.dumps(release),
+            "config": json.dumps(config),
+            "readme": readme,
+            "modalTemplate": modal_template,
+            "archive": (
+                archive_name,
+                f,
+                "application/gzip"
+                if archive_name.endswith(".tar.gz")
+                else "application/x-tar",
+            ),
+        }
+        if slug:
+            fields["slug"] = slug
+        if user_id:
+            fields["userId"] = str(user_id)
+        if share_app:
+            fields["isShared"] = "true"
+        if files:
+            files_contents = {}
+            fields["files"] = files_contents
+            for file_name, file_path in files.items():
+                files_contents[file_name] = Path(file_path).read_text(encoding="utf-8")
+            fields["files"] = json.dumps(files_contents)
+
+        e = MultipartEncoder(fields=fields)
+        encoder_len = e.len
+        with tqdm(
+            total=encoder_len,
+            unit="B",
+            unit_scale=True,
+            unit_divisor=1024,
+        ) as bar:
+            m = MultipartEncoderMonitor(e, lambda monitor: bar.update(monitor.bytes_read - bar.n))
+            response = requests.post(
+                f"{server_address.rstrip('/')}/public/api/v3/ecosystem.release",
+                data=m,
+                headers={"Content-Type": m.content_type, "x-api-key": api_token},
+            )
+        f.close()
+
+        if not response.ok:
+            # Not an upload-integrity problem - let the existing caller-level retry/error
+            # handling (do_release_with_retry) deal with real HTTP/server errors as before.
+            return response
+
+        if version is None:
+            # Nothing to read back and compare against (e.g. archive_only_config flows).
+            return response
+
+        is_valid, err = _verify_uploaded_archive(
+            server_address, api_token, appKey, version, archive_name
         )
-    f.close()
-    return response
+        if is_valid:
+            return response
+
+        print(
+            f"[upload_archive] Attempt {attempt}/{max_attempts}: server accepted the upload "
+            f"(HTTP {response.status_code}) but the stored archive failed verification: {err}. "
+            + ("Retrying with a fresh upload..." if attempt < max_attempts else "Giving up."),
+            file=sys.stderr,
+        )
+
+    raise RuntimeError(
+        f"Uploaded archive for appKey={appKey!r} version={version!r} repeatedly failed "
+        f"post-upload verification after {max_attempts} attempts - the server is storing a "
+        "truncated/corrupted archive despite returning a successful HTTP response. This is "
+        "not a client-side problem to retry away; the ecosystem.release/ecosystem.file.download "
+        "backend needs investigation."
+    )
 
 
 def archive_application(repo: git.Repo, config, slug):


### PR DESCRIPTION
Root cause investigated end-to-end: neither the release upload path (upload_archive -> POST ecosystem.release) nor the agent download path (download_git_archive -> POST ecosystem.file.download) ever validate that the bytes actually transferred match what was sent/expected. A connection dropped mid-transfer can still produce a "successful" HTTP response while the server stores (or serves) a truncated archive - which then only surfaces much later as an opaque
"EOFError: Compressed file ended before the end-of-stream marker was reached" three abstraction layers away (deep inside tarfile/gzip on whichever agent tries to extract it), with no indication of the real cause.

Reproduced live against the dev instance: two production releases (supervisely-ecosystem/yolo v1.0.49 and v1.0.50) are permanently affected - every download of either version deterministically truncates at the exact same byte offset every time (31718 and 31734 bytes respectively, out of ~597KB), while the immediately-preceding v1.0.48 and several older versions (v1.0.10/20/30/40) download perfectly through the identical endpoint. GitHub's own tarballs for all versions are verified healthy. This means whatever got stored server-side for those two versions is permanently corrupted and no client-side retry will ever fix it - only a fresh, verified upload can.

download_git_archive (app_api.py): now tracks bytes actually written against the Content-Length header, and additionally does a full streaming gzip-validity pass for .gz targets, raising a clear IOError naming the exact module/app/version and byte counts instead of silently leaving a truncated file for the caller to stumble into. Same Content-Length check applied to the sibling download_git_file.

upload_archive (release.py): after an HTTP-successful upload, now reads the just-uploaded archive back via the same download endpoint and gzip-validates it before declaring success. On failure, retries the entire upload (rebuilding the multipart body fresh) up to max_attempts=3 times, and raises a loud RuntimeError naming the appKey/version if it still can't get a verified-good copy stored - instead of silently returning a "200 OK" response over a corrupted archive the way the current release pipeline does today.