### PR TITLE
[sdk] Raise on failed async inference instead of polling forever

### DIFF
--- a/supervisely/nn/inference/session.py
+++ b/supervisely/nn/inference/session.py
@@ -20,6 +20,9 @@ from supervisely.nn.utils import DeployInfo
 from supervisely.sly_logger import logger
 
 
+_USE_CONFIGURED_TIMEOUT = object()
+
+
 class SessionJSON:
     """Client for running inference on a deployed model and returning raw JSON predictions."""
 
@@ -29,6 +32,8 @@ class SessionJSON:
         task_id: int = None,
         session_url: str = None,
         inference_settings: Union[dict, str] = None,
+        async_start_timeout: Optional[float] = 600,
+        pending_results_timeout: Optional[float] = 600,
     ):
         """
         A convenient class for inference of deployed models.
@@ -48,6 +53,10 @@ class SessionJSON:
         :type session_url: str, optional
         :param inference_settings: a dict or a path to YAML file with settings, defaults to None
         :type inference_settings: Union[dict, str], optional
+        :param async_start_timeout: seconds to wait for asynchronous inference to start. None disables the timeout, defaults to 600
+        :type async_start_timeout: float, optional
+        :param pending_results_timeout: seconds to wait for new asynchronous inference results. None disables the timeout, defaults to 600
+        :type pending_results_timeout: float, optional
 
 
         :Usage Example:
@@ -93,6 +102,8 @@ class SessionJSON:
         self._async_inference_uuid = None
         self._stop_async_inference_flag = False
         self.inference_result = None
+        self.async_start_timeout = async_start_timeout
+        self.pending_results_timeout = pending_results_timeout
 
         if inference_settings is not None:
             self.set_inference_settings(inference_settings)
@@ -537,16 +548,66 @@ class SessionJSON:
         endpoint = "clear_inference_request"
         return self._get_from_endpoint_for_async_inference(endpoint)
 
-    def _wait_for_async_inference_start(self, delay=1, timeout=None) -> Tuple[dict, bool]:
+    def _raise_for_async_inference_error(
+        self, resp: Dict[str, Any], raise_on_finished_without_results: bool = False
+    ) -> None:
+        exception = resp.get("exception")
+        has_result = bool(resp.get("result") or resp.get("final_result"))
+        has_pending_results = bool(resp.get("pending_results"))
+        finished_without_results = (
+            raise_on_finished_without_results
+            and resp.get("finished", False)
+            and not (has_result or has_pending_results)
+        )
+        if not exception and resp.get("stage") != "Error" and not finished_without_results:
+            return
+
+        if isinstance(exception, dict):
+            exception_details = ": ".join(
+                str(exception[key]) for key in ("type", "message") if exception.get(key)
+            )
+            if not exception_details:
+                exception_details = "The serving app reported an inference error."
+            if exception.get("traceback"):
+                exception_details = f"{exception_details}\n{exception['traceback']}"
+        elif exception:
+            exception_details = str(exception)
+        elif finished_without_results:
+            exception_details = "Inference finished without returning results."
+        else:
+            exception_details = "The serving app reported an inference error."
+        raise RuntimeError(f"Inference Error: {exception_details}")
+
+    def _wait_for_async_inference_start(
+        self, delay=1, timeout=_USE_CONFIGURED_TIMEOUT
+    ) -> Tuple[dict, bool]:
+        if timeout is _USE_CONFIGURED_TIMEOUT:
+            timeout = self.async_start_timeout
         logger.info("Preparing data on the model, this may take a while...")
         has_started = False
         timeout_exceeded = False
         t0 = time.time()
         while not has_started and not timeout_exceeded:
             resp = self._get_inference_progress()
+            try:
+                self._raise_for_async_inference_error(
+                    resp, raise_on_finished_without_results=True
+                )
+            except RuntimeError:
+                try:
+                    self._on_async_inference_end()
+                except Exception as cleanup_error:
+                    logger.warning(
+                        f"Failed to clean up the inference request after an error: {cleanup_error}"
+                    )
+                raise
             pending_results = resp.get("pending_results", None)
             has_results = bool(pending_results)
-            has_started = bool(resp.get("result")) or resp["progress"]["total"] != 1 or has_results
+            has_started = (
+                bool(resp.get("result") or resp.get("final_result"))
+                or resp["progress"]["total"] != 1
+                or has_results
+            )
             if not has_started:
                 time.sleep(delay)
             timeout_exceeded = timeout and time.time() - t0 > timeout
@@ -556,13 +617,18 @@ class SessionJSON:
             raise Timeout("Timeout exceeded. The server didn't start the inference")
         return resp, has_started
 
-    def _wait_for_new_pending_results(self, delay=1, timeout=600) -> List[dict]:
+    def _wait_for_new_pending_results(
+        self, delay=1, timeout=_USE_CONFIGURED_TIMEOUT
+    ) -> List[dict]:
+        if timeout is _USE_CONFIGURED_TIMEOUT:
+            timeout = self.pending_results_timeout
         logger.debug("waiting pending results...")
         has_results = False
         timeout_exceeded = False
         t0 = time.time()
         while not has_results and not timeout_exceeded:
             resp = self._pop_pending_results()
+            self._raise_for_async_inference_error(resp)
             pending_results = resp["pending_results"]
             has_results = bool(pending_results)
             if resp["is_inferring"] is False:
@@ -722,6 +788,8 @@ class Session(SessionJSON):
         task_id: int = None,
         session_url: str = None,
         inference_settings: Union[dict, str] = None,
+        async_start_timeout: Optional[float] = 600,
+        pending_results_timeout: Optional[float] = 600,
     ):
         """
         A convenient class for inference of deployed models.
