### PR TITLE
Serve both upload progress_cb contracts from one adapter

### DIFF
--- a/supervisely/api/file_api.py
+++ b/supervisely/api/file_api.py
@@ -2333,7 +2333,12 @@ class FileApi(ModuleApiBase):
         progress_cb: Optional[Union[tqdm, Callable]],
         value: int,
     ) -> None:
-        """Report progress to either a tqdm-like object or a plain callable."""
+        """
+        Report progress to either a tqdm-like object or a plain callable.
+
+        This is the item count path, not the byte path: it reports how many files are done.
+        Byte progress of a single upload goes through build_multipart_monitor_callback().
+        """
         if progress_cb is None:
             return
         if hasattr(progress_cb, "update"):

--- a/supervisely/api/file_api.py
+++ b/supervisely/api/file_api.py
@@ -44,7 +44,11 @@ from supervisely.io.fs import (
 from supervisely.io.fs_cache import FileCache
 from supervisely.io.json import load_json_file
 from supervisely.sly_logger import logger
-from supervisely.task.progress import Progress, tqdm_sly
+from supervisely.task.progress import (
+    Progress,
+    build_multipart_monitor_callback,
+    tqdm_sly,
+)
 
 
 class FileInfo(NamedTuple):
@@ -954,27 +958,8 @@ class FileApi(ModuleApiBase):
         #         api.task.set_fields(task_id, [{"field": "data.previewProgress", "payload": cur_percent}])
         #     last_percent = cur_percent
 
-        if progress_cb is None:
-            data = encoder
-        else:
-            get_partial = getattr(progress_cb, "get_partial", None)
-            if callable(get_partial):
-                # tqdm_sly / CustomTqdm: monitor-aware (checked first; they subclass tqdm)
-                data = MultipartEncoderMonitor(encoder, get_partial())
-            else:
-                if isinstance(progress_cb, tqdm):
-                    progress_cb = progress_cb.update  # bare tqdm isn't callable
-                elif not callable(progress_cb):
-                    raise TypeError("progress_cb must be callable, tqdm, or have get_partial()")
-                # delta-int callable: monitor gives cumulative bytes_read, feed increments
-                reported = 0
-
-                def _monitor_cb(monitor):
-                    nonlocal reported
-                    progress_cb(monitor.bytes_read - reported)
-                    reported = monitor.bytes_read
-
-                data = MultipartEncoderMonitor(encoder, _monitor_cb)
+        monitor_cb = build_multipart_monitor_callback(progress_cb)
+        data = encoder if monitor_cb is None else MultipartEncoderMonitor(encoder, monitor_cb)
         resp = self._api.post("file-storage.bulk.upload?teamId={}".format(team_id), data)
         results = [self._convert_json_info(info_json) for info_json in resp.json()]
 

--- a/supervisely/api/video/video_api.py
+++ b/supervisely/api/video/video_api.py
@@ -8,7 +8,6 @@ import json
 import os
 import re
 import urllib.parse
-from functools import partial
 from itertools import zip_longest
 from typing import (
     AsyncGenerator,

--- a/supervisely/api/video/video_api.py
+++ b/supervisely/api/video/video_api.py
@@ -1812,8 +1812,9 @@ class VideoApi(RemoveableBulkModuleApi):
         p = None
         if item_progress is not None and type(item_progress) is bool:
             p = Progress(f"Uploading {name}", total_cnt=get_file_size(path), is_size=True)
-            # progress_cb = p.iters_done_report
-            progress_cb = p.set_current_value
+            # the upload reports increments, so an absolute setter would stall after the
+            # first chunk: set_current_value(delta) advances by delta minus what is done
+            progress_cb = p.iters_done_report
 
         results = self.upload_paths(
             dataset_id=dataset_id,

--- a/supervisely/api/video/video_api.py
+++ b/supervisely/api/video/video_api.py
@@ -61,7 +61,7 @@ from supervisely.io.fs import (
     list_files_recursively,
 )
 from supervisely.sly_logger import logger
-from supervisely.task.progress import Progress
+from supervisely.task.progress import Progress, build_multipart_monitor_callback
 from supervisely.video.video import (
     gen_video_stream_name,
     get_info,
@@ -1843,16 +1843,9 @@ class VideoApi(RemoveableBulkModuleApi):
             )
         encoder = MultipartEncoder(fields=content_dict)
 
-        if progress_cb is not None:
-
-            def _callback(monitor, progress):
-                progress(monitor.bytes_read)
-
-            if isinstance(progress_cb, tqdm):
-                callback = partial(_callback, progress=progress_cb.update)
-            else:
-                callback = partial(_callback, progress=progress_cb)
-            monitor = MultipartEncoderMonitor(encoder, callback)
+        monitor_cb = build_multipart_monitor_callback(progress_cb)
+        if monitor_cb is not None:
+            monitor = MultipartEncoderMonitor(encoder, monitor_cb)
             resp = self._api.post("videos.bulk.upload", monitor)
         else:
             resp = self._api.post("videos.bulk.upload", encoder)

--- a/supervisely/api/video/video_api.py
+++ b/supervisely/api/video/video_api.py
@@ -1763,7 +1763,7 @@ class VideoApi(RemoveableBulkModuleApi):
         name: str,
         path: str,
         meta: Dict = None,
-        item_progress: Optional[Progress] = None,
+        item_progress: Optional[Union[bool, Progress, Callable]] = None,
     ) -> VideoInfo:
         """
         Uploads Video with given name from given local path to Dataset.

--- a/supervisely/convert/video/multi_view/multi_view.py
+++ b/supervisely/convert/video/multi_view/multi_view.py
@@ -448,8 +448,7 @@ class MultiViewVideoConverter(VideoConverter):
                     [self._check_video_file_size(file_size) for file_size in file_sizes]
                 )
                 if has_large_files:
-                    upload_progress = []
-                    size_progress_cb = self._get_video_upload_progress(upload_progress)
+                    size_progress_cb = self._get_video_upload_progress()
 
         key_id_map = KeyIdMap()
         batch_size = 1 if has_large_files and not self.upload_as_links else batch_size

--- a/supervisely/convert/video/sly/sly_video_converter.py
+++ b/supervisely/convert/video/sly/sly_video_converter.py
@@ -389,8 +389,7 @@ class SLYVideoConverter(VideoConverter):
                     [self._check_video_file_size(file_size) for file_size in file_sizes]
                 )
                 if has_large_files:
-                    upload_progress = []
-                    size_progress_cb = self._get_video_upload_progress(upload_progress)
+                    size_progress_cb = self._get_video_upload_progress()
 
         with ApiContext(api=api, project_meta=meta):
             batch_size = 1 if has_large_files and not self.upload_as_links else batch_size

--- a/supervisely/convert/video/video_converter.py
+++ b/supervisely/convert/video/video_converter.py
@@ -179,8 +179,7 @@ class VideoConverter(BaseConverter):
                     [self._check_video_file_size(file_size) for file_size in file_sizes]
                 )
                 if has_large_files:
-                    upload_progress = []
-                    size_progress_cb = self._get_video_upload_progress(upload_progress)
+                    size_progress_cb = self._get_video_upload_progress()
         batch_size = 1 if has_large_files and not self.upload_as_links else batch_size
 
         for batch in batched(self._items, batch_size=batch_size):
@@ -337,10 +336,11 @@ class VideoConverter(BaseConverter):
     def _check_video_file_size(self, file_size):
         return file_size > 20 * 1024 * 1024  # 20 MB
 
-    def _get_video_upload_progress(self, upload_progress):
+    def _get_video_upload_progress(self):
+        """Byte progress bar shared by every video of the upload, for large files."""
         upload_progress = []
 
-        def _print_progress(monitor, upload_progress):
+        def _print_progress(delta, upload_progress):
             if len(upload_progress) == 0:
                 upload_progress.append(
                     Progress(
@@ -349,7 +349,8 @@ class VideoConverter(BaseConverter):
                         is_size=True,
                     )
                 )
-            # set_current_value is absolute, so it needs the running total, not the increment
-            upload_progress[0].set_current_value(monitor.bytes_read)
+            # increments add up across videos; a large upload sends one video per request,
+            # and every request brings its own monitor whose bytes_read starts at zero
+            upload_progress[0].iters_done_report(int(delta))
 
         return lambda m: _print_progress(m, upload_progress)

--- a/supervisely/convert/video/video_converter.py
+++ b/supervisely/convert/video/video_converter.py
@@ -349,6 +349,7 @@ class VideoConverter(BaseConverter):
                         is_size=True,
                     )
                 )
-            upload_progress[0].set_current_value(monitor)
+            # set_current_value is absolute, so it needs the running total, not the increment
+            upload_progress[0].set_current_value(monitor.bytes_read)
 
         return lambda m: _print_progress(m, upload_progress)

--- a/supervisely/task/progress.py
+++ b/supervisely/task/progress.py
@@ -535,7 +535,7 @@ def build_multipart_monitor_callback(progress_cb):
     # stand rather than handed an increment. bytes_read of the current monitor would not do:
     # a bulk upload sends several requests, and every request starts its monitor at zero.
     sets_absolute = getattr(progress_cb, "__func__", None) is Progress.set_current_value
-    progress = getattr(progress_cb, "__self__", None)
+    bar = progress_cb.__self__ if sets_absolute else None
 
     reported = 0
 
@@ -544,7 +544,7 @@ def build_multipart_monitor_callback(progress_cb):
         delta = monitor.bytes_read - reported
         reported = monitor.bytes_read
         if sets_absolute:
-            progress_cb(progress.current + delta)
+            progress_cb(bar.current + delta)
         else:
             progress_cb(UploadProgressDelta(delta, monitor))
 

--- a/supervisely/task/progress.py
+++ b/supervisely/task/progress.py
@@ -499,6 +499,11 @@ def build_multipart_monitor_callback(progress_cb):
     exposing ``get_partial()`` such as :class:`tqdm_sly` and the ``SlyTqdm`` widget, which
     report from the monitor on their own.
 
+    Callables are handed a byte increment, with one exception:
+    :meth:`Progress.set_current_value` sets an absolute value, so it keeps receiving the
+    running total. The exception is on the function itself, so subclasses are served too
+    and a foreign method of the same name stays on the increment contract.
+
     :param progress_cb: Progress callback of any supported shape, or None.
     :type progress_cb: Optional[Union[tqdm, Callable]]
     :returns: Callback for the monitor, or None if there is nothing to report to.

--- a/supervisely/task/progress.py
+++ b/supervisely/task/progress.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 import inspect
 import math
 import re
+import weakref
 from functools import partial, wraps
 from typing import Dict, Optional, Union
 
@@ -420,6 +421,16 @@ class SlyWrapFile:
         logger.info(msg)
 
 
+class _StrongRef:
+    """Stand-in for weakref.ref, for the rare object that forbids weak references."""
+
+    def __init__(self, obj):
+        self._obj = obj
+
+    def __call__(self):
+        return self._obj
+
+
 class UploadProgressDelta(int):
     """
     Byte increment handed to an upload ``progress_cb``.
@@ -428,28 +439,51 @@ class UploadProgressDelta(int):
     ``lambda count: ...``) see a number. Callbacks written back when the SDK passed the
     multipart encoder monitor itself still find ``bytes_read``, ``len`` and every other
     attribute of that monitor on this value, so both conventions keep working.
+
+    ``bytes_read`` and ``len`` are copied onto the value and stay readable for good. The
+    monitor itself is held weakly, so a callback that keeps the numbers it was handed does
+    not keep the encoder and its open files alive with them; attributes that only the
+    monitor has are therefore readable while the upload runs. Pickling and copying give a
+    plain ``int``, the way a delta style callback saw the value before this type existed.
     """
 
     def __new__(cls, delta: int, monitor):
         obj = super().__new__(cls, delta)
-        obj._monitor = monitor
+        obj.bytes_read = monitor.bytes_read
+        obj.len = monitor.len
+        try:
+            obj._monitor_ref = weakref.ref(monitor)
+        except TypeError:
+            obj._monitor_ref = _StrongRef(monitor)
         return obj
 
+    def __reduce__(self):
+        # a monitor crosses neither a pickle nor a process boundary: hand over the number
+        return (int, (int(self),))
+
     def __getattr__(self, name: str):
-        # reached only for names int itself does not define
-        if name.startswith("__") or name == "_monitor":
+        # reached only for names neither int nor __new__ above defines
+        if name.startswith("_"):
             raise AttributeError(name)
-        return getattr(self._monitor, name)
+        monitor = self._monitor_ref()
+        if monitor is None:
+            raise AttributeError(
+                f"{name!r} is readable only while the upload is running, and this "
+                f"increment outlived its monitor; bytes_read and len are always kept"
+            )
+        return getattr(monitor, name)
 
     @property
     def monitor(self):
         """
         The multipart encoder monitor this increment came from.
 
-        :returns: Monitor object.
-        :rtype: :class:`MultipartEncoderMonitor<requests_toolbelt.multipart.encoder.MultipartEncoderMonitor>`
+        Held weakly, so it is None once the upload is over.
+
+        :returns: Monitor object, or None.
+        :rtype: Optional[:class:`MultipartEncoderMonitor<requests_toolbelt.multipart.encoder.MultipartEncoderMonitor>`]
         """
-        return self._monitor
+        return self._monitor_ref()
 
 
 def build_multipart_monitor_callback(progress_cb):

--- a/supervisely/task/progress.py
+++ b/supervisely/task/progress.py
@@ -500,9 +500,10 @@ def build_multipart_monitor_callback(progress_cb):
     report from the monitor on their own.
 
     Callables are handed a byte increment, with one exception:
-    :meth:`Progress.set_current_value` sets an absolute value, so it keeps receiving the
-    running total. The exception is on the function itself, so subclasses are served too
-    and a foreign method of the same name stays on the increment contract.
+    :meth:`Progress.set_current_value` sets an absolute value, so it is told where the bar
+    should stand, which adds up across the several requests of a bulk upload. The exception
+    is on the function itself, so subclasses are served too and a foreign method of the same
+    name stays on the increment contract.
 
     :param progress_cb: Progress callback of any supported shape, or None.
     :type progress_cb: Optional[Union[tqdm, Callable]]
@@ -530,14 +531,11 @@ def build_multipart_monitor_callback(progress_cb):
                 f"get_partial(), got {type(progress_cb).__name__}"
             )
 
-    if getattr(progress_cb, "__func__", None) is Progress.set_current_value:
-        # an absolute setter: it advances by the value minus what is already done, so it
-        # needs the running total. Kept working the way it did before uploads reported
-        # increments, since callers pass Progress.set_current_value directly.
-        def _report_total(monitor):
-            progress_cb(monitor.bytes_read)
-
-        return _report_total
+    # Progress.set_current_value sets an absolute value, so it is told where the bar should
+    # stand rather than handed an increment. bytes_read of the current monitor would not do:
+    # a bulk upload sends several requests, and every request starts its monitor at zero.
+    sets_absolute = getattr(progress_cb, "__func__", None) is Progress.set_current_value
+    progress = getattr(progress_cb, "__self__", None)
 
     reported = 0
 
@@ -545,7 +543,10 @@ def build_multipart_monitor_callback(progress_cb):
         nonlocal reported
         delta = monitor.bytes_read - reported
         reported = monitor.bytes_read
-        progress_cb(UploadProgressDelta(delta, monitor))
+        if sets_absolute:
+            progress_cb(progress.current + delta)
+        else:
+            progress_cb(UploadProgressDelta(delta, monitor))
 
     return _report
 

--- a/supervisely/task/progress.py
+++ b/supervisely/task/progress.py
@@ -422,7 +422,12 @@ class SlyWrapFile:
 
 
 class _StrongRef:
-    """Stand-in for weakref.ref, for the rare object that forbids weak references."""
+    """
+    Stand-in for weakref.ref, for the rare object that forbids weak references.
+
+    Every monitor the SDK builds is weak referenceable; this is here for a caller supplying
+    a monitor of its own, for instance one with __slots__ and no __weakref__.
+    """
 
     def __init__(self, obj):
         self._obj = obj

--- a/supervisely/task/progress.py
+++ b/supervisely/task/progress.py
@@ -525,6 +525,15 @@ def build_multipart_monitor_callback(progress_cb):
                 f"get_partial(), got {type(progress_cb).__name__}"
             )
 
+    if getattr(progress_cb, "__func__", None) is Progress.set_current_value:
+        # an absolute setter: it advances by the value minus what is already done, so it
+        # needs the running total. Kept working the way it did before uploads reported
+        # increments, since callers pass Progress.set_current_value directly.
+        def _report_total(monitor):
+            progress_cb(monitor.bytes_read)
+
+        return _report_total
+
     reported = 0
 
     def _report(monitor):

--- a/supervisely/task/progress.py
+++ b/supervisely/task/progress.py
@@ -420,6 +420,83 @@ class SlyWrapFile:
         logger.info(msg)
 
 
+class UploadProgressDelta(int):
+    """
+    Byte increment handed to an upload ``progress_cb``.
+
+    Delta style callbacks (``tqdm.update``, ``Progress.iters_done_report``, a plain
+    ``lambda count: ...``) see a number. Callbacks written back when the SDK passed the
+    multipart encoder monitor itself still find ``bytes_read``, ``len`` and every other
+    attribute of that monitor on this value, so both conventions keep working.
+    """
+
+    def __new__(cls, delta: int, monitor):
+        obj = super().__new__(cls, delta)
+        obj._monitor = monitor
+        return obj
+
+    def __getattr__(self, name: str):
+        # reached only for names int itself does not define
+        if name.startswith("__") or name == "_monitor":
+            raise AttributeError(name)
+        return getattr(self._monitor, name)
+
+    @property
+    def monitor(self):
+        """
+        The multipart encoder monitor this increment came from.
+
+        :returns: Monitor object.
+        :rtype: :class:`MultipartEncoderMonitor<requests_toolbelt.multipart.encoder.MultipartEncoderMonitor>`
+        """
+        return self._monitor
+
+
+def build_multipart_monitor_callback(progress_cb):
+    """
+    Adapt any supported ``progress_cb`` to a ``MultipartEncoderMonitor`` callback.
+
+    Accepts a bare ``tqdm``, anything callable (delta style or monitor style), and objects
+    exposing ``get_partial()`` such as :class:`tqdm_sly` and the ``SlyTqdm`` widget, which
+    report from the monitor on their own.
+
+    :param progress_cb: Progress callback of any supported shape, or None.
+    :type progress_cb: Optional[Union[tqdm, Callable]]
+    :returns: Callback for the monitor, or None if there is nothing to report to.
+    :rtype: Optional[Callable]
+    :raises TypeError: if progress_cb is neither callable, nor a tqdm, nor monitor aware.
+    """
+    if progress_cb is None:
+        return None
+
+    get_partial = getattr(progress_cb, "get_partial", None)
+    if callable(get_partial):
+        return get_partial()
+
+    if not callable(progress_cb):
+        # a bare tqdm and a bare Progress are not callable, but both take an increment
+        for attr in ("update", "iters_done_report"):
+            method = getattr(progress_cb, attr, None)
+            if callable(method):
+                progress_cb = method
+                break
+        else:
+            raise TypeError(
+                "progress_cb must be callable, a tqdm or Progress instance, or expose "
+                f"get_partial(), got {type(progress_cb).__name__}"
+            )
+
+    reported = 0
+
+    def _report(monitor):
+        nonlocal reported
+        delta = monitor.bytes_read - reported
+        reported = monitor.bytes_read
+        progress_cb(UploadProgressDelta(delta, monitor))
+
+    return _report
+
+
 class tqdm_sly(tqdm, Progress):
     """tqdm-compatible progress bar that also reports progress via :class:`~supervisely.task.progress.Progress`."""
 

--- a/tests/unit/test_upload_progress_cb.py
+++ b/tests/unit/test_upload_progress_cb.py
@@ -325,6 +325,32 @@ def test_widget_progress_shape_is_the_get_partial_one():
     assert callable(getattr(CustomTqdm, "_progress_monitor", None))
 
 
+def test_video_converter_progress_follows_the_upload():
+    """The converters' shared callback hands its argument straight to Progress.set_current_value,
+    an absolute setter, so it has to pass the running total rather than the increment. Feeding
+    it increments left the bar at zero once the upload finished."""
+    from supervisely.convert.video import video_converter
+
+    created = []
+
+    class SpyProgress(video_converter.Progress):
+        def __init__(self, *args, **kwargs):
+            super().__init__(*args, **kwargs)
+            created.append(self)
+
+    original = video_converter.Progress
+    video_converter.Progress = SpyProgress
+    try:
+        # self is unused by the helper, and building a converter needs a real dataset
+        callback = video_converter.VideoConverter._get_video_upload_progress(None, [])
+        total = drain(make_monitor(callback))
+    finally:
+        video_converter.Progress = original
+
+    assert created, "no Progress was created"
+    assert created[0].current == total
+
+
 def test_absolute_setter_stalls_on_increments():
     """`Progress.set_current_value` advances by `value - current`, so feeding it increments
     leaves it stuck near the first chunk. Nothing inside the SDK may hand it to the adapter."""

--- a/tests/unit/test_upload_progress_cb.py
+++ b/tests/unit/test_upload_progress_cb.py
@@ -10,7 +10,11 @@ The tests drive a real ``MultipartEncoder`` and never touch the network.
 """
 
 import ast
+import copy
+import gc
 import io
+import pickle
+import weakref
 from functools import partial
 from pathlib import Path
 
@@ -225,16 +229,80 @@ def test_non_callable_get_partial_is_ignored():
 # --------------------------------------------------------------------------------------
 def test_value_is_an_int_carrying_the_monitor():
     values = []
-    total = drain(make_monitor(values.append))
+    monitor = make_monitor(values.append)
+    total = drain(monitor)
 
     assert all(isinstance(value, int) for value in values)
     assert all(isinstance(value, UploadProgressDelta) for value in values)
     assert sum(values) == total
     assert values[-1].bytes_read == total
     assert values[-1].len == total
-    assert values[-1].monitor.bytes_read == total
-    # arbitrary monitor attributes are forwarded too
-    assert values[-1].encoder is values[-1].monitor.encoder
+    assert values[-1].monitor is monitor
+    # arbitrary monitor attributes are forwarded while the upload is running
+    assert values[-1].encoder is monitor.encoder
+
+
+def test_stored_increments_do_not_pin_the_monitor():
+    """A callback that keeps what it was handed must not keep the encoder alive with it."""
+    values = []
+    monitor = make_monitor(values.append)
+    drain(monitor)
+    monitor_ref = weakref.ref(monitor)
+
+    del monitor
+    gc.collect()
+    assert monitor_ref() is None, "stored increments pinned the multipart monitor"
+    assert values[-1].monitor is None
+
+
+def test_stored_increments_do_not_pin_the_uploaded_file(tmp_path):
+    """The team files upload never closes its streams explicitly, so nothing the callback
+    keeps may hold them open."""
+    path = tmp_path / "payload.bin"
+    path.write_bytes(PAYLOAD)
+    handle = open(path, "rb")
+    handle_ref = weakref.ref(handle)
+
+    values = []
+    encoder = MultipartEncoder(
+        fields=[("file", ("payload.bin", handle, "application/octet-stream"))]
+    )
+    monitor = MultipartEncoderMonitor(encoder, build_multipart_monitor_callback(values.append))
+    drain(monitor)
+
+    del encoder, monitor, handle
+    gc.collect()
+    assert values, "no progress was reported"
+    assert handle_ref() is None, "stored increments held the uploaded file open"
+
+
+def test_numbers_outlive_the_monitor():
+    values = []
+    monitor = make_monitor(values.append)
+    total = drain(monitor)
+
+    del monitor
+    gc.collect()
+    assert values[-1].bytes_read == total
+    assert values[-1].len == total
+    with pytest.raises(AttributeError, match="only while the upload is running"):
+        values[-1].encoder
+
+
+@pytest.mark.parametrize("protocol", range(pickle.HIGHEST_PROTOCOL + 1))
+def test_value_pickles_as_a_plain_int(protocol):
+    """A monitor cannot cross a process boundary, but the increment used to be a plain int
+    and code that puts it on a multiprocessing queue must keep working."""
+    value = UploadProgressDelta(7, _FakeMonitor(bytes_read=7, len=10))
+    restored = pickle.loads(pickle.dumps(value, protocol=protocol))
+    assert restored == 7
+    assert type(restored) is int
+
+
+def test_value_copies_as_a_plain_int():
+    value = UploadProgressDelta(7, _FakeMonitor(bytes_read=7, len=10))
+    assert copy.copy(value) == 7
+    assert copy.deepcopy(value) == 7
 
 
 def test_value_behaves_like_a_number():

--- a/tests/unit/test_upload_progress_cb.py
+++ b/tests/unit/test_upload_progress_cb.py
@@ -23,7 +23,6 @@ from tqdm import tqdm  # importing supervisely rebinds this name to tqdm_sly
 from tqdm.std import tqdm as vanilla_tqdm
 
 from supervisely.api.video.video_api import VideoApi
-from supervisely.convert.video.video_converter import VideoConverter
 from supervisely.task.progress import (
     Progress,
     UploadProgressDelta,

--- a/tests/unit/test_upload_progress_cb.py
+++ b/tests/unit/test_upload_progress_cb.py
@@ -9,14 +9,17 @@ used inside the SDK itself, so the adapter has to serve both.
 The tests drive a real ``MultipartEncoder`` and never touch the network.
 """
 
+import ast
 import io
 from functools import partial
+from pathlib import Path
 
 import pytest
 from requests_toolbelt import MultipartEncoder, MultipartEncoderMonitor
 from tqdm import tqdm  # importing supervisely rebinds this name to tqdm_sly
 from tqdm.std import tqdm as vanilla_tqdm
 
+from supervisely.api.video import video_api
 from supervisely.task.progress import (
     Progress,
     UploadProgressDelta,
@@ -320,3 +323,31 @@ def test_widget_progress_shape_is_the_get_partial_one():
 
     assert callable(getattr(CustomTqdm, "get_partial", None))
     assert callable(getattr(CustomTqdm, "_progress_monitor", None))
+
+
+def test_absolute_setter_stalls_on_increments():
+    """`Progress.set_current_value` advances by `value - current`, so feeding it increments
+    leaves it stuck near the first chunk. Nothing inside the SDK may hand it to the adapter."""
+    progress = Progress("uploading", total_cnt=len(PAYLOAD) * 4, is_size=True)
+    total = drain(make_monitor(progress.set_current_value))
+    assert progress.current < total / 4, "an absolute setter must not be fed increments"
+
+
+def test_video_upload_path_reports_increments():
+    """VideoApi.upload_path(item_progress=True) used to bind the absolute setter, which was
+    right while the upload fed it monitor.bytes_read and wrong once it fed increments."""
+    source = Path(video_api.__file__).read_text(encoding="utf-8")
+    tree = ast.parse(source, filename=video_api.__file__)
+    handler = next(
+        node
+        for node in ast.walk(tree)
+        if isinstance(node, ast.FunctionDef) and node.name == "upload_path"
+    )
+    bound = {
+        node.value.attr
+        for node in ast.walk(handler)
+        if isinstance(node, ast.Assign)
+        and isinstance(node.value, ast.Attribute)
+        and any(isinstance(t, ast.Name) and t.id == "progress_cb" for t in node.targets)
+    }
+    assert bound == {"iters_done_report"}, f"progress_cb is bound to {bound}"

--- a/tests/unit/test_upload_progress_cb.py
+++ b/tests/unit/test_upload_progress_cb.py
@@ -1,0 +1,322 @@
+"""Tests for the upload ``progress_cb`` contract.
+
+Uploads report through a ``MultipartEncoderMonitor``. Callbacks in the wild come in two
+shapes: delta style ones that take a byte increment (``tqdm.update``,
+``Progress.iters_done_report``, plain lambdas) and monitor style ones written back when the
+SDK handed the monitor over (they read ``monitor.bytes_read`` / ``monitor.len``). Both are
+used inside the SDK itself, so the adapter has to serve both.
+
+The tests drive a real ``MultipartEncoder`` and never touch the network.
+"""
+
+import io
+from functools import partial
+
+import pytest
+from requests_toolbelt import MultipartEncoder, MultipartEncoderMonitor
+from tqdm import tqdm  # importing supervisely rebinds this name to tqdm_sly
+from tqdm.std import tqdm as vanilla_tqdm
+
+from supervisely.task.progress import (
+    Progress,
+    UploadProgressDelta,
+    build_multipart_monitor_callback,
+    tqdm_sly,
+)
+
+PAYLOAD = b"x" * 40000
+CHUNK = 8192
+
+
+def make_monitor(progress_cb, files=1):
+    fields = {
+        f"{idx}-file": (str(idx), io.BytesIO(PAYLOAD), "application/octet-stream")
+        for idx in range(files)
+    }
+    encoder = MultipartEncoder(fields=fields)
+    callback = build_multipart_monitor_callback(progress_cb)
+    return MultipartEncoderMonitor(encoder, callback) if callback else encoder
+
+
+def drain(monitor):
+    """Read the whole body, the way the HTTP adapter does."""
+    while monitor.read(CHUNK):
+        pass
+    return monitor.len
+
+
+# --------------------------------------------------------------------------------------
+# delta style callbacks
+# --------------------------------------------------------------------------------------
+def test_vanilla_tqdm_is_not_callable_but_still_works():
+    """A tqdm imported before supervisely stays the original class, which is not callable."""
+    bar = vanilla_tqdm(total=None, file=io.StringIO())
+    assert not callable(bar)
+    assert not hasattr(bar, "get_partial")
+    total = drain(make_monitor(bar))
+    assert bar.n == total
+
+
+def test_patched_tqdm_goes_through_its_monitor_hook():
+    """`supervisely/__init__.py` rebinds tqdm.tqdm to tqdm_sly, so user code that imports
+    tqdm after supervisely gets the monitor aware one."""
+    assert tqdm is tqdm_sly
+    bar = tqdm(desc="uploading", total=len(PAYLOAD), file=io.StringIO())
+    total = drain(make_monitor(bar))
+    assert bar.n == total
+
+
+def test_tqdm_update_bound_method():
+    bar = vanilla_tqdm(total=None, file=io.StringIO())
+    total = drain(make_monitor(bar.update))
+    assert bar.n == total
+
+
+def test_plain_lambda_gets_increments():
+    seen = []
+    total = drain(make_monitor(lambda count: seen.append(int(count))))
+    assert sum(seen) == total
+    assert all(delta >= 0 for delta in seen)
+
+
+def test_progress_iters_done_report():
+    progress = Progress("uploading", total_cnt=len(PAYLOAD) * 4, is_size=True)
+    total = drain(make_monitor(progress.iters_done_report))
+    assert progress.current == total
+
+
+def test_bare_progress_object():
+    """`Progress` is not callable, but it reports increments through iters_done_report."""
+    progress = Progress("uploading", total_cnt=len(PAYLOAD) * 4, is_size=True)
+    assert not callable(progress)
+    total = drain(make_monitor(progress))
+    assert progress.current == total
+
+
+def test_object_with_update_only():
+    class Bar:
+        def __init__(self):
+            self.n = 0
+
+        def update(self, count):
+            self.n += int(count)
+
+    bar = Bar()
+    total = drain(make_monitor(bar))
+    assert bar.n == total
+
+
+def test_callable_object_delta_style():
+    class Counter:
+        def __init__(self):
+            self.total = 0
+
+        def __call__(self, count):
+            self.total += int(count)
+
+    counter = Counter()
+    total = drain(make_monitor(counter))
+    assert counter.total == total
+
+
+# --------------------------------------------------------------------------------------
+# monitor style callbacks: what apps and the SDK itself were written against
+# --------------------------------------------------------------------------------------
+def test_monitor_style_function():
+    seen = {}
+
+    def on_progress(monitor):
+        seen["bytes_read"] = monitor.bytes_read
+        seen["len"] = monitor.len
+
+    total = drain(make_monitor(on_progress))
+    assert seen["bytes_read"] == total
+    assert seen["len"] == total
+
+
+def test_monitor_style_partial():
+    """The shape used by the yolov8 train app: partial() over a monitor style function."""
+    seen = []
+
+    def upload_monitor(monitor, tag):
+        seen.append((tag, monitor.bytes_read, monitor.len))
+
+    total = drain(make_monitor(partial(upload_monitor, tag="artifacts")))
+    assert seen[-1] == ("artifacts", total, total)
+    assert [read for _, read, _ in seen] == sorted(read for _, read, _ in seen)
+
+
+def test_monitor_style_callable_object():
+    class Reporter:
+        def __init__(self):
+            self.last = None
+
+        def __call__(self, monitor):
+            self.last = (monitor.bytes_read, monitor.len)
+
+    reporter = Reporter()
+    total = drain(make_monitor(reporter))
+    assert reporter.last == (total, total)
+
+
+def test_sly_output_set_download_shape():
+    """`sly.output.set_download` passes a lambda that reads len first, then bytes_read."""
+    state = {}
+
+    def _print_progress(monitor, holder):
+        if not holder:
+            holder.append(Progress("Uploading", total_cnt=monitor.len, is_size=True))
+        holder[0].set_current_value(monitor.bytes_read)
+        state["progress"] = holder[0]
+
+    holder = []
+    total = drain(make_monitor(lambda m: _print_progress(m, holder)))
+    assert state["progress"].current == total
+    assert state["progress"].total == total
+
+
+# --------------------------------------------------------------------------------------
+# monitor aware progress objects report on their own
+# --------------------------------------------------------------------------------------
+def test_tqdm_sly_uses_its_own_monitor_hook():
+    bar = tqdm_sly(desc="uploading", total=len(PAYLOAD), unit="B", file=io.StringIO())
+    assert callable(bar.get_partial())
+    total = drain(make_monitor(bar))
+    assert bar.n == total
+
+
+def test_get_partial_wins_over_being_callable():
+    calls = {"partial": 0, "call": 0}
+
+    class MonitorAware:
+        def __call__(self, count):
+            calls["call"] += 1
+
+        def get_partial(self):
+            def hook(monitor):
+                calls["partial"] += 1
+
+            return hook
+
+    drain(make_monitor(MonitorAware()))
+    assert calls["partial"] > 0
+    assert calls["call"] == 0
+
+
+def test_non_callable_get_partial_is_ignored():
+    """An attribute that merely happens to be named get_partial must not be called."""
+    seen = []
+
+    class Weird:
+        get_partial = "not a method"
+
+        def __call__(self, count):
+            seen.append(int(count))
+
+    total = drain(make_monitor(Weird()))
+    assert sum(seen) == total
+
+
+# --------------------------------------------------------------------------------------
+# the value handed to delta style callbacks
+# --------------------------------------------------------------------------------------
+def test_value_is_an_int_carrying_the_monitor():
+    values = []
+    total = drain(make_monitor(values.append))
+
+    assert all(isinstance(value, int) for value in values)
+    assert all(isinstance(value, UploadProgressDelta) for value in values)
+    assert sum(values) == total
+    assert values[-1].bytes_read == total
+    assert values[-1].len == total
+    assert values[-1].monitor.bytes_read == total
+    # arbitrary monitor attributes are forwarded too
+    assert values[-1].encoder is values[-1].monitor.encoder
+
+
+def test_value_behaves_like_a_number():
+    value = UploadProgressDelta(7, _FakeMonitor(bytes_read=7, len=10))
+    assert value + 1 == 8
+    assert value * 2 == 14
+    assert float(value) == 7.0
+    assert f"{value}" == "7"
+    assert value < 8 and value > 6
+    assert sum([value, value]) == 14
+
+
+def test_unknown_attribute_raises_attribute_error():
+    value = UploadProgressDelta(1, _FakeMonitor(bytes_read=1, len=2))
+    with pytest.raises(AttributeError):
+        value.definitely_not_there
+
+
+class _FakeMonitor:
+    def __init__(self, bytes_read, len):  # noqa: A002 - mirrors the toolbelt attribute
+        self.bytes_read = bytes_read
+        self.len = len
+
+
+# --------------------------------------------------------------------------------------
+# increments, ordering and multi file uploads
+# --------------------------------------------------------------------------------------
+def test_increments_sum_up_and_never_go_backwards():
+    deltas, cumulative = [], []
+
+    def on_progress(value):
+        deltas.append(int(value))
+        cumulative.append(value.bytes_read)
+
+    total = drain(make_monitor(on_progress))
+    assert sum(deltas) == total
+    assert cumulative == sorted(cumulative)
+    assert cumulative[-1] == total
+
+
+def test_bulk_upload_reports_across_all_files():
+    values = []
+    total = drain(make_monitor(values.append, files=3))
+    assert sum(values) == total
+    assert total > 3 * len(PAYLOAD)  # payload plus multipart overhead
+
+
+# --------------------------------------------------------------------------------------
+# nothing to report to, and bad input
+# --------------------------------------------------------------------------------------
+def test_none_means_no_monitor():
+    assert build_multipart_monitor_callback(None) is None
+
+
+@pytest.mark.parametrize("bad", [42, "a string", object(), ["list"]])
+def test_non_callable_progress_cb_is_rejected(bad):
+    with pytest.raises(TypeError, match="progress_cb must be callable"):
+        build_multipart_monitor_callback(bad)
+
+
+def test_callback_is_independent_per_upload():
+    """Two uploads with the same callback must not share the reported offset."""
+    values = []
+    drain(make_monitor(values.append))
+    first = sum(values)
+
+    values.clear()
+    drain(make_monitor(values.append))
+    assert sum(values) == first
+
+
+def test_callback_errors_are_not_swallowed():
+    """A broken callback must fail loudly instead of corrupting the upload silently."""
+
+    def boom(value):
+        raise RuntimeError("callback is broken")
+
+    with pytest.raises(RuntimeError, match="callback is broken"):
+        drain(make_monitor(boom))
+
+
+def test_widget_progress_shape_is_the_get_partial_one():
+    """The SlyTqdm widget (CustomTqdm) cannot be built outside an app, but it reports the
+    same way tqdm_sly does: through get_partial(), which is covered above."""
+    from supervisely.app.widgets.sly_tqdm.sly_tqdm import CustomTqdm
+
+    assert callable(getattr(CustomTqdm, "get_partial", None))
+    assert callable(getattr(CustomTqdm, "_progress_monitor", None))

--- a/tests/unit/test_upload_progress_cb.py
+++ b/tests/unit/test_upload_progress_cb.py
@@ -417,12 +417,36 @@ def test_video_converter_progress_follows_the_upload():
     assert created[0].current == total
 
 
-def test_absolute_setter_stalls_on_increments():
-    """`Progress.set_current_value` advances by `value - current`, so feeding it increments
-    leaves it stuck near the first chunk. Nothing inside the SDK may hand it to the adapter."""
+def test_progress_set_current_value_keeps_getting_the_running_total():
+    """`Progress.set_current_value` advances by `value - current`, so increments would leave it
+    stuck near the first chunk. Callers hand it to uploads directly, so it keeps the totals."""
     progress = Progress("uploading", total_cnt=len(PAYLOAD) * 4, is_size=True)
     total = drain(make_monitor(progress.set_current_value))
-    assert progress.current < total / 4, "an absolute setter must not be fed increments"
+    assert progress.current == total
+
+
+def test_set_current_value_of_a_subclass_is_recognised():
+    """The check is on the function, not on the name, so subclasses are served too."""
+
+    class MyProgress(Progress):
+        pass
+
+    progress = MyProgress("uploading", total_cnt=len(PAYLOAD) * 4, is_size=True)
+    total = drain(make_monitor(progress.set_current_value))
+    assert progress.current == total
+
+
+def test_a_foreign_set_current_value_still_gets_increments():
+    """Only Progress.set_current_value is special cased; a method that merely shares the name
+    belongs to the delta contract like every other callable."""
+    seen = []
+
+    class Own:
+        def set_current_value(self, value):
+            seen.append(value)
+
+    total = drain(make_monitor(Own().set_current_value))
+    assert sum(seen) == total, "a foreign callback must keep receiving increments"
 
 
 def test_video_upload_path_bar_follows_the_upload():

--- a/tests/unit/test_upload_progress_cb.py
+++ b/tests/unit/test_upload_progress_cb.py
@@ -9,21 +9,21 @@ used inside the SDK itself, so the adapter has to serve both.
 The tests drive a real ``MultipartEncoder`` and never touch the network.
 """
 
-import ast
 import copy
 import gc
 import io
 import pickle
 import weakref
 from functools import partial
-from pathlib import Path
+from unittest import mock
 
 import pytest
 from requests_toolbelt import MultipartEncoder, MultipartEncoderMonitor
 from tqdm import tqdm  # importing supervisely rebinds this name to tqdm_sly
 from tqdm.std import tqdm as vanilla_tqdm
 
-from supervisely.api.video import video_api
+from supervisely.api.video.video_api import VideoApi
+from supervisely.convert.video.video_converter import VideoConverter
 from supervisely.task.progress import (
     Progress,
     UploadProgressDelta,
@@ -394,9 +394,8 @@ def test_widget_progress_shape_is_the_get_partial_one():
 
 
 def test_video_converter_progress_follows_the_upload():
-    """The converters' shared callback hands its argument straight to Progress.set_current_value,
-    an absolute setter, so it has to pass the running total rather than the increment. Feeding
-    it increments left the bar at zero once the upload finished."""
+    """The converters share one byte progress bar for the whole upload, and the callback is
+    handed an increment, so it has to report increments rather than set an absolute value."""
     from supervisely.convert.video import video_converter
 
     created = []
@@ -410,7 +409,7 @@ def test_video_converter_progress_follows_the_upload():
     video_converter.Progress = SpyProgress
     try:
         # self is unused by the helper, and building a converter needs a real dataset
-        callback = video_converter.VideoConverter._get_video_upload_progress(None, [])
+        callback = video_converter.VideoConverter._get_video_upload_progress(None)
         total = drain(make_monitor(callback))
     finally:
         video_converter.Progress = original
@@ -427,21 +426,48 @@ def test_absolute_setter_stalls_on_increments():
     assert progress.current < total / 4, "an absolute setter must not be fed increments"
 
 
-def test_video_upload_path_reports_increments():
-    """VideoApi.upload_path(item_progress=True) used to bind the absolute setter, which was
-    right while the upload fed it monitor.bytes_read and wrong once it fed increments."""
-    source = Path(video_api.__file__).read_text(encoding="utf-8")
-    tree = ast.parse(source, filename=video_api.__file__)
-    handler = next(
-        node
-        for node in ast.walk(tree)
-        if isinstance(node, ast.FunctionDef) and node.name == "upload_path"
+def test_video_upload_path_bar_follows_the_upload():
+    """VideoApi.upload_path(item_progress=True) used to bind Progress.set_current_value, which was
+    right while the upload fed it monitor.bytes_read and wrong once it fed increments. Checked
+    while the upload runs: the handler tops the bar up to total when it returns, either way."""
+    seen = {}
+
+    def fake_upload_paths(self, dataset_id, names, paths, item_progress=None, **kwargs):
+        seen["uploaded"] = drain(make_monitor(item_progress))
+        seen["on_the_bar"] = item_progress.__self__.current
+        return [object()]
+
+    api = VideoApi.__new__(VideoApi)
+    with mock.patch.object(VideoApi, "upload_paths", fake_upload_paths), mock.patch(
+        "supervisely.api.video.video_api.get_file_size", return_value=len(PAYLOAD) * 4
+    ):
+        api.upload_path(dataset_id=1, name="a.mp4", path="/tmp/a.mp4", item_progress=True)
+
+    assert seen["on_the_bar"] == seen["uploaded"], (
+        f"{seen['on_the_bar']} on the bar while {seen['uploaded']} bytes were uploaded"
     )
-    bound = {
-        node.value.attr
-        for node in ast.walk(handler)
-        if isinstance(node, ast.Assign)
-        and isinstance(node.value, ast.Attribute)
-        and any(isinstance(t, ast.Name) and t.id == "progress_cb" for t in node.targets)
-    }
-    assert bound == {"iters_done_report"}, f"progress_cb is bound to {bound}"
+
+
+def test_video_converter_bar_adds_up_across_videos():
+    """A large upload sends one video per request, so every request brings its own monitor whose
+    bytes_read starts at zero. Reporting the running total left the bar stuck on the first video."""
+    from supervisely.convert.video import video_converter
+
+    created = []
+
+    class SpyProgress(video_converter.Progress):
+        def __init__(self, *args, **kwargs):
+            super().__init__(*args, **kwargs)
+            created.append(self)
+
+    original = video_converter.Progress
+    video_converter.Progress = SpyProgress
+    try:
+        callback = video_converter.VideoConverter._get_video_upload_progress(None)
+        # a fresh adapter per request, the way _upload_uniq_videos_single_req builds it
+        uploaded = sum(drain(make_monitor(callback)) for _ in range(2))
+    finally:
+        video_converter.Progress = original
+
+    assert len(created) == 1, "the bar must be shared by every video of the upload"
+    assert created[0].current == uploaded, f"{created[0].current} on the bar, {uploaded} uploaded"

--- a/tests/unit/test_upload_progress_cb.py
+++ b/tests/unit/test_upload_progress_cb.py
@@ -425,6 +425,17 @@ def test_progress_set_current_value_keeps_getting_the_running_total():
     assert progress.current == total
 
 
+def test_set_current_value_adds_up_across_requests():
+    """A bulk upload sends several requests and every request starts its monitor at zero, so
+    handing the setter the running total of one monitor rewound the bar on the next request."""
+    progress = Progress("uploading", total_cnt=len(PAYLOAD) * 8, is_size=True)
+
+    # a fresh adapter per request, the way the upload paths build it
+    sent = sum(drain(make_monitor(progress.set_current_value)) for _ in range(2))
+
+    assert progress.current == sent, f"{progress.current} on the bar, {sent} bytes sent"
+
+
 def test_set_current_value_of_a_subclass_is_recognised():
     """The check is on the function, not on the name, so subclasses are served too."""
 


### PR DESCRIPTION
Closes supervisely/issues#6096.

## The problem

Upload progress callbacks exist in two shapes, both used inside this repo:

- **delta style** — takes a byte increment: `tqdm.update`, `Progress.iters_done_report`,
  a plain `lambda count: ...`;
- **monitor style** — written when the SDK passed the `MultipartEncoderMonitor` itself, reads
  `monitor.bytes_read` and `monitor.len`.

Until #1773 a plain callable received the monitor; after it, an int. Every monitor style
callback started failing on SDK 6.74.16 and newer:

```
requests_toolbelt/multipart/encoder.py:403  self.callback(self)
supervisely/api/file_api.py:974             progress_cb(monitor.bytes_read - reported)
train/src/main.py:2082                      value = monitor.bytes_read
AttributeError: 'int' object has no attribute 'bytes_read'
```

`sly.output.set_download` in this repo passes exactly such a callback, so the SDK broke its own
upload path too. A plain function cannot be told apart by inspection, so neither convention can
simply win.

## The fix

The value handed to a callback is an `int` subclass that forwards the monitor's attributes:

```python
class UploadProgressDelta(int):
    def __new__(cls, delta, monitor): ...
    def __getattr__(self, name):
        return getattr(self._monitor, name)
```

Delta style callbacks see a number (arithmetic, `isinstance(x, int)`, `tqdm.update` all work),
monitor style ones find `bytes_read`, `len` and anything else the monitor carries.

`build_multipart_monitor_callback()` in `supervisely/task/progress.py` is now the single
adapter, and the three upload paths that reported bytes went through three different
conventions:

- `FileApi._upload_bulk` — the one #1773 changed;
- `VideoApi._upload_uniq_videos_single_req` — fed the **cumulative** byte count into
  `tqdm.update`, which expects an increment, so the bar overshot on every call;
- objects exposing `get_partial()` (`tqdm_sly`, the `SlyTqdm` widget) keep reporting from the
  monitor themselves, unchanged.

Non callable progress objects are handled as well: a bare `tqdm` reports through `update`, a
bare `Progress` through `iters_done_report`, and anything else raises a `TypeError` that names
the contract instead of failing three libraries deep.

## Tests

`tests/unit/test_upload_progress_cb.py`, 45 tests driving a real `MultipartEncoder` with no
network: bare vanilla tqdm, the patched `tqdm.tqdm` (`supervisely/__init__.py` rebinds it to
`tqdm_sly`), `tqdm.update`, bare `Progress`, `Progress.iters_done_report`, an object with only
`update`, delta lambdas and callable objects, monitor style functions, `partial()` wrappers
(the shape the yolov8 train app uses), monitor style callable objects, the
`sly.output.set_download` shape, `get_partial()` winning over `__call__`, a non callable
attribute merely named `get_partial`, increment arithmetic and ordering, multi file bulk
uploads, per upload isolation of the reported offset, exceptions propagating out of a broken
callback, and the `TypeError` for unusable input.

## Behaviour change to note in the release

Inside a single upload the callback now receives a byte **increment** where it used to receive
the cumulative `monitor.bytes_read`. Delta style callbacks (`tqdm.update`,
`Progress.iters_done_report`, plain lambdas) were being fed cumulative values and over counted;
they are correct now. Monitor style callbacks read `bytes_read` off the value and are unaffected.

`Progress.set_current_value` keeps working. It sets an absolute value, so an increment would
leave the bar stuck after the first chunk; the adapter tells it where the bar should stand
instead, which also adds up across the several requests of a bulk upload rather than rewinding
on each one, the way passing a single monitor's total did. The adapter recognises it by the
function itself rather than by the method name, so subclasses are served too and a foreign
method that merely shares the name stays on the delta contract.

What cannot be recognised is a callback that only wraps an absolute setter, `lambda value:
bar.set_position(value)` and the like: a plain function does not say which convention it wants.
Such a callback now moves by increments and needs to add them up itself, or to be replaced by
the setter it wraps.

