### PR TITLE
Run annotation and geometry batches concurrently

### DIFF
--- a/supervisely/_utils.py
+++ b/supervisely/_utils.py
@@ -18,7 +18,18 @@ from collections import deque
 from datetime import datetime
 from functools import wraps
 from tempfile import gettempdir
-from typing import Any, Deque, Dict, List, Literal, Optional, Tuple
+from typing import (
+    Any,
+    Awaitable,
+    Callable,
+    Deque,
+    Dict,
+    List,
+    Literal,
+    Optional,
+    Sequence,
+    Tuple,
+)
 
 import numpy as np
 import requests
@@ -909,6 +920,94 @@ def run_coroutine(coroutine):
         return future.result()
     else:
         return loop.run_until_complete(coroutine)
+
+
+def get_semaphore_limit(semaphore, default: int = 10) -> int:
+    """
+    Number of permits a semaphore was configured with, used to size worker pools.
+
+    :class:`CrossLoopSemaphore` keeps it in ``_limit``; ``asyncio.Semaphore`` only exposes
+    ``_value``, which is the count still free and therefore right only while nothing is in
+    flight. Both are best effort, so an unreadable semaphore falls back to ``default``:
+    the value sizes a pool, it never controls how many requests actually run at once.
+
+    :param semaphore: Semaphore to inspect.
+    :type semaphore: :class:`CrossLoopSemaphore` or :class:`asyncio.Semaphore`
+    :param default: Value to return when the limit cannot be read.
+    :type default: int
+    :returns: Number of permits.
+    :rtype: int
+    """
+    for attr in ("_limit", "_value"):
+        value = getattr(semaphore, attr, None)
+        if isinstance(value, int) and value > 0:
+            return value
+    return default
+
+
+async def run_bounded(
+    coro_factories: Sequence[Callable[[], Awaitable[Any]]], limit: int
+) -> List[Any]:
+    """
+    Await coroutine factories keeping at most ``limit`` of them alive, results in input order.
+
+    Unlike ``asyncio.gather(*[factory() for factory in factories])`` this never builds one
+    task per item, so a job spanning hundreds of thousands of entities keeps a pool the
+    size of the throttle instead of a task list the size of the dataset.
+
+    Takes factories rather than coroutines because a coroutine is created eagerly: passing
+    coroutines would allocate them all upfront and leave the unstarted ones to be destroyed
+    with a "never awaited" warning if the run fails early.
+
+    The first failure cancels the remaining workers and propagates.
+
+    :param coro_factories: Callables that each return a fresh coroutine.
+    :type coro_factories: Sequence[Callable[[], Awaitable[Any]]]
+    :param limit: Maximum number of coroutines running at the same time.
+    :type limit: int
+    :returns: Results in the order of ``coro_factories``.
+    :rtype: List[Any]
+
+    :Usage Example:
+
+     .. code-block:: python
+
+        from functools import partial
+
+        from supervisely._utils import run_bounded
+
+        results = await run_bounded([partial(fetch, url) for url in urls], limit=10)
+    """
+    factories = list(coro_factories)
+    results: List[Any] = [None] * len(factories)
+    if not factories:
+        return results
+
+    next_index = 0
+
+    async def worker() -> None:
+        nonlocal next_index
+        while True:
+            # no await between the read and the bump, so workers cannot claim the same index
+            index = next_index
+            if index >= len(factories):
+                return
+            next_index += 1
+            results[index] = await factories[index]()
+
+    workers = [
+        asyncio.create_task(worker()) for _ in range(min(max(1, limit), len(factories)))
+    ]
+    try:
+        await asyncio.gather(*workers)
+    except BaseException:
+        for task in workers:
+            task.cancel()
+        # gather() propagates the first failure without touching its siblings; drain them
+        # here so no worker outlives this call and keeps issuing requests
+        await asyncio.gather(*workers, return_exceptions=True)
+        raise
+    return results
 
 
 def get_filename_from_headers(url):

--- a/supervisely/api/annotation_api.py
+++ b/supervisely/api/annotation_api.py
@@ -8,6 +8,7 @@ import asyncio
 import json
 from collections import defaultdict
 from copy import deepcopy