@@ -741,6 +809,10 @@ class Session(SessionJSON):
         :type session_url: str, optional
         :param inference_settings: a dict or a path to YAML file with settings, defaults to None
         :type inference_settings: Union[dict, str], optional
+        :param async_start_timeout: seconds to wait for asynchronous inference to start. None disables the timeout, defaults to 600
+        :type async_start_timeout: float, optional
+        :param pending_results_timeout: seconds to wait for new asynchronous inference results. None disables the timeout, defaults to 600
+        :type pending_results_timeout: float, optional
 
 
         :Usage Example:
@@ -755,7 +827,14 @@ class Session(SessionJSON):
                 predicted_annotation = session.inference_image_id(image_id)
 
         """
-        super().__init__(api, task_id, session_url, inference_settings)
+        super().__init__(
+            api,
+            task_id,
+            session_url,
+            inference_settings,
+            async_start_timeout,
+            pending_results_timeout,
+        )
 
     def is_model_deployed(self):
         is_deployed = self.api.task.send_request(self._task_id, "is_deployed", {})

--- a/tests/unit/test_inference_session_polling.py
+++ b/tests/unit/test_inference_session_polling.py
@@ -1,0 +1,289 @@
+from types import SimpleNamespace
+
+import pytest
+from requests import Timeout
+
+from supervisely.nn.inference import session as session_module
+from supervisely.nn.inference.session import Session, SessionJSON
+
+
+def _session():
+    session = object.__new__(SessionJSON)
+    session._async_inference_uuid = "inference-request"
+    session.async_start_timeout = 600
+    session.pending_results_timeout = 600
+    return session
+
+
+def _error_response(traceback=None):
+    exception = {
+        "type": "RuntimeError",
+        "message": "Item pexels-photo-744487.png not found in the project.",
+    }
+    if traceback is not None:
+        exception["traceback"] = traceback
+    return {
+        "stage": "Error",
+        "finished": True,
+        "is_inferring": False,
+        "progress": {"current": 0, "total": 1},
+        "result": False,
+        "exception": exception,
+    }
+
+
+def test_wait_for_async_inference_start_raises_terminal_error_without_polling_again(
+    monkeypatch,
+):
+    session = _session()
+    responses = [_error_response()]
+    cleanup_calls = []
+    session._get_inference_progress = lambda: responses.pop(0)
+    session._on_async_inference_end = lambda: cleanup_calls.append(True)
+    monkeypatch.setattr(
+        session_module.time,
+        "sleep",
+        lambda delay: pytest.fail("terminal responses must not be polled again"),
+    )
+
+    with pytest.raises(RuntimeError) as exc_info:
+        session._wait_for_async_inference_start()
+
+    message = str(exc_info.value)
+    assert "RuntimeError" in message
+    assert "Item pexels-photo-744487.png not found in the project." in message
+    assert responses == []
+    assert cleanup_calls == [True]
+
+
+def test_wait_for_async_inference_start_includes_app_traceback():
+    session = _session()
+    session._get_inference_progress = lambda: _error_response("app traceback details")
+    session._on_async_inference_end = lambda: None
+
+    with pytest.raises(RuntimeError, match="app traceback details"):
+        session._wait_for_async_inference_start(delay=0)
+
+
+def test_wait_for_new_pending_results_raises_terminal_error(monkeypatch):
+    session = _session()
+    responses = [_error_response()]
+    session._pop_pending_results = lambda: responses.pop(0)
+    monkeypatch.setattr(
+        session_module.time,
+        "sleep",
+        lambda delay: pytest.fail("terminal responses must not be polled again"),
+    )
+
+    with pytest.raises(RuntimeError, match="RuntimeError.*not found in the project"):
+        session._wait_for_new_pending_results()
+
+    assert responses == []
+
+
+def test_wait_for_new_pending_results_keeps_successful_completion():
+    session = _session()
+    session._pop_pending_results = lambda: {
+        "stage": "Finished",
+        "finished": True,
+        "is_inferring": False,
+        "pending_results": [],
+        "result": False,
+        "exception": None,
+    }
+
+    assert session._wait_for_new_pending_results(delay=0) == []
+
+
+def test_finished_response_without_results_raises():
+    session = _session()
+    session._get_inference_progress = lambda: {
+        "stage": "Finished",
+        "finished": True,
+        "is_inferring": False,
+        "progress": {"current": 0, "total": 1},
+        "pending_results": [],
+        "result": False,
+        "exception": None,
+    }
+    session._on_async_inference_end = lambda: None
+
+    with pytest.raises(RuntimeError, match="finished without returning results"):
+        session._wait_for_async_inference_start(delay=0)
+
+
+def test_wait_for_async_inference_start_has_finite_default_timeout(monkeypatch):
+    session = _session()
+    session._get_inference_progress = lambda: {
+        "progress": {"current": 0, "total": 1},
+        "pending_results": [],
+    }
+    cleanup_calls = []
+    session.stop_async_inference = lambda: cleanup_calls.append("stop")
+    session._on_async_inference_end = lambda: cleanup_calls.append("clear")
+    times = iter([0, 601])
+    monkeypatch.setattr(
+        session_module,
+        "time",
+        SimpleNamespace(time=lambda: next(times), sleep=lambda delay: None),
+    )
+
+    with pytest.raises(Timeout, match="didn't start"):
+        session._wait_for_async_inference_start(delay=0)
+
+    assert cleanup_calls == ["stop", "clear"]
+
+
+def test_wait_for_async_inference_start_keeps_successful_response():
+    session = _session()
+    response = {
+        "stage": "Inference",
+        "finished": False,
+        "is_inferring": True,
+        "progress": {"current": 0, "total": 2},
+        "pending_results": [],
+        "result": False,
+        "exception": None,
+    }
+    session._get_inference_progress = lambda: response
+
+    actual_response, has_started = session._wait_for_async_inference_start(delay=0)
+
+    assert actual_response is response
+    assert has_started is True
+
+
+@pytest.mark.parametrize("session_cls", [SessionJSON, Session])
+def test_session_timeout_defaults_are_forwarded(monkeypatch, session_cls):
+    monkeypatch.setattr(SessionJSON, "get_session_info", lambda self: {})
+
+    session = session_cls(api=object(), session_url="http://model")
+
+    assert session.async_start_timeout == 600
+    assert session.pending_results_timeout == 600
+
+
+def test_configured_and_explicit_timeout_values(monkeypatch):
+    session = _session()
+    session.async_start_timeout = 5
+    session._get_inference_progress = lambda: {
+        "progress": {"current": 0, "total": 1},
+        "pending_results": [],
+    }
+    cleanup_calls = []
+    session.stop_async_inference = lambda: cleanup_calls.append("stop")
+    session._on_async_inference_end = lambda: cleanup_calls.append("clear")
+    times = iter([0, 6])
+    monkeypatch.setattr(
+        session_module,
+        "time",
+        SimpleNamespace(time=lambda: next(times), sleep=lambda delay: None),
+    )
+
+    with pytest.raises(Timeout):
+        session._wait_for_async_inference_start(delay=0)
+
+    assert cleanup_calls == ["stop", "clear"]
+
+    responses = iter(
+        [
+            {
+                "progress": {"current": 0, "total": 1},
+                "pending_results": [],
+            },
+            {
+                "progress": {"current": 0, "total": 2},
+                "pending_results": [],
+            },
+        ]
+    )
+    session._get_inference_progress = lambda: next(responses)
+    times = iter([0, 6, 7])
+    monkeypatch.setattr(
+        session_module,
+        "time",
+        SimpleNamespace(time=lambda: next(times), sleep=lambda delay: None),
+    )
+
+    _, has_started = session._wait_for_async_inference_start(delay=0, timeout=10)
+
+    assert has_started is True
+
+
+def test_session_forwards_custom_timeout_values(monkeypatch):
+    monkeypatch.setattr(SessionJSON, "get_session_info", lambda self: {})
+
+    session = Session(
+        api=object(),
+        session_url="http://model",
+        async_start_timeout=12,
+        pending_results_timeout=34,
+    )
+
+    assert session.async_start_timeout == 12
+    assert session.pending_results_timeout == 34
+
+
+def test_configured_pending_results_timeout(monkeypatch):
+    session = _session()
+    session.pending_results_timeout = 5
+    session._pop_pending_results = lambda: {
+        "pending_results": [],
+        "is_inferring": True,
+    }
+    cleanup_calls = []
+    session.stop_async_inference = lambda: cleanup_calls.append("stop")
+    session._on_async_inference_end = lambda: cleanup_calls.append("clear")
+    times = iter([0, 6])
+    monkeypatch.setattr(
+        session_module,
+        "time",
+        SimpleNamespace(time=lambda: next(times), sleep=lambda delay: None),
+    )
+
+    with pytest.raises(Timeout, match="Pending results"):
+        session._wait_for_new_pending_results(delay=0)
+
+    assert cleanup_calls == ["stop", "clear"]
+
+
+def test_none_disables_configured_timeouts(monkeypatch):
+    monkeypatch.setattr(SessionJSON, "get_session_info", lambda self: {})
+    session = Session(
+        api=object(),
+        session_url="http://model",
+        async_start_timeout=None,
+        pending_results_timeout=None,
+    )
+    progress_responses = iter(
+        [
+            {
+                "progress": {"current": 0, "total": 1},
+                "pending_results": [],
+            },
+            {
+                "progress": {"current": 0, "total": 2},
+                "pending_results": [],
+            },
+        ]
+    )
+    pending_responses = iter(
+        [
+            {"pending_results": [], "is_inferring": True},
+            {"pending_results": [{"result": 1}], "is_inferring": True},
+        ]
+    )
+    session._get_inference_progress = lambda: next(progress_responses)
+    session._pop_pending_results = lambda: next(pending_responses)
+    times = iter([0, 1000, 0, 1000])
+    monkeypatch.setattr(
+        session_module,
+        "time",
+        SimpleNamespace(time=lambda: next(times), sleep=lambda delay: None),
+    )
+
+    _, has_started = session._wait_for_async_inference_start(delay=0)
+    pending_results = session._wait_for_new_pending_results(delay=0)
+
+    assert has_started is True
+    assert pending_results == [{"result": 1}]


### PR DESCRIPTION
## Summary

- surface terminal serving-app errors while waiting for async inference startup and pending results
- preserve the application exception type, message, and traceback and retain request cleanup
- add configurable `async_start_timeout` and `pending_results_timeout` parameters to `SessionJSON` and `Session`; both default to 600 seconds and accept `None` to disable the timeout
- add focused regression coverage for error, timeout, configuration, forwarding, and successful completion paths

## Verification

- `13 passed` in `tests/unit/test_inference_session_polling.py`
- `203 passed, 1 xpassed` in `tests/unit`
- `git diff --check`

Closes supervisely/issues#6111