### PR TITLE
Import zstd lazily to avoid a GC-during-init segfault

### DIFF
--- a/supervisely/project/data_version.py
+++ b/supervisely/project/data_version.py
@@ -7,7 +7,6 @@ from datetime import datetime
 from typing import List, NamedTuple, Optional, Tuple, Union
 
 import requests
-import zstd
 
 from supervisely._utils import logger
 from supervisely.api.module_api import ApiField, ModuleApiBase
@@ -777,6 +776,8 @@ class DataVersion(ModuleApiBase):
         :returns: Binary IO object with extracted file
         :rtype: io.BytesIO
         """
+        import zstd  # imported lazily to avoid a GC-during-module-init crash in some zstd builds
+
         temp_dir = tempfile.mkdtemp()
         local_path = os.path.join(temp_dir, "download.tar.zst")
         try:
@@ -844,6 +845,8 @@ class DataVersion(ModuleApiBase):
         :returns: File info
         :rtype: dict
         """
+        import zstd  # imported lazily to avoid a GC-during-module-init crash in some zstd builds
+
         temp_dir = tempfile.mkdtemp()
         data = None
         version_bin_path = None

--- a/supervisely/project/video_project.py
+++ b/supervisely/project/video_project.py
@@ -11,7 +11,6 @@ import tempfile
 from collections import namedtuple
 from typing import Callable, Dict, List, NamedTuple, Optional, Tuple, Union
 
-import zstd
 from tqdm import tqdm
 
 from supervisely._utils import batched, logger
@@ -1531,6 +1530,8 @@ class VideoProject(Project):
         :returns: In-memory snapshot stream (io.BytesIO).
         :rtype: io.BytesIO
         """
+        import zstd  # imported lazily to avoid a GC-during-module-init crash in some zstd builds
+
         try:
             import pyarrow  # pylint: disable=import-error
             import pyarrow.parquet as parquet  # pylint: disable=import-error
@@ -1767,6 +1768,8 @@ class VideoProject(Project):
         """
         Restore a video project from a snapshot and return ProjectInfo.
         """
+        import zstd  # imported lazily to avoid a GC-during-module-init crash in some zstd builds
+
         try:
             import pyarrow  # pylint: disable=import-error
             import pyarrow.parquet as parquet  # pylint: disable=import-error


### PR DESCRIPTION
## Why

`zstd` was imported unconditionally at module load in `data_version.py` and `video_project.py`, which runs on every `import supervisely` regardless of whether project versioning or video snapshots are ever used.

`python-zstd`'s C extension has an unguarded NULL-deref in its GC traverse callback (`myextension_traverse` calls `PyModule_GetState(m)` without checking for `NULL`) — if Python's GC runs a collection cycle in the narrow window while the module object exists but its state hasn't finished allocating, the whole process segfaults. Upstream `python-zstd` has since added the missing guard, but the version currently pinned doesn't have it.

## What changed

Moved `import zstd` from module scope into the four functions that actually use it (`DataVersion._download_and_extract`, `DataVersion._compress_and_upload`, `VideoProject.build_snapshot`, `VideoProject.restore_snapshot`). This removes the crash window for every app/process that doesn't touch project versioning or video snapshots, without changing any behavior for the ones that do — `zstd` usage itself is untouched.