+from functools import partial
 from typing import (
     Any,
     Callable,
@@ -23,7 +24,7 @@ from uuid import uuid4
 
 from tqdm import tqdm
 
-from supervisely._utils import batched, run_coroutine
+from supervisely._utils import batched, get_semaphore_limit, run_bounded, run_coroutine
 from supervisely.annotation.annotation import Annotation, AnnotationJsonFields
 from supervisely.annotation.label import Label, LabelJsonFields
 from supervisely.annotation.tag import Tag
@@ -64,6 +65,19 @@ class AnnotationInfo(NamedTuple):
             ApiField.UPDATED_AT: self.updated_at,
             ApiField.DATASET_ID: self.dataset_id,
         }
+
+
+#: Server side cap on ``imageIds`` for the ``annotations.bulk.info`` endpoint.
+#: Larger batches are rejected with a 400 "must contain less than or equal to 100 items".
+BULK_INFO_MAX_BATCH_SIZE = 100
+
+#: Default ``imageIds`` per ``annotations.bulk.info`` request.
+#: Deliberately below the server cap: from about 60 ids up the server stops returning a
+#: stable order of tags inside an object, so identical requests yield annotations that
+#: differ byte for byte. The values are the same either way and tag order carries no
+#: meaning, but a reproducible download is worth more than the few percent that larger
+#: batches buy - the speed here comes from running batches concurrently, not from size.
+BULK_INFO_DEFAULT_BATCH_SIZE = 50
 
 
 class AnnotationApi(ModuleApi):
@@ -1824,10 +1838,12 @@ class AnnotationApi(ModuleApi):
         force_metadata_for_links: Optional[bool] = True,
         semaphore: Optional[asyncio.Semaphore] = None,
         figure_filters: Optional[List[Dict[str, Any]]] = None,
