### PR TITLE
Fix tag-based train/val split and centralize split method names

### DIFF
--- a/supervisely/app/widgets/__init__.py
+++ b/supervisely/app/widgets/__init__.py
@@ -52,6 +52,7 @@ from supervisely.app.widgets.select_tag_meta.select_tag_meta import SelectTagMet
 from supervisely.app.widgets.video_thumbnail.video_thumbnail import VideoThumbnail
 from supervisely.app.widgets.tabs.tabs import Tabs
 from supervisely.app.widgets.radio_tabs.radio_tabs import RadioTabs
+from supervisely.app.widgets.train_val_splits.split_method import SplitMethod
 from supervisely.app.widgets.train_val_splits.train_val_splits import TrainValSplits
 from supervisely.app.widgets.editor.editor import Editor
 from supervisely.app.widgets.textarea.textarea import TextArea

--- a/supervisely/app/widgets/train_val_splits/split_method.py
+++ b/supervisely/app/widgets/train_val_splits/split_method.py
@@ -1,0 +1,116 @@
+from typing import Iterable, List, Optional
+
+from supervisely.sly_logger import logger
+
+
+class SplitMethod:
+    """Canonical names of the train/val split methods.
+
+    The constants below are the titles of the tabs rendered by the ``TrainValSplits``
+    widget and, at the same time, the values returned by
+    :meth:`TrainValSplits.get_split_method`. Short names are the keys stored in
+    ``app_state.json`` and accepted in app options.
+
+    Always compare a split method against these constants (normalizing user input
+    with :meth:`parse`) instead of hardcoding a string literal: the tab title
+    ("Based on item tags") and the literal used in the validation code
+    ("Based on tags") had silently drifted apart, which disabled the tag-based
+    split without any error message.
+    """
+
+    RANDOM = "Random"
+    TAGS = "Based on item tags"
+    DATASETS = "Based on datasets"
+    COLLECTIONS = "Based on collections"
+
+    ALL = (RANDOM, TAGS, DATASETS, COLLECTIONS)
+
+    # Legacy titles that are still accepted on input (some app options and UIs use them).
+    # Kept as constants on purpose: they must stay recognized, but never be produced.
+    TAGS_LEGACY = "Based on tags"
+    LEGACY_TITLES = {TAGS_LEGACY: TAGS}
+
+    # Short names used in app_state.json and in app options
+    SHORT_NAMES = {
+        RANDOM: "random",
+        TAGS: "tags",
+        DATASETS: "datasets",
+        COLLECTIONS: "collections",
+    }
+
+    # Every spelling ever written in app options / app states, lowercased
+    _ALIASES = {
+        "random": RANDOM,
+        "tags": TAGS,
+        TAGS_LEGACY.lower(): TAGS,
+        TAGS.lower(): TAGS,
+        "datasets": DATASETS,
+        "based on datasets": DATASETS,
+        "collections": COLLECTIONS,
+        "based on collections": COLLECTIONS,
+    }
+
+    @classmethod
+    def parse(cls, split_method: str, raise_error: bool = True) -> Optional[str]:
+        """Normalize any known spelling of a split method to its canonical title.
+
+        :param split_method: Split method: a tab title, a short name or a legacy alias.
+        :type split_method: str
+        :param raise_error: If True, raise ValueError on an unknown method, otherwise return None.
+        :type raise_error: bool
+        :returns: One of the :class:`SplitMethod` constants, or None if unknown and raise_error is False.
+        :rtype: Optional[str]
+        """
+        method = cls._ALIASES.get(str(split_method).strip().lower())
+        if method is None and raise_error:
+            raise ValueError(
+                f"Unknown train/val split method: '{split_method}'. "
+                f"Expected one of {list(cls.ALL)} or their short names "
+                f"{list(cls.SHORT_NAMES.values())}"
+            )
+        return method
+
+    @classmethod
+    def parse_list(cls, split_methods: Iterable[str]) -> List[str]:
+        """Normalize a list of split methods, skipping (with a warning) the unknown ones.
+
+        :param split_methods: Split methods to normalize.
+        :type split_methods: Iterable[str]
+        :returns: Canonical split method titles, without duplicates, in the original order.
+        :rtype: List[str]
+        """
+        methods = []
+        for split_method in split_methods or []:
+            method = cls.parse(split_method, raise_error=False)
+            if method is None:
+                logger.warning(
+                    f"Unknown train/val split method: '{split_method}'. Skipping it. "
+                    f"Expected one of {list(cls.ALL)}"
+                )
+            elif method not in methods:
+                methods.append(method)
+        return methods
+
+    @classmethod
+    def matches(cls, split_method: str, expected: str) -> bool:
+        """Check that a split method is the expected one, ignoring spelling and aliases.
+
+        :param split_method: Split method to check.
+        :type split_method: str
+        :param expected: Expected split method, usually one of the :class:`SplitMethod` constants.
+        :type expected: bool
+        :returns: True if both refer to the same split method.
+        :rtype: bool
+        """
+        return cls.parse(split_method, raise_error=False) == cls.parse(expected)
+
+    @classmethod
+    def to_short(cls, split_method: str) -> str:
+        """Convert a split method to its short name used in app_state.json.
+
+        :param split_method: Split method: a tab title, a short name or a legacy alias.
+        :type split_method: str
+        :returns: Short name of the split method.
+        :rtype: str
+        """
+        return cls.SHORT_NAMES[cls.parse(split_method)]

