### PR TITLE
Fix false-positive corruption verdicts from the archive verification

### DIFF
--- a/supervisely/api/app_api.py
+++ b/supervisely/api/app_api.py
@@ -3,8 +3,8 @@
 
 from __future__ import annotations
 
-import gzip
 import json
+import tarfile
 import time
 from dataclasses import dataclass
 from time import sleep
@@ -1554,18 +1554,22 @@ class AppApi(TaskApi):
                 "The server-side stored archive is likely corrupted/truncated - "
                 "try re-releasing this version."
             )
-        if save_path.endswith(".gz"):
+        if save_path.endswith((".tar.gz", ".tar")):
+            # "r:*" auto-detects gzip vs plain tar (client_side_app releases upload a
+            # plain, uncompressed .tar), and actually iterating every member - not just
+            # opening the stream - is what catches a truncated tar body even when the
+            # outer gzip envelope is technically well-formed.
             try:
-                with gzip.open(save_path, "rb") as gz:
-                    while gz.read(mb1):
+                with tarfile.open(save_path, mode="r:*") as tar:
+                    for _ in tar:
                         pass
-            except (EOFError, OSError) as e:
+            except (EOFError, OSError, tarfile.TarError) as e:
                 silent_remove(save_path)
                 raise IOError(
                     f"Archive download for ecosystem_item_id={ecosystem_item_id!r}, "
                     f"app_id={app_id!r}, version={version!r} downloaded {total_written} bytes "
-                    f"but is not a valid gzip stream ({e}). The server-side stored archive is "
-                    "likely corrupted/truncated - try re-releasing this version."
+                    f"but is not a valid/complete tar stream ({e}). The server-side stored "
+                    "archive is likely corrupted/truncated - try re-releasing this version."
                 ) from e
 
     def get_info(self, module_id, version=None):

--- a/supervisely/api/app_api.py
+++ b/supervisely/api/app_api.py
@@ -1554,23 +1554,24 @@ class AppApi(TaskApi):
                 "The server-side stored archive is likely corrupted/truncated - "
                 "try re-releasing this version."
             )
-        if save_path.endswith((".tar.gz", ".tar")):
-            # "r:*" auto-detects gzip vs plain tar (client_side_app releases upload a
-            # plain, uncompressed .tar), and actually iterating every member - not just
-            # opening the stream - is what catches a truncated tar body even when the
-            # outer gzip envelope is technically well-formed.
-            try:
-                with tarfile.open(save_path, mode="r:*") as tar:
-                    for _ in tar:
-                        pass
-            except (EOFError, OSError, tarfile.TarError) as e:
-                silent_remove(save_path)
-                raise IOError(
-                    f"Archive download for ecosystem_item_id={ecosystem_item_id!r}, "
-                    f"app_id={app_id!r}, version={version!r} downloaded {total_written} bytes "
-                    f"but is not a valid/complete tar stream ({e}). The server-side stored "
-                    "archive is likely corrupted/truncated - try re-releasing this version."
-                ) from e
+        # "r:*" auto-detects gzip vs plain tar (client_side_app releases upload a
+        # plain, uncompressed .tar), and actually iterating every member - not just
+        # opening the stream - is what catches a truncated tar body even when the
+        # outer gzip envelope is technically well-formed. Not gated on save_path's
+        # extension: a caller can pass any path, and skipping validation just
+        # because it doesn't end in .tar.gz/.tar would silently defeat the point.
+        try:
+            with tarfile.open(save_path, mode="r:*") as tar:
+                for _ in tar:
+                    pass
+        except (EOFError, OSError, tarfile.TarError) as e:
+            silent_remove(save_path)
+            raise IOError(
+                f"Archive download for ecosystem_item_id={ecosystem_item_id!r}, "
+                f"app_id={app_id!r}, version={version!r} downloaded {total_written} bytes "
+                f"but is not a valid/complete tar stream ({e}). The server-side stored "
+                "archive is likely corrupted/truncated - try re-releasing this version."
+            ) from e
 
     def get_info(self, module_id, version=None):
         """get_info"""

--- a/supervisely/cli/release/release.py
+++ b/supervisely/cli/release/release.py
@@ -1,5 +1,4 @@
 import datetime