+        batch_size: int = BULK_INFO_DEFAULT_BATCH_SIZE,
     ) -> List[AnnotationInfo]:
         """
         Get list of AnnotationInfos for given dataset ID from API.
         This method is optimized for downloading a large number of small size annotations with a single API call.
+        Batches are requested concurrently, bounded by the semaphore.
 
         :param dataset_id: Dataset ID in Supervisely.
         :type dataset_id: int
@@ -1843,8 +1859,13 @@ class AnnotationApi(ModuleApi):
         :type semaphore: asyncio.Semaphore, optional
         :param figure_filters: Optional figure filters applied to labels in downloaded annotations. Uses the same filter format as `images.list`. See https://api.docs.supervisely.com/#tag/Figures/paths/~1figures.list/get for more details.
         :type figure_filters: List[Dict[str, Any]], optional
+        :param batch_size: Number of images per request, default :data:`BULK_INFO_DEFAULT_BATCH_SIZE`.
+                        Clamped to the server limit of :data:`BULK_INFO_MAX_BATCH_SIZE`. Raising it
+                        above the default costs reproducible tag order, see the constant.
+        :type batch_size: int, optional
         :returns: Information about Annotations.
         :rtype: :class:`List[AnnotationInfo]`
+        :raises RuntimeError: If the server returned no annotation for some of the requested images.
 
         :Usage Example:
 
@@ -1889,6 +1910,8 @@ class AnnotationApi(ModuleApi):
         if semaphore is None:
             semaphore = self._api.get_default_semaphore()
 
+        batch_size = max(1, min(batch_size, BULK_INFO_MAX_BATCH_SIZE))
+
         # use context to avoid redundant API calls
         context = self._api.optimization_context
         context_dataset_id = context.get("dataset_id")
@@ -1918,8 +1941,8 @@ class AnnotationApi(ModuleApi):
             semaphore=semaphore,
         )
 
-        id_to_ann = {}
-        for batch in batched(image_ids):
+        async def _process_batch(batch: List[int]) -> Dict[int, AnnotationInfo]:
+            """Fetch and assemble one batch of annotations. Returns image ID to AnnotationInfo."""
             json_data = {
                 ApiField.DATASET_ID: dataset_id,
                 ApiField.IMAGE_IDS: batch,
@@ -1927,6 +1950,8 @@ class AnnotationApi(ModuleApi):
                 ApiField.FORCE_METADATA_FOR_LINKS: force_metadata_for_links,
                 ApiField.INTEGER_COORDS: False,
             }
+            # the semaphore is held for the request only: the alpha mask download below takes
+            # it again on its own, and holding it across both would deadlock the pool
             async with semaphore:
                 results = await self._api.post_async("annotations.bulk.info", json=json_data)
                 results = results.json()
@@ -1960,18 +1985,37 @@ class AnnotationApi(ModuleApi):
                             label_idx
                         ].update({BITMAP: geometry})
 
+            batch_anns = {}
             for ann_dict in results:
                 # Convert annotation to pixel coordinate system
                 ann_dict[ApiField.ANNOTATION] = Annotation._to_pixel_coordinate_system_json(
                     ann_dict[ApiField.ANNOTATION]
                 )
                 ann_info = self._convert_json_info(ann_dict)
-                id_to_ann[ann_info.image_id] = ann_info
+                batch_anns[ann_info.image_id] = ann_info
 
             if progress_cb is not None:
                 progress_cb(len(batch))
-        ordered_results = [id_to_ann[image_id] for image_id in image_ids]
-        return ordered_results
+            return batch_anns
+
+        batches = list(batched(image_ids, batch_size))
+        per_batch = await run_bounded(
+            [partial(_process_batch, batch) for batch in batches],
+            limit=get_semaphore_limit(semaphore),
+        )
+
+        id_to_ann = {}
+        for batch_anns in per_batch:
+            id_to_ann.update(batch_anns)
+
+        missing = [image_id for image_id in image_ids if image_id not in id_to_ann]
+        if missing:
+            raise RuntimeError(
+                f"Dataset {dataset_id}: server returned no annotation for "
+                f"{len(missing)} of {len(image_ids)} requested images, "
+                f"first missing IDs: {missing[:10]}"
+            )
+        return [id_to_ann[image_id] for image_id in image_ids]
 
     def append_labels_group(
         self,

--- a/supervisely/api/entity_annotation/figure_api.py
+++ b/supervisely/api/entity_annotation/figure_api.py
@@ -7,6 +7,7 @@ import asyncio
 import json
 import re
 from collections import defaultdict
+from functools import partial
 from typing import (
     Any,
     AsyncGenerator,
@@ -24,7 +25,13 @@ import numpy as np
 from requests_toolbelt import MultipartDecoder, MultipartEncoder
 from tqdm import tqdm
 
-from supervisely._utils import batched, logger, run_coroutine
+from supervisely._utils import (
+    batched,
+    get_semaphore_limit,
+    logger,
+    run_bounded,
+    run_coroutine,
+)
 from supervisely.annotation.label import LabelingStatus
 from supervisely.api.module_api import ApiField, ModuleApi, RemoveableBulkModuleApi
 from supervisely.geometry.rectangle import Rectangle
@@ -739,17 +746,37 @@ class FigureApi(RemoveableBulkModuleApi):
             semaphore = self._api.get_default_semaphore()
 
         for batch_ids in batched(ids):
-            async with semaphore:
-                response = await self._api.post_async(
-                    "figures.bulk.download.geometry", {ApiField.IDS: batch_ids}
-                )
-                decoder = MultipartDecoder.from_response(response)
-                for part in decoder.parts:
-                    content_utf8 = part.headers[b"Content-Disposition"].decode("utf-8")
-                    # Find name="1245" preceded by a whitespace, semicolon or beginning of line.
-                    # The regex has 2 capture group: one for the prefix and one for the actual name value.
-                    figure_id = int(re.findall(r'(^|[\s;])name="(\d*)"', content_utf8)[0][1])
-                    yield figure_id, part.content
+            for figure_id, content in await self._download_geometries_batch_part(
+                batch_ids, semaphore
+            ):
+                yield figure_id, content
+
+    async def _download_geometries_batch_part(
+        self, batch_ids: List[int], semaphore: asyncio.Semaphore
+    ) -> List[Tuple[int, bytes]]:
+        """
+        Private method. Download geometries for a single batch of figure IDs.
+
+        :param batch_ids: Batch of figure IDs in Supervisely.
+        :type batch_ids: List[int]
+        :param semaphore: Semaphore to limit the number of concurrent downloads.
+        :type semaphore: asyncio.Semaphore
+        :returns: Pairs of figure ID and figure geometry.
+        :rtype: List[Tuple[int, bytes]]
+        """
+        async with semaphore:
+            response = await self._api.post_async(
+                "figures.bulk.download.geometry", {ApiField.IDS: batch_ids}
+            )
+        parts = []
+        decoder = MultipartDecoder.from_response(response)
+        for part in decoder.parts:
+            content_utf8 = part.headers[b"Content-Disposition"].decode("utf-8")
+            # Find name="1245" preceded by a whitespace, semicolon or beginning of line.
+            # The regex has 2 capture group: one for the prefix and one for the actual name value.
+            figure_id = int(re.findall(r'(^|[\s;])name="(\d*)"', content_utf8)[0][1])
+            parts.append((figure_id, part.content))
+        return parts
 
     async def download_geometries_batch_async(
         self,
@@ -796,17 +823,36 @@ class FigureApi(RemoveableBulkModuleApi):
                     )
                 )
         """