--- a/supervisely/app/widgets/train_val_splits/train_val_splits.py
+++ b/supervisely/app/widgets/train_val_splits/train_val_splits.py
@@ -19,6 +19,7 @@ from supervisely.app.widgets.random_splits_table.random_splits_table import (
     RandomSplitsTable,
 )
 from supervisely.app.widgets.select_collection.select_collection import SelectCollection
+from supervisely.app.widgets.train_val_splits.split_method import SplitMethod
 from supervisely.app.widgets.select_dataset_tree.select_dataset_tree import (
     SelectDatasetTree,
 )
@@ -95,21 +96,21 @@ class TrainValSplits(Widget):
         contents = []
         tabs_descriptions = []
         if random_splits:
-            self._split_methods.append("Random")
+            self._split_methods.append(SplitMethod.RANDOM)
             tabs_descriptions.append("Shuffle data and split with defined probability")
             contents.append(self._get_random_content())
         if tags_splits:
-            self._split_methods.append("Based on item tags")
+            self._split_methods.append(SplitMethod.TAGS)
             tabs_descriptions.append(
                 f"{self._project_type.capitalize()} should have assigned train or val tag"
             )
             contents.append(self._get_tags_content())
         if datasets_splits:
-            self._split_methods.append("Based on datasets")
+            self._split_methods.append(SplitMethod.DATASETS)
             tabs_descriptions.append("Select one or several datasets for every split")
             contents.append(self._get_datasets_content())
         if collections_splits:
-            self._split_methods.append("Based on collections")
+            self._split_methods.append(SplitMethod.COLLECTIONS)
             tabs_descriptions.append("Select one or several collections for every split")
             contents.append(self._get_collections_content())
         if not self._split_methods:
@@ -286,7 +287,7 @@ class TrainValSplits(Widget):
 
         project_dir = tmp_project_dir if tmp_project_dir is not None else self._project_fs.directory
 
-        if split_method == "Random":
+        if split_method == SplitMethod.RANDOM:
             splits_counts = self._random_splits_table.get_splits_counts()
             train_count = splits_counts["train"]
             val_count = splits_counts["val"]
@@ -300,7 +301,7 @@ class TrainValSplits(Widget):
                 project_dir, new_train_count, new_val_count
             )
 
-        elif split_method == "Based on item tags":
+        elif split_method == SplitMethod.TAGS:
             train_tag_name = self._train_tag_select.get_selected_name()
             val_tag_name = self._val_tag_select.get_selected_name()
             add_untagged_to = self._untagged_select.get_value()
@@ -308,7 +309,7 @@ class TrainValSplits(Widget):
                 project_dir, train_tag_name, val_tag_name, add_untagged_to
             )
 