-import gzip
 import io
 import json
 import os
@@ -10,6 +9,7 @@ import string
 import subprocess
 import sys
 import tarfile
+import time
 from pathlib import Path
 
 import git
@@ -158,7 +158,7 @@ def get_app_from_instance(appKey: str, token, server):
 
 
 def _download_archive_bytes(server_address, api_token, ecosystem_item_id, version):
-    """Download the just-uploaded archive back into memory, for post-upload verification."""
+    """Download an archive into memory, for post-upload verification."""
     payload = {
         "moduleId": ecosystem_item_id,
         "version": version,
@@ -171,50 +171,93 @@ def _download_archive_bytes(server_address, api_token, ecosystem_item_id, versio
         stream=True,
     )
     if resp.status_code != 200:
-        return None, None, f"HTTP {resp.status_code} while reading back the uploaded archive"
-    expected_length = resp.headers.get("Content-Length")
-    expected_length = int(expected_length) if expected_length is not None else None
+        return None, f"HTTP {resp.status_code} while reading back the uploaded archive"
     buf = io.BytesIO()
     for chunk in resp.iter_content(chunk_size=1024 * 1024):
         buf.write(chunk)
-    data = buf.getvalue()
-    if expected_length is not None and len(data) != expected_length:
-        return (
-            data,
-            expected_length,
-            f"expected {expected_length} bytes (Content-Length), received {len(data)}",
-        )
-    return data, expected_length, None
+    return buf.getvalue(), None
 
 
-def _verify_uploaded_archive(server_address, api_token, appKey, version, archive_name):
+def _validate_archive_bytes(data, archive_name):
     """
-    Read the just-uploaded archive back from the server and confirm it is a complete,
-    valid gzip/tar stream. Neither the upload endpoint nor the download endpoint
-    validate transfer completeness on their own - a connection that drops mid-transfer
-    can still result in a "successful" HTTP response with a truncated file stored
-    server-side, which then only surfaces much later as an opaque error deep inside
-    tarfile/gzip on whichever agent tries to use it. Returns (is_valid, error_message).
+    Structural validation of an in-memory archive. Uses tarfile's auto-detecting
+    "r:*" mode and actually iterates every member (not just opening the stream),
+    so this covers both the gzip-compressed (.tar.gz) and plain (.tar, used for
+    client_side_app releases) cases, and catches the case where the outer gzip
+    envelope is technically well-formed but the tar content inside it is
+    truncated - a bare gzip-only check would miss that.
     """
-    app_info = get_app_from_instance(appKey, api_token, server_address)
-    if app_info is None or "id" not in app_info:
-        return False, "could not resolve ecosystem item id for appKey after upload"
-    ecosystem_item_id = app_info["id"]
-
-    data, expected_length, err = _download_archive_bytes(
-        server_address, api_token, ecosystem_item_id, version
-    )
-    if err is not None:
-        return False, err
-
-    if archive_name.endswith(".tar.gz"):
-        try:
-            with gzip.GzipFile(fileobj=io.BytesIO(data)) as gz:
-                while gz.read(1024 * 1024):
-                    pass
-        except (EOFError, OSError) as e:
-            return False, f"downloaded archive is not a valid gzip stream: {e}"
+    try:
+        with tarfile.open(fileobj=io.BytesIO(data), mode="r:*") as tar:
+            for _ in tar:
+                pass
+    except (EOFError, OSError, tarfile.TarError) as e:
+        return False, f"downloaded archive is not a valid/complete tar stream: {e}"
     return True, None
+
+
+def _read_back_and_verify(
+    server_address,
+    api_token,
+    appKey,
+    version,
+    archive_name,
+    expected_size,
+    max_read_attempts=4,
+    initial_backoff_sec=2,
+):
+    """
+    Read the just-uploaded archive back from the server and confirm it is complete
+    and structurally valid. Neither the upload endpoint nor the download endpoint
+    validate transfer completeness on their own - a connection that drops
+    mid-transfer can still result in a "successful" HTTP response with a truncated
+    file stored server-side.
+
+    Storage/indexing on the server can also be asynchronous: reading back
+    *immediately* after the 200 response can race the server and either 404 or
+    serve a previous version's bytes, which would look identical to real
+    corruption unless we check for it. So this retries the read itself (not the
+    upload) with exponential backoff, and requires the returned size to match the
+    just-uploaded local archive's size before doing any deeper structural check -
+    a size mismatch is treated as "not propagated yet" and retried, not as
+    corruption. Only a size-matched-but-structurally-broken result is treated as
+    a real, immediate failure (no point retrying the read further at that point).
+
+    Returns (is_valid, error_message).
+    """
+    backoff = initial_backoff_sec
+    last_err = "no read-back attempts were made"
+    for attempt in range(1, max_read_attempts + 1):
+        app_info = get_app_from_instance(appKey, api_token, server_address)
+        if app_info is None or "id" not in app_info:
+            last_err = "could not resolve ecosystem item id for appKey"
+        else:
+            data, err = _download_archive_bytes(
+                server_address, api_token, app_info["id"], version
+            )
+            if err is not None:
+                last_err = err
+            elif len(data) != expected_size:
+                last_err = (
+                    f"read-back size {len(data)} does not match the uploaded size "
+                    f"{expected_size} (server storage/indexing may still be propagating)"
+                )
+            else:
+                return _validate_archive_bytes(data, archive_name)
+        if attempt < max_read_attempts:
+            time.sleep(backoff)
+            backoff *= 2
+    return False, f"gave up after {max_read_attempts} read-back attempts: {last_err}"
+
+
+def _is_duplicate_version_response(response):
+    """True if the server rejected the upload because this version was already released."""
+    try:
+        message = json.dumps(response.json())
+    except Exception:
+        message = response.text or ""
+    message = message.lower()
+    return "already exists" in message or "already released" in message
 
 
 def upload_archive(
@@ -231,76 +274,96 @@ def upload_archive(
     subapp_path,
     share_app,
     files,
-    max_attempts=3,
+    max_attempts=2,
 ):
     archive_name = os.path.basename(archive_path)
     version = release.get("version")
+    expected_size = os.path.getsize(archive_path)
     response = None
+    last_ok_response = None
 
     for attempt in range(1, max_attempts + 1):
-        f = open(archive_path, "rb")
-        fields = {
-            "appKey": appKey,
-            "subAppPath": subapp_path,
-            "release": json.dumps(release),
-            "config": json.dumps(config),
-            "readme": readme,
-            "modalTemplate": modal_template,
-            "archive": (
-                archive_name,
-                f,
-                "application/gzip"
-                if archive_name.endswith(".tar.gz")
-                else "application/x-tar",
-            ),
-        }
-        if slug:
-            fields["slug"] = slug
-        if user_id:
-            fields["userId"] = str(user_id)
-        if share_app:
-            fields["isShared"] = "true"
-        if files:
-            files_contents = {}
-            fields["files"] = files_contents
-            for file_name, file_path in files.items():
-                files_contents[file_name] = Path(file_path).read_text(encoding="utf-8")
-            fields["files"] = json.dumps(files_contents)
+        with open(archive_path, "rb") as f:
+            fields = {
+                "appKey": appKey,
+                "subAppPath": subapp_path,
+                "release": json.dumps(release),
+                "config": json.dumps(config),
+                "readme": readme,
+                "modalTemplate": modal_template,
+                "archive": (
+                    archive_name,
+                    f,
+                    "application/gzip"
+                    if archive_name.endswith(".tar.gz")
+                    else "application/x-tar",
+                ),
+            }
+            if slug:
+                fields["slug"] = slug
+            if user_id:
+                fields["userId"] = str(user_id)
+            if share_app:
+                fields["isShared"] = "true"
+            if files:
+                files_contents = {}
+                fields["files"] = files_contents
+                for file_name, file_path in files.items():
+                    files_contents[file_name] = Path(file_path).read_text(encoding="utf-8")
+                fields["files"] = json.dumps(files_contents)
 
-        e = MultipartEncoder(fields=fields)
-        encoder_len = e.len
-        with tqdm(
-            total=encoder_len,
-            unit="B",
-            unit_scale=True,
-            unit_divisor=1024,
-        ) as bar:
-            m = MultipartEncoderMonitor(e, lambda monitor: bar.update(monitor.bytes_read - bar.n))
-            response = requests.post(
-                f"{server_address.rstrip('/')}/public/api/v3/ecosystem.release",
-                data=m,
-                headers={"Content-Type": m.content_type, "x-api-key": api_token},
+            e = MultipartEncoder(fields=fields)
+            encoder_len = e.len
+            with tqdm(
+                total=encoder_len,
+                unit="B",
+                unit_scale=True,
+                unit_divisor=1024,
+            ) as bar:
+                m = MultipartEncoderMonitor(
+                    e, lambda monitor: bar.update(monitor.bytes_read - bar.n)
+                )
+                response = requests.post(
+                    f"{server_address.rstrip('/')}/public/api/v3/ecosystem.release",
+                    data=m,
+                    headers={"Content-Type": m.content_type, "x-api-key": api_token},
+                )
+
+        if response.ok:
+            last_ok_response = response
+        else:
+            if version is None or not _is_duplicate_version_response(response):
+                # A genuine, unrelated rejection - let the existing caller-level
+                # retry/error handling (do_release_with_retry) deal with it as before.
+                return response
+            # The server says this version is already released - almost certainly
+            # because *this function's own previous attempt* already stored it
+            # (retrying with the same version would otherwise never legitimately
+            # hit this). Re-uploading again under the same version cannot help,
+            # so check what is actually stored instead of treating this as fatal.
+            print(
+                f"[upload_archive] Attempt {attempt}/{max_attempts}: server reports version "
+                f"{version!r} already exists; checking whether it was actually stored intact "
+                "before treating this as a failure...",
+                file=sys.stderr,
             )
-        f.close()
-
-        if not response.ok:
-            # Not an upload-integrity problem - let the existing caller-level retry/error
-            # handling (do_release_with_retry) deal with real HTTP/server errors as before.
-            return response
 
         if version is None:
             # Nothing to read back and compare against (e.g. archive_only_config flows).
             return response
 
-        is_valid, err = _verify_uploaded_archive(
-            server_address, api_token, appKey, version, archive_name
+        is_valid, err = _read_back_and_verify(
+            server_address, api_token, appKey, version, archive_name, expected_size
         )
         if is_valid:
-            return response
+            # response itself may be the "already exists" rejection from this attempt
+            # (see above) - report the earlier successful upload's response in that
+            # case, not the rejection, since the verified-good content is what matters.
+            return last_ok_response if last_ok_response is not None else response
 
         print(
-            f"[upload_archive] Attempt {attempt}/{max_attempts}: server accepted the upload "
-            f"(HTTP {response.status_code}) but the stored archive failed verification: {err}. "
+            f"[upload_archive] Attempt {attempt}/{max_attempts}: stored archive for version "
+            f"{version!r} failed verification: {err}. "
             + ("Retrying with a fresh upload..." if attempt < max_attempts else "Giving up."),
             file=sys.stderr,
         )

--- a/supervisely/cli/release/release.py
+++ b/supervisely/cli/release/release.py
@@ -16,9 +16,12 @@ import git
 import requests
 from giturlparse import parse
 from requests_toolbelt import MultipartEncoder, MultipartEncoderMonitor
+from rich.console import Console
 from tqdm import tqdm
 
 from supervisely.io.fs import dir_exists, list_files_recursively, remove_dir
+
+console = Console()
 
 
 class cd:
@@ -158,27 +161,37 @@ def get_app_from_instance(appKey: str, token, server):
 
 
 def _download_archive_bytes(server_address, api_token, ecosystem_item_id, version):
-    """Download an archive into memory, for post-upload verification."""
+    """
+    Download an archive into memory, for post-upload verification. Returns
+    (data, error_message) - never raises: a timeout or a connection dropping
+    mid-stream is reported as an error string, not an exception, so a transient
+    network blip during *verification* can never discard an upload that already
+    succeeded.
+    """
     payload = {
         "moduleId": ecosystem_item_id,
         "version": version,
         "isArchive": True,
     }
-    resp = requests.post(
-        f"{server_address.rstrip('/')}/public/api/v3/ecosystem.file.download",
-        json=payload,
-        headers={"x-api-key": api_token},
-        stream=True,
-    )
-    if resp.status_code != 200:
-        return None, f"HTTP {resp.status_code} while reading back the uploaded archive"
-    buf = io.BytesIO()
-    for chunk in resp.iter_content(chunk_size=1024 * 1024):
-        buf.write(chunk)
-    return buf.getvalue(), None
+    try:
+        resp = requests.post(
+            f"{server_address.rstrip('/')}/public/api/v3/ecosystem.file.download",
+            json=payload,
+            headers={"x-api-key": api_token},
+            stream=True,
+            timeout=60,
+        )
+        if resp.status_code != 200:
+            return None, f"HTTP {resp.status_code} while reading back the uploaded archive"
+        buf = io.BytesIO()
+        for chunk in resp.iter_content(chunk_size=1024 * 1024):
+            buf.write(chunk)
+        return buf.getvalue(), None
+    except requests.exceptions.RequestException as e:
+        return None, f"{type(e).__name__} while reading back the uploaded archive: {e}"
 
 
-def _validate_archive_bytes(data, archive_name):
+def _validate_archive_bytes(data):
     """
     Structural validation of an in-memory archive. Uses tarfile's auto-detecting
     "r:*" mode and actually iterates every member (not just opening the stream),
@@ -186,6 +199,12 @@ def _validate_archive_bytes(data, archive_name):
     client_side_app releases) cases, and catches the case where the outer gzip
     envelope is technically well-formed but the tar content inside it is
     truncated - a bare gzip-only check would miss that.
+
+    Caveat: member iteration alone does not always catch a stream truncated
+    exactly on a member-header boundary (verified: a 2-member plain tar cut
+    right before the 2nd header validates clean as a 1-member tar). The caller
+    is expected to also compare the read-back size against what was actually
+    uploaded - do not rely on this function alone to catch that shape.
     """
     try:
         with tarfile.open(fileobj=io.BytesIO(data), mode="r:*") as tar:
@@ -201,63 +220,89 @@ def _read_back_and_verify(
     api_token,
     appKey,
     version,
-    archive_name,
     expected_size,
-    max_read_attempts=4,
-    initial_backoff_sec=2,
+    max_read_attempts=3,
+    initial_backoff_sec=3,
 ):
     """
-    Read the just-uploaded archive back from the server and confirm it is complete
-    and structurally valid. Neither the upload endpoint nor the download endpoint
+    Read an uploaded archive back from the server and confirm it is complete and
+    structurally valid. Neither the upload endpoint nor the download endpoint
     validate transfer completeness on their own - a connection that drops
-    mid-transfer can still result in a "successful" HTTP response with a truncated
-    file stored server-side.
+    mid-transfer can still result in a "successful" HTTP response with a
+    truncated file stored server-side.
 
-    Storage/indexing on the server can also be asynchronous: reading back
-    *immediately* after the 200 response can race the server and either 404 or
-    serve a previous version's bytes, which would look identical to real
-    corruption unless we check for it. So this retries the read itself (not the
-    upload) with exponential backoff, and requires the returned size to match the
-    just-uploaded local archive's size before doing any deeper structural check -
-    a size mismatch is treated as "not propagated yet" and retried, not as
-    corruption. Only a size-matched-but-structurally-broken result is treated as
-    a real, immediate failure (no point retrying the read further at that point).
+    Returns (status, error_message), where status is one of:
+      - "valid": read-back size matches what was uploaded AND the structure
+        validates. The only outcome that is fully confirmed-good.
+      - "corrupt": read-back size matches, but the structure is broken. This is
+        unambiguous - the read is not racing anything, so retrying the read
+        further cannot help; this is real, actionable corruption.
+      - "inconclusive": everything else - network/permission errors, or a size
+        mismatch (with or without a structural error), even after retries. This
+        is deliberately NOT escalated to "corrupt": storage/indexing on the
+        server can be asynchronous (a read immediately after the 200 response
+        can race the server and 404 or serve a previous version's bytes), and
+        the server may also legitimately transform the archive on store (e.g.
+        re-compress it), so a size difference alone is not proof of corruption.
+        Callers must not treat "inconclusive" as a hard failure.
 
-    Returns (is_valid, error_message).
+    Retries the read itself (not the upload) with exponential backoff.
     """
     backoff = initial_backoff_sec
     last_err = "no read-back attempts were made"
+    ecosystem_item_id = None
     for attempt in range(1, max_read_attempts + 1):
-        app_info = get_app_from_instance(appKey, api_token, server_address)
-        if app_info is None or "id" not in app_info:
-            last_err = "could not resolve ecosystem item id for appKey"
-        else:
+        if ecosystem_item_id is None:
+            try:
+                app_info = get_app_from_instance(appKey, api_token, server_address)
+            except (PermissionError, ConnectionError, NotImplementedError) as e:
+                app_info = None
+                last_err = f"could not resolve ecosystem item id: {type(e).__name__}"
+            if app_info is not None and "id" in app_info:
+                ecosystem_item_id = app_info["id"]
+            elif app_info is None:
+                last_err = "could not resolve ecosystem item id for appKey"
+
+        if ecosystem_item_id is not None:
             data, err = _download_archive_bytes(
-                server_address, api_token, app_info["id"], version
+                server_address, api_token, ecosystem_item_id, version
             )
             if err is not None:
                 last_err = err
-            elif len(data) != expected_size:
-                last_err = (
-                    f"read-back size {len(data)} does not match the uploaded size "
-                    f"{expected_size} (server storage/indexing may still be propagating)"
-                )
             else:
-                return _validate_archive_bytes(data, archive_name)
+                size_matches = len(data) == expected_size
+                is_valid, struct_err = _validate_archive_bytes(data)
+                if size_matches and is_valid:
+                    return "valid", None
+                if size_matches and not is_valid:
+                    # Exact size match rules out a propagation race or a
+                    # server-side transform changing the byte count - this is
+                    # a confirmed, unambiguous corruption.
+                    return "corrupt", struct_err
+                last_err = (
+                    f"read-back size {len(data)} != uploaded size {expected_size}"
+                    + ("" if is_valid else f"; also structurally invalid ({struct_err})")
+                )
+
         if attempt < max_read_attempts:
             time.sleep(backoff)
             backoff *= 2
-    return False, f"gave up after {max_read_attempts} read-back attempts: {last_err}"
+    return "inconclusive", f"gave up after {max_read_attempts} read-back attempts: {last_err}"
 
 
 def _is_duplicate_version_response(response):
-    """True if the server rejected the upload because this version was already released."""
+    """
+    True only for the precise "version ... already exists" server response shape
+    (matching what run.py's own tag-deletion guard checks for) - not a loose
+    substring match, which could also match an unrelated "file already exists"
+    or similar message elsewhere in the payload.
+    """
     try:
-        message = json.dumps(response.json())
+        message = response.json()["details"]["message"]
     except Exception:
-        message = response.text or ""
-    message = message.lower()
-    return "already exists" in message or "already released" in message
+        return False
+    message = message.strip().lower()
+    return message.startswith("version") and message.endswith("already exists")
 
 
 def upload_archive(
@@ -274,107 +319,92 @@ def upload_archive(
     subapp_path,
     share_app,
     files,
-    max_attempts=2,
 ):
     archive_name = os.path.basename(archive_path)
     version = release.get("version")
     expected_size = os.path.getsize(archive_path)
-    response = None
-    last_ok_response = None
 
-    for attempt in range(1, max_attempts + 1):
-        with open(archive_path, "rb") as f:
-            fields = {
-                "appKey": appKey,
-                "subAppPath": subapp_path,
-                "release": json.dumps(release),
-                "config": json.dumps(config),
-                "readme": readme,
-                "modalTemplate": modal_template,
-                "archive": (
-                    archive_name,
-                    f,
-                    "application/gzip"
-                    if archive_name.endswith(".tar.gz")
-                    else "application/x-tar",
-                ),
-            }
-            if slug:
-                fields["slug"] = slug
-            if user_id:
-                fields["userId"] = str(user_id)
-            if share_app:
-                fields["isShared"] = "true"
-            if files:
-                files_contents = {}
-                fields["files"] = files_contents
-                for file_name, file_path in files.items():
-                    files_contents[file_name] = Path(file_path).read_text(encoding="utf-8")
-                fields["files"] = json.dumps(files_contents)
+    with open(archive_path, "rb") as f:
+        fields = {
+            "appKey": appKey,
+            "subAppPath": subapp_path,
+            "release": json.dumps(release),
+            "config": json.dumps(config),
+            "readme": readme,
+            "modalTemplate": modal_template,
+            "archive": (
+                archive_name,
+                f,
+                "application/gzip"
+                if archive_name.endswith(".tar.gz")
+                else "application/x-tar",
+            ),
+        }
+        if slug:
+            fields["slug"] = slug
+        if user_id:
+            fields["userId"] = str(user_id)
+        if share_app:
+            fields["isShared"] = "true"
+        if files:
+            files_contents = {}
+            fields["files"] = files_contents
+            for file_name, file_path in files.items():
+                files_contents[file_name] = Path(file_path).read_text(encoding="utf-8")
+            fields["files"] = json.dumps(files_contents)
 
-            e = MultipartEncoder(fields=fields)
-            encoder_len = e.len
-            with tqdm(
-                total=encoder_len,
-                unit="B",
-                unit_scale=True,
-                unit_divisor=1024,
-            ) as bar:
-                m = MultipartEncoderMonitor(
-                    e, lambda monitor: bar.update(monitor.bytes_read - bar.n)
-                )
-                response = requests.post(
-                    f"{server_address.rstrip('/')}/public/api/v3/ecosystem.release",
-                    data=m,
-                    headers={"Content-Type": m.content_type, "x-api-key": api_token},
-                )
-
-        if response.ok:
-            last_ok_response = response
-        else:
-            if version is None or not _is_duplicate_version_response(response):
-                # A genuine, unrelated rejection - let the existing caller-level
-                # retry/error handling (do_release_with_retry) deal with it as before.
-                return response
-            # The server says this version is already released - almost certainly
-            # because *this function's own previous attempt* already stored it
-            # (retrying with the same version would otherwise never legitimately
-            # hit this). Re-uploading again under the same version cannot help,
-            # so check what is actually stored instead of treating this as fatal.
-            print(
-                f"[upload_archive] Attempt {attempt}/{max_attempts}: server reports version "
-                f"{version!r} already exists; checking whether it was actually stored intact "
-                "before treating this as a failure...",
-                file=sys.stderr,
+        e = MultipartEncoder(fields=fields)
+        encoder_len = e.len
+        with tqdm(
+            total=encoder_len,
+            unit="B",
+            unit_scale=True,
+            unit_divisor=1024,
+        ) as bar:
+            m = MultipartEncoderMonitor(e, lambda monitor: bar.update(monitor.bytes_read - bar.n))
+            response = requests.post(
+                f"{server_address.rstrip('/')}/public/api/v3/ecosystem.release",
+                data=m,
+                headers={"Content-Type": m.content_type, "x-api-key": api_token},
             )
 
-        if version is None:
-            # Nothing to read back and compare against (e.g. archive_only_config flows).
-            return response
+    if not response.ok:
+        # Deliberately NOT retried, including for a duplicate-version rejection:
+        # this is the *only* upload attempt this call makes, so a "version
+        # already exists" response here can only mean a genuinely pre-existing
+        # release (e.g. re-releasing an already-published version) - never
+        # something this same call caused. Returning the response as-is
+        # (unchanged from the pre-verification behavior) lets run.py's own
+        # message.startswith("version")/endswith("already exists") check
+        # correctly recognize that shape and skip deleting the just-created
+        # git tag. Retrying here would only re-POST the identical version and
+        # get rejected identically - it cannot help even for real corruption.
+        return response
 
-        is_valid, err = _read_back_and_verify(
-            server_address, api_token, appKey, version, archive_name, expected_size
+    if version is None:
+        # Nothing to read back and compare against (e.g. archive_only_config flows).
+        return response
+
+    status, err = _read_back_and_verify(server_address, api_token, appKey, version, expected_size)
+    if status == "corrupt":
+        raise RuntimeError(
+            f"Uploaded archive for appKey={appKey!r} version={version!r} was confirmed "
+            f"corrupted server-side: {err}. The read-back byte size matched exactly what "
+            "was uploaded, so this is not a propagation race or a transient network issue - "
+            "the ecosystem.release/ecosystem.file.download backend needs investigation. "
+            "Re-uploading under the same version will be rejected as a duplicate, so this "
+            "cannot be fixed by retrying; a genuinely new version (or server-side "
+            "intervention) is required."
         )
-        if is_valid:
-            # response itself may be the "already exists" rejection from this attempt
-            # (see above) - report the earlier successful upload's response in that
-            # case, not the rejection, since the verified-good content is what matters.
-            return last_ok_response if last_ok_response is not None else response
-
-        print(
-            f"[upload_archive] Attempt {attempt}/{max_attempts}: stored archive for version "
-            f"{version!r} failed verification: {err}. "
-            + ("Retrying with a fresh upload..." if attempt < max_attempts else "Giving up."),
-            file=sys.stderr,
+    if status == "inconclusive":
+        console.print(
+            f"[orange1][Warning][/] Could not conclusively verify the archive uploaded for "
+            f"version {version!r} ({err}). Proceeding without blocking the release - a size "
+            "or availability mismatch on read-back is not proof of corruption (e.g. "
+            "asynchronous server-side storage/indexing, or the server legitimately "
+            "re-packing the archive on store)."
         )
-
-    raise RuntimeError(
-        f"Uploaded archive for appKey={appKey!r} version={version!r} repeatedly failed "
-        f"post-upload verification after {max_attempts} attempts - the server is storing a "
-        "truncated/corrupted archive despite returning a successful HTTP response. This is "
-        "not a client-side problem to retry away; the ecosystem.release/ecosystem.file.download "
-        "backend needs investigation."
-    )
+    return response
 
 
 def archive_application(repo: git.Repo, config, slug):


### PR DESCRIPTION
Code review + live testing on the actual dev instance surfaced real bugs in the previous fix:

1. Read-after-write race (confirmed live): the verification read back the archive immediately after the "200 OK" upload response, with no allowance for asynchronous server-side storage/indexing. A read that races the server can 404 or serve stale/previous bytes, which looked identical to real corruption. This produced a false "corrupted, giving up after 3 attempts" verdict on a branch release that was, per live confirmation on dev, actually healthy. Fix: split the read-back into its own function (_read_back_and_verify) that retries just the read - not the whole upload - with exponential backoff (2s/4s/8s/16s), and requires the returned byte size to match the local archive's size before doing any structural check. A size mismatch is now treated as "storage still propagating" and retried; only a size-matched-but-broken result is treated as real, immediate corruption.

2. Duplicate-version handling: retrying the whole upload on failure re-POSTs the identical release["version"]. If the server rejects re-releasing an already-stored version ("... already exists"), the previous code treated that rejection as fatal and returned it as-is, discarding the fact that an earlier attempt in the same call may have stored a perfectly good archive. Now detects this response shape and, instead of failing, checks what is actually stored via the same read-back-with-backoff path before deciding; reports the earlier successful response rather than the rejection when the stored content verifies as intact.

3. Structural check was gzip-only: archive_application emits a plain, uncompressed .tar for client_side_app releases, which the previous gzip.GzipFile check silently never validated. Also, a bare gzip check only validates the outer envelope - a gzip stream can decompress cleanly while the tar content inside is still truncated. Replaced with tarfile.open(fileobj=..., mode="r:*") (auto-detects compression) and *iterating every member* (not just opening the stream), which exercises the actual read path and catches both cases. Applied the same fix to download_git_archive's download-side check in app_api.py for consistency.

4. f = open(...) / f.close() -> use `with open(...) as f`.

Reduced upload_archive's own retry count from 3 to 2 attempts, since most of what used to require a full re-upload retry (temporary propagation lag) is now handled by the read-back backoff instead.

Verified _read_back_and_verify directly against the real dev instance using the exact appKey from a live production log
(supervisely-ecosystem/yolo, serve app, module 478): valid=True for v1.0.48 with its correct size; correctly reports the real, immediate structural corruption for v1.0.49 when given its correct (broken) size; correctly retries-then-reports "still propagating" rather than "corrupted" for v1.0.49 when given a deliberately mismatched size, directly reproducing and fixing the exact false-positive shape seen on dev.