-        geometries = {}
-        async for idx, part in self._download_geometries_generator_async(ids, semaphore):
-            if progress_cb is not None:
-                progress_cb(len(part))
-            geometry_json = json.loads(part)
-            geometries[idx] = geometry_json
+        if semaphore is None:
+            semaphore = self._api.get_default_semaphore()
 
-        if len(geometries) != len(ids):
-            raise RuntimeError("Not all geometries were downloaded")
-        ordered_results = [geometries[i] for i in ids]
-        return ordered_results
+        async def _fetch_batch(batch_ids: List[int]) -> List[Tuple[int, dict]]:
+            parts = await self._download_geometries_batch_part(batch_ids, semaphore)
+            # reported here rather than after the pool drains, so the bar tracks the
+            # download instead of jumping to full at the end
+            for _, content in parts:
+                if progress_cb is not None:
+                    progress_cb(len(content))
+            return [(idx, json.loads(content)) for idx, content in parts]
+
+        batches = list(batched(ids))
+        per_batch = await run_bounded(
+            [partial(_fetch_batch, batch) for batch in batches],
+            limit=get_semaphore_limit(semaphore),
+        )
+
+        geometries = {}
+        for parts in per_batch:
+            for idx, geometry in parts:
+                geometries[idx] = geometry
+
+        missing = [i for i in ids if i not in geometries]
+        if missing:
+            raise RuntimeError(
+                f"Not all geometries were downloaded: {len(missing)} of {len(ids)} missing, "
+                f"first missing figure IDs: {missing[:10]}"
+            )
+        return [geometries[i] for i in ids]
 
     async def upload_geometries_batch_async(
         self,

--- a/supervisely/project/project.py
+++ b/supervisely/project/project.py
@@ -12,6 +12,7 @@ import random
 import shutil
 from collections import Counter, defaultdict, namedtuple
 from enum import Enum
+from functools import partial
 from pathlib import Path
 from typing import (
     Callable,
@@ -35,8 +36,10 @@ from supervisely._utils import (
     abs_url,
     batched,
     get_or_create_event_loop,
+    get_semaphore_limit,
     is_development,
     removesuffix,
+    run_bounded,
     snake_to_human,
 )
 from supervisely.annotation.annotation import (
@@ -6170,50 +6173,30 @@ async def _download_project_async(
                             ds_progress(1)
                 return to_download
 
-            async def run_tasks_with_semaphore_control(task_list: list, delay=0.05):
+            async def run_tasks_with_semaphore_control(task_list: list):
                 """
-                Execute tasks with semaphore control - create tasks only as semaphore permits become available.
+                Execute tasks with semaphore control - keep at most as many in flight as the
+                semaphore has permits.
                 task_list - list of coroutines or callables that create tasks
+
+                A failing task is logged and the rest keep going: one unreadable image must
+                not abandon the remaining items of the dataset.
                 """
                 random.shuffle(task_list)
-                running_tasks = set()
-                max_concurrent = getattr(semaphore, "_value", 10)
-
-                task_iter = iter(task_list)
                 completed_count = 0
 
-                while True:
-                    # Add new tasks while we have capacity
-                    while len(running_tasks) < max_concurrent:
-                        try:
-                            task_gen = next(task_iter)
-                            if callable(task_gen):
-                                task = asyncio.create_task(task_gen())
-                            else:
-                                task = asyncio.create_task(task_gen)
-                            running_tasks.add(task)
-                            await asyncio.sleep(delay)
-                        except StopIteration:
-                            break
+                async def guarded(task):
+                    nonlocal completed_count
+                    try:
+                        await (task() if callable(task) else task)
+                    except Exception as e:
+                        logger.error(f"Task error: {e}")
+                    completed_count += 1
 
-                    if not running_tasks:
-                        break
-
-                    # Wait for at least one task to complete
-                    done, running_tasks = await asyncio.wait(
-                        running_tasks, return_when=asyncio.FIRST_COMPLETED
-                    )
-
-                    # Process completed tasks
-                    for task in done:
-                        completed_count += 1
-                        try:
-                            await task
-                        except Exception as e:
-                            logger.error(f"Task error: {e}")
-
-                    # Clear the done set - this should be enough for memory cleanup
-                    done.clear()
+                await run_bounded(
+                    [partial(guarded, task) for task in task_list],
+                    limit=get_semaphore_limit(semaphore),
+                )
 
                 logger.debug(
                     f"{completed_count} tasks have been completed for dataset ID: {dataset.id}, Name: {dataset.name}"
@@ -6282,7 +6265,7 @@ async def _download_project_async(
                             progress_cb=ds_progress,
                         )
                         offset_tasks.append(offset_task)
-                    await run_tasks_with_semaphore_control(offset_tasks, 0.05)
+                    await run_tasks_with_semaphore_control(offset_tasks)
 
             tasks = []
             if resume_download is True:


### PR DESCRIPTION
## Summary

Three loops on the annotation download path issued their requests strictly one after another, so the time was round trips rather than work:

- `download_bulk_async` walked batches of image ids sequentially — the semaphore it held was gating a loop that had nothing to overlap
- `download_geometries_batch_async` did the same for figure geometries, which is where alpha mask projects spend their time
- the project download scheduler slept 50 ms per task it created, capping task creation at 20/s regardless of how fast the server answered, so a dataset of N items downloaded one by one could not finish sooner than `N * 50 ms` — 150 s for 3000 images

All three now go through `run_bounded()`, a small pool in `_utils.py` that keeps at most as many coroutines alive as the semaphore has permits and returns results in input order. It takes factories rather than coroutines so nothing is allocated for work a failure cancels, and it drains its workers on the way out instead of leaving them to keep issuing requests. `get_semaphore_limit()` sizes the pool — the old code read `getattr(semaphore, "_value", 10)`, which is the count of *free* permits and therefore shrank the pool arbitrarily under load.

## Numbers

Measured on three generated projects of 3000 images each — rectangle, polygon and bitmap per image, tags on both images and objects — 5 repetitions, median:

| | before | after | |
|---|---|---|---|
| `download_bulk_async`, small 800×450 | 10.64 s | **2.01 s** | 5.3× |
| `download_bulk_async`, large 2K | 14.31 s | **3.82 s** | 3.7× |
| `download_bulk_async`, mixed | 12.81 s | **3.03 s** | 4.2× |
| project download, 2K images one by one | 163.0 s | **50.6 s** | 3.2× |
| project download, mixed | 84.9 s | **27.5 s** | 3.1× |

Traffic is unchanged; the gain is entirely overlap. Downloaded annotations carry the same sha256 as before on every project, and the same hash across repeated runs.

## Batch size stays at 50

Raising it to the server cap of 100 looked like free speed, but from about 60 ids up `annotations.bulk.info` stops ordering tags inside an object consistently — identical requests return annotations that differ byte for byte (`supervisely/issues#6129`). Values are the same and tag order carries no meaning, but reproducible downloads are worth more than the few percent, and larger batches turned out to be *slower* on heavy annotations anyway (3.50 s vs 3.21 s). `batch_size` is now an explicit parameter with the reasoning recorded on the constant.

## Also

A missing annotation or geometry raises with the ids it could not get, instead of a bare `KeyError` or a bare "Not all geometries were downloaded".

Related: supervisely/issues#6129