-        elif split_method == "Based on datasets":
+        elif split_method == SplitMethod.DATASETS:
             if self._project_id is not None:
                 self._train_ds_select: SelectDatasetTree
                 self._val_ds_select: SelectDatasetTree
@@ -336,7 +337,7 @@ class TrainValSplits(Widget):
             train_set, val_set = self._project_class.get_train_val_splits_by_dataset(
                 project_dir, train_ds_names, val_ds_names
             )
-        elif split_method == "Based on collections":
+        elif split_method == SplitMethod.COLLECTIONS:
             if self._project_id is None:
                 raise ValueError(
                     "You can not use collections_splits parameter without project_id parameter."
@@ -357,25 +358,18 @@ class TrainValSplits(Widget):
         return train_set, val_set
 
     def set_split_method(self, split_method: Literal["random", "tags", "datasets", "collections"]):
-        if split_method == "random":
-            split_method = "Random"
-        elif split_method == "tags":
-            split_method = "Based on item tags"
-        elif split_method == "datasets":
-            split_method = "Based on datasets"
-        elif split_method == "collections":
-            split_method = "Based on collections"
-        self._content.set_active_tab(split_method)
+        self._content.set_active_tab(SplitMethod.parse(split_method))
         StateJson().send_changes()
         DataJson().send_changes()
 
     def get_split_method(self) -> str:
+        """Returns the active split method, one of the :class:`SplitMethod` constants."""
         return self._content.get_active_tab()
 
     def set_random_splits(
         self, split: Literal["train", "training", "val", "validation"], percent: int
     ):
-        self._content.set_active_tab("Random")
+        self._content.set_active_tab(SplitMethod.RANDOM)
         if split == "train" or split == "training":
             self._random_splits_table.set_train_split_percent(percent)
         elif split == "val" or split == "validation":
@@ -392,7 +386,7 @@ class TrainValSplits(Widget):
     def set_tags_splits(
         self, train_tag: str, val_tag: str, untagged_action: Literal["train", "val", "ignore"]
     ):
-        self._content.set_active_tab("Based on item tags")
+        self._content.set_active_tab(SplitMethod.TAGS)
         self._train_tag_select.set_name(train_tag)
         self._val_tag_select.set_name(val_tag)
         self._untagged_select.set_value(untagged_action)
@@ -404,7 +398,7 @@ class TrainValSplits(Widget):
         return self._val_tag_select.get_selected_name()
 
     def set_datasets_splits(self, train_datasets: List[int], val_datasets: List[int]):
-        self._content.set_active_tab("Based on datasets")
+        self._content.set_active_tab(SplitMethod.DATASETS)
         self._train_ds_select.set_dataset_ids(train_datasets)
         self._val_ds_select.set_dataset_ids(val_datasets)
 
@@ -436,7 +430,7 @@ class TrainValSplits(Widget):
         return self._val_collections_select.get_selected_ids() or []
 
     def set_collections_splits(self, train_collections: List[int], val_collections: List[int]):
-        self._content.set_active_tab("Based on collections")
+        self._content.set_active_tab(SplitMethod.COLLECTIONS)
         self.set_collections_splits_by_ids("train", train_collections)
         self.set_collections_splits_by_ids("val", val_collections)
 

--- a/supervisely/nn/training/gui/gui.py
+++ b/supervisely/nn/training/gui/gui.py
@@ -15,7 +15,7 @@ import supervisely.io.fs as sly_fs
 import supervisely.io.json as sly_json
 from supervisely import Api, ProjectMeta, logger
 from supervisely._utils import is_production
-from supervisely.app.widgets import Button, Card, Stepper, Widget
+from supervisely.app.widgets import Button, Card, SplitMethod, Stepper, Widget
 from supervisely.geometry.bitmap import Bitmap
 from supervisely.geometry.graph import GraphNodes
 from supervisely.geometry.polygon import Polygon
@@ -744,7 +744,11 @@ class TrainGUI:
 
         # Check train val splits
         train_val_splits_settings = app_state.get("train_val_split")
-        if train_val_splits_settings.get("method") == "datasets":
+        # An app state without a split method is valid: the defaults are applied later
+        app_state_split_method = None
+        if train_val_splits_settings.get("method") is not None:
+            app_state_split_method = SplitMethod.parse(train_val_splits_settings["method"])
+        if app_state_split_method == SplitMethod.DATASETS:
             dataset_ids = []
             for parents, dataset in self._api.dataset.tree(self.project_id):
                 dataset_ids.append(dataset.id)
@@ -762,19 +766,19 @@ class TrainGUI:
                 raise ValueError(
                     f"Datasets with ids: {missing_datasets_text} not found in the project"
                 )
-        elif train_val_splits_settings.get("method") == "tags":
+        elif app_state_split_method == SplitMethod.TAGS:
             train_tag = train_val_splits_settings.get("train_tag")
             val_tag = train_val_splits_settings.get("val_tag")
             if not train_tag or not val_tag:
                 raise ValueError("train_tag and val_tag must be specified in tags split method")
-        elif train_val_splits_settings.get("method") == "random":
+        elif app_state_split_method == SplitMethod.RANDOM:
             split = train_val_splits_settings.get("split")
             percent = train_val_splits_settings.get("percent")
             if split not in ["train", "val"]:
                 raise ValueError("split must be 'train' or 'val'")
             if not isinstance(percent, int) or not 0 < percent < 100:
                 raise ValueError("percent must be an integer in range 1 to 99")
-        elif train_val_splits_settings.get("method") == "collections":
+        elif app_state_split_method == SplitMethod.COLLECTIONS:
             train_collections = train_val_splits_settings.get("train_collections", [])
             val_collections = train_val_splits_settings.get("val_collections", [])
             collection_ids = set()
@@ -1062,47 +1066,54 @@ class TrainGUI:
             return True  # Selector disabled by app options
 
         if train_val_splits_settings == {}:
-            available_methods = self.app_options.get("train_val_splits_methods", [])
-            if available_methods == []:
-                method = "random"
-                train_val_splits_settings = {"method": method, "split": "train", "percent": 80}
+            available_methods = self.train_val_splits_selector.available_split_methods
+            method = available_methods[0] if available_methods else SplitMethod.RANDOM
+            short_method = SplitMethod.to_short(method)
+            if method == SplitMethod.TAGS:
+                train_val_splits_settings = {
+                    "method": short_method,
+                    "train_tag": "train",
+                    "val_tag": "val",
+                    "untagged_action": "ignore",
+                }
+            elif method == SplitMethod.DATASETS:
+                train_val_splits_settings = {
+                    "method": short_method,
+                    "train_datasets": [],
+                    "val_datasets": [],
+                }
+            elif method == SplitMethod.COLLECTIONS:
+                train_val_splits_settings = {
+                    "method": short_method,
+                    "train_collections": [],
+                    "val_collections": [],
+                }
             else:
-                method = available_methods[0]
-                if method == "random":
-                    train_val_splits_settings = {"method": method, "split": "train", "percent": 80}
-                elif method == "tags":
-                    train_val_splits_settings = {
-                        "method": method,
-                        "train_tag": "train",
-                        "val_tag": "val",
-                        "untagged_action": "ignore",
-                    }
-                elif method == "datasets":
-                    train_val_splits_settings = {
-                        "method": method,
-                        "train_datasets": [],
-                        "val_datasets": [],
-                    }
+                train_val_splits_settings = {
+                    "method": SplitMethod.to_short(SplitMethod.RANDOM),
+                    "split": "train",
+                    "percent": 80,
+                }
 
-        split_method = train_val_splits_settings["method"]
-        if split_method == "random":
+        split_method = SplitMethod.parse(train_val_splits_settings["method"])
+        if split_method == SplitMethod.RANDOM:
             split = train_val_splits_settings["split"]
             percent = train_val_splits_settings["percent"]
             self.train_val_splits_selector.train_val_splits.set_random_splits(split, percent)
-        elif split_method == "tags":
+        elif split_method == SplitMethod.TAGS:
             train_tag = train_val_splits_settings["train_tag"]
             val_tag = train_val_splits_settings["val_tag"]
             untagged_action = train_val_splits_settings["untagged_action"]
             self.train_val_splits_selector.train_val_splits.set_tags_splits(
                 train_tag, val_tag, untagged_action
             )
-        elif split_method == "datasets":
+        elif split_method == SplitMethod.DATASETS:
             train_datasets = train_val_splits_settings["train_datasets"]
             val_datasets = train_val_splits_settings["val_datasets"]
             self.train_val_splits_selector.train_val_splits.set_datasets_splits(
                 train_datasets, val_datasets
             )
-        elif split_method == "collections":
+        elif split_method == SplitMethod.COLLECTIONS:
             train_collections = train_val_splits_settings["train_collections"]
             val_collections = train_val_splits_settings["val_collections"]
             self.train_val_splits_selector.train_val_splits.set_project_id_for_collections(

--- a/supervisely/nn/training/gui/train_val_splits_selector.py
+++ b/supervisely/nn/training/gui/train_val_splits_selector.py
@@ -1,7 +1,14 @@
 from typing import List
 
 from supervisely import Api, Project
-from supervisely.app.widgets import Button, Card, Container, Text, TrainValSplits
+from supervisely.app.widgets import (
+    Button,
+    Card,
+    Container,
+    SplitMethod,
+    Text,
+    TrainValSplits,
+)
 from supervisely.api.module_api import ApiField
 from supervisely.api.entities_collection_api import EntitiesCollectionInfo
 
@@ -41,17 +48,22 @@ class TrainValSplitsSelector:
         self.project_id = project_id
 
         # GUI Components
-        split_methods = self.app_options.get("train_val_split_methods", [])
+        split_methods = SplitMethod.parse_list(self._get_split_methods_option())
         if len(split_methods) == 0:
-            split_methods = ["Random", "Based on tags", "Based on datasets", "Based on collections"]
-        random_split = "Random" in split_methods
-        tag_split = "Based on tags" in split_methods
-        ds_split = "Based on datasets" in split_methods
-        coll_split = "Based on collections" in split_methods
+            split_methods = list(SplitMethod.ALL)
+        random_split = SplitMethod.RANDOM in split_methods
+        tag_split = SplitMethod.TAGS in split_methods
+        ds_split = SplitMethod.DATASETS in split_methods
+        coll_split = SplitMethod.COLLECTIONS in split_methods
 
+        self._available_split_methods = split_methods
         self.train_val_splits = TrainValSplits(project_id, None, random_split, tag_split, ds_split, collections_splits=coll_split)
 
         self._detect_splits(coll_split, ds_split)
+        if self.validator_text is None:
+            # Neither datasets nor collections split is enabled, so nothing was auto-detected
+            self.validator_text = Text("")
+            self.validator_text.hide()
         self.button = Button("Select")
         self.display_widgets.extend([self.train_val_splits, self.validator_text, self.button])
         # -------------------------------- #
@@ -65,6 +77,19 @@ class TrainValSplitsSelector:
             collapsable=self.app_options.get("collapsable", False),
         )
         self.card.lock()
+
+    @property
+    def available_split_methods(self) -> List[str]:
+        """Split methods enabled in this app, as :class:`SplitMethod` constants."""
+        return self._available_split_methods
+
+    def _get_split_methods_option(self) -> List[str]:
+        """Split methods allowed by app options, in any of the historically used keys."""
+        for key in ("train_val_split_methods", "train_val_splits_methods"):
+            methods = self.app_options.get(key, [])
+            if methods:
+                return methods
+        return self.app_options.get("train_val_splits_selector", {}).get("methods", [])
 
     @property
     def all_train_collections(self) -> List[EntitiesCollectionInfo]:
@@ -151,13 +176,19 @@ class TrainValSplitsSelector:
                 else:
                     tags_count[tag_name] = tag_total
 
-            if tags_count[train_tag] == 0:
+            if train_tag is None or val_tag is None:
+                self.validator_text.set(
+                    text="Train and val tags are not selected", status="error"
+                )
+                return False
+
+            if tags_count.get(train_tag, 0) == 0:
                 self.validator_text.set(
                     text=f"Train tag '{train_tag}' is not present in any images. {ensure_text}",
                     status="error",
                 )
                 return False
-            elif tags_count[val_tag] == 0:
+            elif tags_count.get(val_tag, 0) == 0:
                 self.validator_text.set(
                     text=f"Val tag '{val_tag}' is not present in any images. {ensure_text}",
                     status="error",
@@ -302,16 +333,20 @@ class TrainValSplitsSelector:
                 self.validator_text.set("Train and val collections are selected", status="success")
                 return True
 
-        if split_method == "Random":
+        if split_method == SplitMethod.RANDOM:
             is_valid = validate_random_split()
 
-        elif split_method == "Based on tags":
+        elif split_method == SplitMethod.TAGS:
             is_valid = validate_based_on_tags()
 
-        elif split_method == "Based on datasets":
+        elif split_method == SplitMethod.DATASETS:
             is_valid = validate_based_on_datasets()
-        elif split_method == "Based on collections":
+        elif split_method == SplitMethod.COLLECTIONS:
             is_valid = validate_based_on_collections()
+        else:
+            self.validator_text.set(
+                text=f"Unknown train/val split method: '{split_method}'", status="error"
+            )
 
         # @TODO: handle button correctly if validation fails. Do not unlock next card until validation passes if returned False
         self.validator_text.show()
@@ -321,6 +356,7 @@ class TrainValSplitsSelector:
         self.train_val_splits._project_fs = project
 
     def get_split_method(self) -> str:
+        """Returns the selected split method, one of the :class:`SplitMethod` constants."""
         return self.train_val_splits.get_split_method()
 
     def get_train_dataset_ids(self) -> List[int]:

--- a/supervisely/nn/training/train_app.py
+++ b/supervisely/nn/training/train_app.py
@@ -48,7 +48,7 @@ from supervisely._utils import abs_url, get_filename_from_headers
 from supervisely.api.entities_collection_api import EntitiesCollectionInfo
 from supervisely.api.file_api import FileInfo
 from supervisely.app import get_synced_data_dir, show_dialog
-from supervisely.app.widgets import Progress
+from supervisely.app.widgets import Progress, SplitMethod
 from supervisely.decorators.profile import timeit_with_result
 from supervisely.nn.benchmark import (
     InstanceSegmentationBenchmark,
@@ -1436,7 +1436,7 @@ class TrainApp:
         """
         dataset_infos = [dataset for _, dataset in self._api.dataset.tree(self.project_id)]
         if self.gui.train_val_splits_selector is not None:
-            if self.gui.train_val_splits_selector.get_split_method() == "Based on datasets":
+            if self.gui.train_val_splits_selector.get_split_method() == SplitMethod.DATASETS:
                 selected_ds_ids = (
                     self.gui.train_val_splits_selector.get_train_dataset_ids()
                     + self.gui.train_val_splits_selector.get_val_dataset_ids()
@@ -1964,7 +1964,7 @@ class TrainApp:
 
         split_method = self.gui.train_val_splits_selector.get_split_method()
         train_set, val_set = self._train_split, self._val_split
-        if split_method == "Based on datasets":
+        if split_method == SplitMethod.DATASETS:
             if project_id is None:
                 val_dataset_ids = self.gui.train_val_splits_selector.get_val_dataset_ids()
                 train_dataset_ids = self.gui.train_val_splits_selector.get_train_dataset_ids()
@@ -2486,15 +2486,15 @@ class TrainApp:
             return {}  # splits disabled in options
 
         split_method = self.gui.train_val_splits_selector.get_split_method()
-        train_val_splits = {"method": split_method.lower()}
-        if split_method == "Random":
+        train_val_splits = {"method": SplitMethod.to_short(split_method)}
+        if split_method == SplitMethod.RANDOM:
             train_val_splits.update(
                 {
                     "split": "train",
                     "percent": self.gui.train_val_splits_selector.train_val_splits.get_train_split_percent(),
                 }
             )
-        elif split_method == "Based on tags":
+        elif split_method == SplitMethod.TAGS:
             train_val_splits.update(
                 {
                     "train_tag": self.gui.train_val_splits_selector.train_val_splits.get_train_tag(),
@@ -2502,14 +2502,14 @@ class TrainApp:
                     "untagged_action": self.gui.train_val_splits_selector.train_val_splits.get_untagged_action(),
                 }
             )
-        elif split_method == "Based on datasets":
+        elif split_method == SplitMethod.DATASETS:
             train_val_splits.update(
                 {
                     "train_datasets": self.gui.train_val_splits_selector.train_val_splits.get_train_dataset_ids(),
                     "val_datasets": self.gui.train_val_splits_selector.train_val_splits.get_val_dataset_ids(),
                 }
             )
-        elif split_method == "Based on collections":
+        elif split_method == SplitMethod.COLLECTIONS:
             train_val_splits.update(
                 {
                     "train_collections": self.gui.train_val_splits_selector.get_train_collection_ids(),
@@ -2924,7 +2924,7 @@ class TrainApp:
                 app_session_id = self.task_id
                 if app_session_id == -1:
                     app_session_id = None
-                if self.gui.train_val_splits_selector.get_split_method() == "Based on datasets":
+                if self.gui.train_val_splits_selector.get_split_method() == SplitMethod.DATASETS:
                     train_info = {
                         "app_session_id": app_session_id,
                         "train_dataset_ids": train_dataset_ids,
@@ -3708,7 +3708,7 @@ class TrainApp:
         all_val_collections = self.gui.train_val_splits_selector.all_val_collections
         latest_train_collection = self.gui.train_val_splits_selector.latest_train_collection
         latest_val_collection = self.gui.train_val_splits_selector.latest_val_collection
-        if split_method == "Based on collections":
+        if split_method == SplitMethod.COLLECTIONS:
             current_selected_train_collection_ids = (
                 self.gui.train_val_splits_selector.train_val_splits.get_train_collections_ids()
             )


### PR DESCRIPTION
## Problem

Selecting **Based on item tags** on the *Train / Val Splits* step does nothing: the *Select* button does not switch to *Reselect*, the next step stays locked, and nothing shows up in the logs (only `POST /Button.../button_clicked_cb 200`). Reported from RT-DETRv2 training (task 1624203, app.supervisely.com); reproducible in every TrainApp-based app.

## Cause

The tab title created by the widget is `"Based on item tags"`, and `get_split_method()` returns exactly that title. `TrainValSplitsSelector.validate_step()` compared it against `"Based on tags"`, so no validation branch matched, `is_valid` stayed `False`, and `wrap_button_click()` returned silently without unlocking the next card.

The same drift exists elsewhere: `_get_train_val_splits_for_app_state()` stored `split_method.lower()` (`"based on datasets"`), while `load_from_app_state()` expects the short names (`"datasets"`), so restoring a non-random split from an app state silently did nothing.

## Changes

- New `SplitMethod` (`supervisely/app/widgets/train_val_splits/split_method.py`, exported from `supervisely.app.widgets`): canonical titles, the legacy `"Based on tags"` spelling that stays accepted on input, the short names used in `app_state.json`, and `parse()` / `parse_list()` / `matches()` / `to_short()` helpers.
- `validate_step()` dispatches on the constants and shows an explicit error for an unknown method instead of failing silently.
- Split methods from app options are normalized, so `"Based on tags"`, `"Based on item tags"` and `"tags"` all enable the tab; the nested `train_val_splits_selector.methods` option key is read as well (apps using it had it ignored).
- `app_state.json` stores the short name, loading and validating an app state normalizes the method, and the missing `collections` default branch was added.
- Tag validation no longer raises `KeyError` for a tag absent from project stats and reports unselected tags.
- `validator_text` is always initialized, even when neither the datasets nor the collections auto-detection runs.