### PR TITLE
Serve both upload progress_cb contracts from one adapter

### DIFF
--- a/supervisely/api/file_api.py
+++ b/supervisely/api/file_api.py
@@ -44,7 +44,11 @@ from supervisely.io.fs import (
 from supervisely.io.fs_cache import FileCache
 from supervisely.io.json import load_json_file
 from supervisely.sly_logger import logger
-from supervisely.task.progress import Progress, tqdm_sly
+from supervisely.task.progress import (
+    Progress,
+    build_multipart_monitor_callback,
+    tqdm_sly,
+)
 
 
 class FileInfo(NamedTuple):
@@ -954,27 +958,8 @@ class FileApi(ModuleApiBase):
         #         api.task.set_fields(task_id, [{"field": "data.previewProgress", "payload": cur_percent}])
         #     last_percent = cur_percent
 
-        if progress_cb is None:
-            data = encoder
-        else:
-            get_partial = getattr(progress_cb, "get_partial", None)
-            if callable(get_partial):
-                # tqdm_sly / CustomTqdm: monitor-aware (checked first; they subclass tqdm)
-                data = MultipartEncoderMonitor(encoder, get_partial())
-            else:
-                if isinstance(progress_cb, tqdm):
-                    progress_cb = progress_cb.update  # bare tqdm isn't callable
-                elif not callable(progress_cb):
-                    raise TypeError("progress_cb must be callable, tqdm, or have get_partial()")
-                # delta-int callable: monitor gives cumulative bytes_read, feed increments
-                reported = 0
-
-                def _monitor_cb(monitor):
-                    nonlocal reported
-                    progress_cb(monitor.bytes_read - reported)
-                    reported = monitor.bytes_read
-
-                data = MultipartEncoderMonitor(encoder, _monitor_cb)
+        monitor_cb = build_multipart_monitor_callback(progress_cb)
+        data = encoder if monitor_cb is None else MultipartEncoderMonitor(encoder, monitor_cb)
         resp = self._api.post("file-storage.bulk.upload?teamId={}".format(team_id), data)
         results = [self._convert_json_info(info_json) for info_json in resp.json()]
 

--- a/supervisely/api/video/video_api.py
+++ b/supervisely/api/video/video_api.py
@@ -61,7 +61,7 @@ from supervisely.io.fs import (
     list_files_recursively,
 )
 from supervisely.sly_logger import logger
-from supervisely.task.progress import Progress
+from supervisely.task.progress import Progress, build_multipart_monitor_callback
 from supervisely.video.video import (
     gen_video_stream_name,
     get_info,
@@ -1843,16 +1843,9 @@ class VideoApi(RemoveableBulkModuleApi):
             )
         encoder = MultipartEncoder(fields=content_dict)
 
-        if progress_cb is not None:
-
-            def _callback(monitor, progress):
-                progress(monitor.bytes_read)
-
-            if isinstance(progress_cb, tqdm):
-                callback = partial(_callback, progress=progress_cb.update)
-            else:
-                callback = partial(_callback, progress=progress_cb)
-            monitor = MultipartEncoderMonitor(encoder, callback)
+        monitor_cb = build_multipart_monitor_callback(progress_cb)
+        if monitor_cb is not None:
+            monitor = MultipartEncoderMonitor(encoder, monitor_cb)
             resp = self._api.post("videos.bulk.upload", monitor)
         else:
             resp = self._api.post("videos.bulk.upload", encoder)

--- a/supervisely/task/progress.py
+++ b/supervisely/task/progress.py
@@ -420,6 +420,83 @@ class SlyWrapFile:
         logger.info(msg)
 
 
+class UploadProgressDelta(int):
+    """
+    Byte increment handed to an upload ``progress_cb``.
+
+    Delta style callbacks (``tqdm.update``, ``Progress.iters_done_report``, a plain
+    ``lambda count: ...``) see a number. Callbacks written back when the SDK passed the
+    multipart encoder monitor itself still find ``bytes_read``, ``len`` and every other
+    attribute of that monitor on this value, so both conventions keep working.
+    """
+
+    def __new__(cls, delta: int, monitor):
+        obj = super().__new__(cls, delta)
+        obj._monitor = monitor
+        return obj
+
+    def __getattr__(self, name: str):
+        # reached only for names int itself does not define
+        if name.startswith("__") or name == "_monitor":
+            raise AttributeError(name)
+        return getattr(self._monitor, name)
+
+    @property
+    def monitor(self):
+        """
+        The multipart encoder monitor this increment came from.
+
+        :returns: Monitor object.
+        :rtype: :class:`MultipartEncoderMonitor<requests_toolbelt.multipart.encoder.MultipartEncoderMonitor>`
+        """
+        return self._monitor
+
+
+def build_multipart_monitor_callback(progress_cb):
+    """
+    Adapt any supported ``progress_cb`` to a ``MultipartEncoderMonitor`` callback.
+
+    Accepts a bare ``tqdm``, anything callable (delta style or monitor style), and objects
+    exposing ``get_partial()`` such as :class:`tqdm_sly` and the ``SlyTqdm`` widget, which
+    report from the monitor on their own.
+
+    :param progress_cb: Progress callback of any supported shape, or None.
+    :type progress_cb: Optional[Union[tqdm, Callable]]
+    :returns: Callback for the monitor, or None if there is nothing to report to.
+    :rtype: Optional[Callable]
+    :raises TypeError: if progress_cb is neither callable, nor a tqdm, nor monitor aware.
+    """
+    if progress_cb is None:
+        return None
+
+    get_partial = getattr(progress_cb, "get_partial", None)
+    if callable(get_partial):
+        return get_partial()
+
+    if not callable(progress_cb):
+        # a bare tqdm and a bare Progress are not callable, but both take an increment
+        for attr in ("update", "iters_done_report"):
+            method = getattr(progress_cb, attr, None)
+            if callable(method):
+                progress_cb = method
+                break
+        else:
+            raise TypeError(
+                "progress_cb must be callable, a tqdm or Progress instance, or expose "
+                f"get_partial(), got {type(progress_cb).__name__}"
+            )
+
+    reported = 0
+
+    def _report(monitor):
+        nonlocal reported
+        delta = monitor.bytes_read - reported
+        reported = monitor.bytes_read
+        progress_cb(UploadProgressDelta(delta, monitor))
+
+    return _report
+
+
 class tqdm_sly(tqdm, Progress):
     """tqdm-compatible progress bar that also reports progress via :class:`~supervisely.task.progress.Progress`."""
 

--- a/tests/unit/test_upload_progress_cb.py
+++ b/tests/unit/test_upload_progress_cb.py
@@ -1,0 +1,322 @@
+"""Tests for the upload ``progress_cb`` contract.
+
+Uploads report through a ``MultipartEncoderMonitor``. Callbacks in the wild come in two
+shapes: delta style ones that take a byte increment (``tqdm.update``,
+``Progress.iters_done_report``, plain lambdas) and monitor style ones written back when the
+SDK handed the monitor over (they read ``monitor.bytes_read`` / ``monitor.len``). Both are
+used inside the SDK itself, so the adapter has to serve both.
+
+The tests drive a real ``MultipartEncoder`` and never touch the network.
+"""
+
+import io
+from functools import partial
+
+import pytest
+from requests_toolbelt import MultipartEncoder, MultipartEncoderMonitor
+from tqdm import tqdm  # importing supervisely rebinds this name to tqdm_sly
+from tqdm.std import tqdm as vanilla_tqdm
+
+from supervisely.task.progress import (
+    Progress,
+    UploadProgressDelta,
+    build_multipart_monitor_callback,
+    tqdm_sly,
+)
+
+PAYLOAD = b"x" * 40000
+CHUNK = 8192
+
+
+def make_monitor(progress_cb, files=1):
+    fields = {
+        f"{idx}-file": (str(idx), io.BytesIO(PAYLOAD), "application/octet-stream")
+        for idx in range(files)
+    }
+    encoder = MultipartEncoder(fields=fields)
+    callback = build_multipart_monitor_callback(progress_cb)
+    return MultipartEncoderMonitor(encoder, callback) if callback else encoder
+
+
+def drain(monitor):
+    """Read the whole body, the way the HTTP adapter does."""
+    while monitor.read(CHUNK):
+        pass
+    return monitor.len
+
+
+# --------------------------------------------------------------------------------------
+# delta style callbacks
+# --------------------------------------------------------------------------------------
+def test_vanilla_tqdm_is_not_callable_but_still_works():
+    """A tqdm imported before supervisely stays the original class, which is not callable."""
+    bar = vanilla_tqdm(total=None, file=io.StringIO())
+    assert not callable(bar)
+    assert not hasattr(bar, "get_partial")
+    total = drain(make_monitor(bar))
+    assert bar.n == total
+
+
+def test_patched_tqdm_goes_through_its_monitor_hook():
+    """`supervisely/__init__.py` rebinds tqdm.tqdm to tqdm_sly, so user code that imports
+    tqdm after supervisely gets the monitor aware one."""
+    assert tqdm is tqdm_sly
+    bar = tqdm(desc="uploading", total=len(PAYLOAD), file=io.StringIO())
+    total = drain(make_monitor(bar))
+    assert bar.n == total
+
+
+def test_tqdm_update_bound_method():
+    bar = vanilla_tqdm(total=None, file=io.StringIO())
+    total = drain(make_monitor(bar.update))
+    assert bar.n == total
+
+
+def test_plain_lambda_gets_increments():
+    seen = []
+    total = drain(make_monitor(lambda count: seen.append(int(count))))
+    assert sum(seen) == total
+    assert all(delta >= 0 for delta in seen)
+
+
+def test_progress_iters_done_report():
+    progress = Progress("uploading", total_cnt=len(PAYLOAD) * 4, is_size=True)
+    total = drain(make_monitor(progress.iters_done_report))
+    assert progress.current == total
+
+
+def test_bare_progress_object():
+    """`Progress` is not callable, but it reports increments through iters_done_report."""
+    progress = Progress("uploading", total_cnt=len(PAYLOAD) * 4, is_size=True)
+    assert not callable(progress)
+    total = drain(make_monitor(progress))
+    assert progress.current == total
+
+
+def test_object_with_update_only():
+    class Bar:
+        def __init__(self):
+            self.n = 0
+
+        def update(self, count):
+            self.n += int(count)
+
+    bar = Bar()
+    total = drain(make_monitor(bar))
+    assert bar.n == total
+
+
+def test_callable_object_delta_style():
+    class Counter:
+        def __init__(self):
+            self.total = 0
+
+        def __call__(self, count):
+            self.total += int(count)
+
+    counter = Counter()
+    total = drain(make_monitor(counter))
+    assert counter.total == total
+
+
+# --------------------------------------------------------------------------------------
+# monitor style callbacks: what apps and the SDK itself were written against
+# --------------------------------------------------------------------------------------
+def test_monitor_style_function():
+    seen = {}
+
+    def on_progress(monitor):
+        seen["bytes_read"] = monitor.bytes_read
+        seen["len"] = monitor.len
+
+    total = drain(make_monitor(on_progress))
+    assert seen["bytes_read"] == total
+    assert seen["len"] == total
+
+
+def test_monitor_style_partial():
+    """The shape used by the yolov8 train app: partial() over a monitor style function."""
+    seen = []
+
+    def upload_monitor(monitor, tag):
+        seen.append((tag, monitor.bytes_read, monitor.len))
+
+    total = drain(make_monitor(partial(upload_monitor, tag="artifacts")))
+    assert seen[-1] == ("artifacts", total, total)
+    assert [read for _, read, _ in seen] == sorted(read for _, read, _ in seen)
+
+
+def test_monitor_style_callable_object():
+    class Reporter:
+        def __init__(self):
+            self.last = None
+
+        def __call__(self, monitor):
+            self.last = (monitor.bytes_read, monitor.len)
+
+    reporter = Reporter()
+    total = drain(make_monitor(reporter))
+    assert reporter.last == (total, total)
+
+
+def test_sly_output_set_download_shape():
+    """`sly.output.set_download` passes a lambda that reads len first, then bytes_read."""
+    state = {}
+
+    def _print_progress(monitor, holder):
+        if not holder:
+            holder.append(Progress("Uploading", total_cnt=monitor.len, is_size=True))
+        holder[0].set_current_value(monitor.bytes_read)
+        state["progress"] = holder[0]
+
+    holder = []
+    total = drain(make_monitor(lambda m: _print_progress(m, holder)))
+    assert state["progress"].current == total
+    assert state["progress"].total == total
+
+
+# --------------------------------------------------------------------------------------
+# monitor aware progress objects report on their own
+# --------------------------------------------------------------------------------------
+def test_tqdm_sly_uses_its_own_monitor_hook():
+    bar = tqdm_sly(desc="uploading", total=len(PAYLOAD), unit="B", file=io.StringIO())
+    assert callable(bar.get_partial())
+    total = drain(make_monitor(bar))
+    assert bar.n == total
+
+
+def test_get_partial_wins_over_being_callable():
+    calls = {"partial": 0, "call": 0}
+
+    class MonitorAware:
+        def __call__(self, count):
+            calls["call"] += 1
+
+        def get_partial(self):
+            def hook(monitor):
+                calls["partial"] += 1
+
+            return hook
+
+    drain(make_monitor(MonitorAware()))
+    assert calls["partial"] > 0
+    assert calls["call"] == 0
+
+
+def test_non_callable_get_partial_is_ignored():
+    """An attribute that merely happens to be named get_partial must not be called."""
+    seen = []
+
+    class Weird:
+        get_partial = "not a method"
+
+        def __call__(self, count):
+            seen.append(int(count))
+
+    total = drain(make_monitor(Weird()))
+    assert sum(seen) == total
+
+
+# --------------------------------------------------------------------------------------
+# the value handed to delta style callbacks
+# --------------------------------------------------------------------------------------
+def test_value_is_an_int_carrying_the_monitor():
+    values = []
+    total = drain(make_monitor(values.append))
+
+    assert all(isinstance(value, int) for value in values)
+    assert all(isinstance(value, UploadProgressDelta) for value in values)
+    assert sum(values) == total
+    assert values[-1].bytes_read == total
+    assert values[-1].len == total
+    assert values[-1].monitor.bytes_read == total
+    # arbitrary monitor attributes are forwarded too
+    assert values[-1].encoder is values[-1].monitor.encoder
+
+
+def test_value_behaves_like_a_number():
+    value = UploadProgressDelta(7, _FakeMonitor(bytes_read=7, len=10))
+    assert value + 1 == 8
+    assert value * 2 == 14
+    assert float(value) == 7.0
+    assert f"{value}" == "7"
+    assert value < 8 and value > 6
+    assert sum([value, value]) == 14
+
+
+def test_unknown_attribute_raises_attribute_error():
+    value = UploadProgressDelta(1, _FakeMonitor(bytes_read=1, len=2))
+    with pytest.raises(AttributeError):
+        value.definitely_not_there
+
+
+class _FakeMonitor:
+    def __init__(self, bytes_read, len):  # noqa: A002 - mirrors the toolbelt attribute
+        self.bytes_read = bytes_read
+        self.len = len
+
+
+# --------------------------------------------------------------------------------------
+# increments, ordering and multi file uploads
+# --------------------------------------------------------------------------------------
+def test_increments_sum_up_and_never_go_backwards():
+    deltas, cumulative = [], []
+
+    def on_progress(value):
+        deltas.append(int(value))
+        cumulative.append(value.bytes_read)
+
+    total = drain(make_monitor(on_progress))
+    assert sum(deltas) == total
+    assert cumulative == sorted(cumulative)
+    assert cumulative[-1] == total
+
+
+def test_bulk_upload_reports_across_all_files():
+    values = []
+    total = drain(make_monitor(values.append, files=3))
+    assert sum(values) == total
+    assert total > 3 * len(PAYLOAD)  # payload plus multipart overhead
+
+
+# --------------------------------------------------------------------------------------
+# nothing to report to, and bad input
+# --------------------------------------------------------------------------------------
+def test_none_means_no_monitor():
+    assert build_multipart_monitor_callback(None) is None
+
+
+@pytest.mark.parametrize("bad", [42, "a string", object(), ["list"]])
+def test_non_callable_progress_cb_is_rejected(bad):
+    with pytest.raises(TypeError, match="progress_cb must be callable"):
+        build_multipart_monitor_callback(bad)
+
+
+def test_callback_is_independent_per_upload():
+    """Two uploads with the same callback must not share the reported offset."""
+    values = []
+    drain(make_monitor(values.append))
+    first = sum(values)
+
+    values.clear()
+    drain(make_monitor(values.append))
+    assert sum(values) == first
+
+
+def test_callback_errors_are_not_swallowed():
+    """A broken callback must fail loudly instead of corrupting the upload silently."""
+
+    def boom(value):
+        raise RuntimeError("callback is broken")
+
+    with pytest.raises(RuntimeError, match="callback is broken"):
+        drain(make_monitor(boom))
+
+
+def test_widget_progress_shape_is_the_get_partial_one():
+    """The SlyTqdm widget (CustomTqdm) cannot be built outside an app, but it reports the
+    same way tqdm_sly does: through get_partial(), which is covered above."""
+    from supervisely.app.widgets.sly_tqdm.sly_tqdm import CustomTqdm
+
+    assert callable(getattr(CustomTqdm, "get_partial", None))
+    assert callable(getattr(CustomTqdm, "_progress_monitor", None))


### PR DESCRIPTION
Closes supervisely/issues#6096.

## The problem

Upload progress callbacks exist in two shapes, both used inside this repo:

- **delta style** — takes a byte increment: `tqdm.update`, `Progress.iters_done_report`,
  a plain `lambda count: ...`;
- **monitor style** — written when the SDK passed the `MultipartEncoderMonitor` itself, reads
  `monitor.bytes_read` and `monitor.len`.

Until #1773 a plain callable received the monitor; after it, an int. Every monitor style
callback started failing on SDK 6.74.16 and newer:

```
requests_toolbelt/multipart/encoder.py:403  self.callback(self)
supervisely/api/file_api.py:974             progress_cb(monitor.bytes_read - reported)
train/src/main.py:2082                      value = monitor.bytes_read
AttributeError: 'int' object has no attribute 'bytes_read'
```

`sly.output.set_download` in this repo passes exactly such a callback, so the SDK broke its own
upload path too. A plain function cannot be told apart by inspection, so neither convention can
simply win.

## The fix

The value handed to a callback is an `int` subclass that forwards the monitor's attributes:

```python
class UploadProgressDelta(int):
    def __new__(cls, delta, monitor): ...
    def __getattr__(self, name):
        return getattr(self._monitor, name)
```

Delta style callbacks see a number (arithmetic, `isinstance(x, int)`, `tqdm.update` all work),
monitor style ones find `bytes_read`, `len` and anything else the monitor carries.

`build_multipart_monitor_callback()` in `supervisely/task/progress.py` is now the single
adapter, and the three upload paths that reported bytes went through three different
conventions:

- `FileApi._upload_bulk` — the one #1773 changed;
- `VideoApi._upload_uniq_videos_single_req` — fed the **cumulative** byte count into
  `tqdm.update`, which expects an increment, so the bar overshot on every call;
- objects exposing `get_partial()` (`tqdm_sly`, the `SlyTqdm` widget) keep reporting from the
  monitor themselves, unchanged.

Non callable progress objects are handled as well: a bare `tqdm` reports through `update`, a
bare `Progress` through `iters_done_report`, and anything else raises a `TypeError` that names
the contract instead of failing three libraries deep.

## Tests

`tests/unit/test_upload_progress_cb.py`, 28 tests driving a real `MultipartEncoder` with no
network: bare vanilla tqdm, the patched `tqdm.tqdm` (`supervisely/__init__.py` rebinds it to
`tqdm_sly`), `tqdm.update`, bare `Progress`, `Progress.iters_done_report`, an object with only
`update`, delta lambdas and callable objects, monitor style functions, `partial()` wrappers
(the shape the yolov8 train app uses), monitor style callable objects, the
`sly.output.set_download` shape, `get_partial()` winning over `__call__`, a non callable
attribute merely named `get_partial`, increment arithmetic and ordering, multi file bulk
uploads, per upload isolation of the reported offset, exceptions propagating out of a broken
callback, and the `TypeError` for unusable input.
