### PR TITLE
Report upload progress and stopping phase in Live Training

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -73,7 +73,7 @@ def get_version():
     return version
 
 
-version = get_version()
+version = "6.99.999"  # hardcoded for testing fix-live-training-stop-upload-progress, was: get_version()
 
 
 INSTALL_REQUIRES = [

--- a/supervisely/nn/live_training/artifacts_utils.py
+++ b/supervisely/nn/live_training/artifacts_utils.py
@@ -1,12 +1,14 @@
 import os
 import shutil
 from pathlib import Path
-from typing import Optional, Dict
+from typing import Dict
 from datetime import datetime
 import supervisely as sly
 from supervisely import logger
 from supervisely.template.live_training.live_training_generator import LiveTrainingGenerator
+from supervisely.app.widgets import Progress
 import supervisely.io.json as sly_json
+import supervisely.io.fs as sly_fs
 from supervisely.nn.live_training.helpers import ClassMap
 import yaml
 
@@ -130,13 +132,24 @@ def upload_artifacts(
         has_logs = False
 
     logger.info("Uploading to Team Files")
-    api.file.upload_directory_fast(
-        team_id=team_id,
-        local_dir=str(output_dir),
-        remote_dir=remote_dir,
-        change_name_if_conflict=False,
-        replace_if_conflict=True
-    )
+    local_files = sly_fs.list_files_recursively(str(output_dir))
+    total_size = sum(sly_fs.get_file_size(file_path) for file_path in local_files)
+    upload_progress = Progress(hide_on_finish=True)
+    with upload_progress(
+        message="Uploading Live Training artifacts to Team Files",
+        total=total_size,
+        unit="B",
+        unit_scale=True,
+        unit_divisor=1024,
+    ) as pbar:
+        api.file.upload_directory_fast(
+            team_id=team_id,
+            local_dir=str(output_dir),
+            remote_dir=remote_dir,
+            change_name_if_conflict=False,
+            replace_if_conflict=True,
+            progress_cb=pbar.update,
+        )
 
     experiment_info = {
         "experiment_name": f"Live Training {task_type.capitalize()} - Task {task_id}",

--- a/supervisely/nn/live_training/live_training.py
+++ b/supervisely/nn/live_training/live_training.py
@@ -26,6 +26,7 @@ class Phase:
     WAITING_FOR_SAMPLES = "waiting_for_samples"
     INITIAL_TRAINING = "initial_training"
     TRAINING = "training"
+    STOPPING = "stopping"
 
 class LiveTraining:
     """Base implementation of an interactive/live training loop driven by requests (start/add sample/predict/status)."""
@@ -637,6 +638,7 @@ class LiveTraining:
 
             # Save checkpoint and state before upload
             logger.info("Received shutdown signal, saving checkpoint...")
+            self.phase = Phase.STOPPING
             self._process_requests_while_finishing("Training was stopped by user.")
             self._save_and_upload()
             sys.exit(0)


### PR DESCRIPTION
## Summary
- Stopping a Live Training task showed no progress in the platform UI during the final artifact upload — only log lines, no progress bar. `upload_directory_fast` was called without a `progress_cb`, unlike every other upload call site in the SDK (e.g. `TrainApp`).
- Added a `Progress` widget around the upload in `artifacts_utils.upload_artifacts`, reporting through the same channel (`ContentOrigin`) the platform already uses for `TrainApp`.
- Added `Phase.STOPPING`, set at the start of the shutdown signal handler before checkpoint save/upload begins, so `/status` reflects that a stop is in progress instead of showing the last training phase.

## Note
- The last commit (`02de5e7a`, "Hardcode package version for testing on dev") is a **temporary testing-only change** — pins the package version to `6.99.999` in `setup.py` so `pip install git+...@branch` reliably reinstalls during dev testing (avoids `get_version()`'s GitHub API round-trip and any version-comparison caching). **Must be reverted before merging.**

## Test plan
- [x] `py_compile` on both changed files
- [x] `flake8` clean on the changed lines (pre-existing issues elsewhere in the files left untouched)
- [x] Live unit test: real `supervisely` import, mocked `api`/`LiveTrainingGenerator`, confirmed `upload_directory_fast` receives a callable `progress_cb` and the widget emits a structured `event_type: progress` log entry
- [ ] Live end-to-end verification on a dev instance (stop a real Live Training session mid-upload, confirm the platform UI shows progress) — in progress via `supervisely-ecosystem/live-training-detection@test-stop-upload-progress-fix`

🤖 Generated with [Claude Code](https://claude.com/claude-code)