### PR TITLE
Add Trash Bin API: list and permanently empty archived entities

### DIFF
--- a/supervisely/api/api.py
+++ b/supervisely/api/api.py
@@ -64,6 +64,7 @@ import supervisely.api.role_api as role_api
 import supervisely.api.storage_api as storage_api
 import supervisely.api.task_api as task_api
 import supervisely.api.team_api as team_api
+import supervisely.api.trash_api as trash_api
 import supervisely.api.user_api as user_api
 import supervisely.api.video.video_api as video_api
 import supervisely.api.video_annotation_tool_api as video_annotation_tool_api
@@ -406,6 +407,7 @@ class Api:
         self.issues = issues_api.IssuesApi(self)
         self.entities_collection = entities_collection_api.EntitiesCollectionApi(self)
         self.webhook = webhook_api.WebhookApi(self)
+        self.trash = trash_api.TrashApi(self)
 
         self.retry_count = retry_count
         self.retry_sleep_sec = retry_sleep_sec

--- a/supervisely/api/dataset_api.py
+++ b/supervisely/api/dataset_api.py
@@ -175,6 +175,7 @@ class DatasetApi(UpdateableModule, RemoveableModuleApi):
         recursive: Optional[bool] = False,
         parent_id: Optional[int] = None,
         include_custom_data: Optional[bool] = False,
+        archived: Optional[Union[bool, str]] = None,
     ) -> List[DatasetInfo]:
         """
         Returns list of dataset in the given project, or list of nested datasets
@@ -193,6 +194,13 @@ class DatasetApi(UpdateableModule, RemoveableModuleApi):
         :type parent_id: Union[int, None], optional
         :param include_custom_data: If True, the response will include the `custom_data` field for each :class:`~supervisely.project.project.Dataset`.
         :type include_custom_data: bool, optional
+        :param archived: Which rows to return. ``None`` (default) omits the parameter
+                         entirely and keeps the server default of live entities only.
+                         ``True`` returns archived (Trash Bin) entities instead.
+                         ``'forever'`` also includes entities already queued for permanent
+                         removal, where the entity has that state; it is root only.
+                         Requires Supervisely instance 6.17.22 or newer.
+        :type archived: Optional[Union[bool, str]]
         :returns: List of all Datasets with information for the given Project.
         :rtype: :class:`List[DatasetInfo]`
 
@@ -254,6 +262,8 @@ class DatasetApi(UpdateableModule, RemoveableModuleApi):
         }
         if include_custom_data:
             data[ApiField.EXTRA_FIELDS] = [ApiField.CUSTOM_DATA]
+        if archived is not None:
+            data[ApiField.ARCHIVED] = archived
 
         return self.get_list_all_pages(method, data)
 

--- a/supervisely/api/module_api.py
+++ b/supervisely/api/module_api.py
@@ -523,6 +523,8 @@ class ApiField:
     """"""
     PRESERVE_PROJECT_CARD = "preserveProjectCard"
     """"""
+    ARCHIVED = "archived"
+    """"""
     GPU_INFO = "gpuInfo"
     """"""
     IS_PUBLIC = "isPublic"

--- a/supervisely/api/project_api.py
+++ b/supervisely/api/project_api.py
@@ -279,6 +279,7 @@ class ProjectApi(CloneableModuleApi, UpdateableModule, RemoveableModuleApi):
         filters: Optional[List[Dict[str, str]]] = None,
         fields: List[str] = [],
         team_id: Optional[int] = None,
+        archived: Optional[Union[bool, str]] = None,
     ) -> List[ProjectInfo]:
         """
         List of Projects in the given Workspace (without version info).
@@ -294,6 +295,13 @@ class ProjectApi(CloneableModuleApi, UpdateableModule, RemoveableModuleApi):
         :type fields: List[str]
         :param team_id: Team ID in which the Projects are located.
         :type team_id: int, optional
+        :param archived: Which rows to return. ``None`` (default) omits the parameter
+                         entirely and keeps the server default of live entities only.
+                         ``True`` returns archived (Trash Bin) entities instead.
+                         ``'forever'`` also includes entities already queued for permanent
+                         removal, where the entity has that state; it is root only.
+                         Requires Supervisely instance 6.17.22 or newer.
+        :type archived: Optional[Union[bool, str]]
         :returns: List of all projects in the workspace (without version info). See :meth:`info_sequence_for_listing`.
         :rtype: List[:class:`~supervisely.api.project_api.ProjectInfo`]
 
@@ -418,6 +426,8 @@ class ProjectApi(CloneableModuleApi, UpdateableModule, RemoveableModuleApi):
             data[ApiField.WORKSPACE_ID] = workspace_id
         if team_id is not None:
             data[ApiField.GROUP_ID] = team_id
+        if archived is not None:
+            data[ApiField.ARCHIVED] = archived
 
         return self.get_list_all_pages(method, data)
 

--- a/supervisely/api/team_api.py
+++ b/supervisely/api/team_api.py
@@ -202,12 +202,23 @@ class TeamApi(ModuleNoParent, UpdateableModule):
         """
         return "TeamInfo"
 
-    def get_list(self, filters: List[Dict[str, str]] = None) -> List[TeamInfo]:
+    def get_list(
+        self,
+        filters: List[Dict[str, str]] = None,
+        archived: Optional[Union[bool, str]] = None,
+    ) -> List[TeamInfo]:
         """
         List of all Teams on the Supervisely instance.
 
         :param filters: List of params to sort output Teams.
         :type filters: list, optional
+        :param archived: Which rows to return. ``None`` (default) omits the parameter
+                         entirely and keeps the server default of live entities only.
+                         ``True`` returns archived (Trash Bin) entities instead.
+                         ``'forever'`` also includes entities already queued for permanent
+                         removal, where the entity has that state; it is root only.
+                         Requires Supervisely instance 6.17.22 or newer.
+        :type archived: Optional[Union[bool, str]]
         :returns: List of all Teams with information.
         :rtype: List[:class:`~supervisely.api.team_api.TeamInfo`]
 
@@ -266,7 +277,10 @@ class TeamApi(ModuleNoParent, UpdateableModule):
                 #                  UsageInfo(plan='free')               )
                 # ]
         """
-        return self.get_list_all_pages("teams.list", {ApiField.FILTER: filters or []})
+        data = {ApiField.FILTER: filters or []}
+        if archived is not None:
+            data[ApiField.ARCHIVED] = archived
+        return self.get_list_all_pages("teams.list", data)
 
     def get_info_by_id(self, id: int, raise_error: Optional[bool] = False) -> TeamInfo:
         """

--- a/supervisely/api/trash_api.py
+++ b/supervisely/api/trash_api.py
@@ -1,0 +1,274 @@
+# coding: utf-8
+"""API for working with the Trash Bin"""
+
+from __future__ import annotations
+
+import time
+from typing import TYPE_CHECKING, Callable, Dict, List, NamedTuple, Optional
+
+from supervisely.sly_logger import logger
+
+if TYPE_CHECKING:
+    from supervisely.api.api import Api
+
+
+TEAM = "team"
+WORKSPACE = "workspace"
+PROJECT = "project"
+DATASET = "dataset"
+
+
+class TrashItem(NamedTuple):
+    """A single archived entity sitting in the Trash Bin."""
+
+    type: str
+    """Entity kind: ``team``, ``workspace``, ``project`` or ``dataset``."""
+    id: int
+    """Entity ID in Supervisely."""
+    name: str
+    """Entity name."""
+    team_id: Optional[int]
+    """ID of the Team the entity belongs to, if known."""
+    workspace_id: Optional[int]
+    """ID of the Workspace the entity belongs to, for workspaces and projects."""
+    project_id: Optional[int]
+    """ID of the Project the entity belongs to, for datasets."""
+
+
+class TrashApi:
+    """
+    API for listing and emptying the Trash Bin (the ``/server-trash`` page).
+
+    Removal in Supervisely is a two-step flow. ``*.archive`` (exposed in the SDK as
+    :func:`ProjectApi.remove`, :func:`DatasetApi.remove`, :func:`TeamApi.archive` and
+    :func:`WorkspaceApi.archive`) is a soft, reversible removal that moves an entity to the
+    Trash Bin. ``*.remove.permanently`` is the second, irreversible step. This class walks the
+    instance, finds everything already on the first step, and applies the second one.
+
+    Only Teams, Workspaces, Projects and Datasets are reachable over the public API. The Trash
+    Bin page also lists models, checkpoints, python notebooks and DTL archives; those have no
+    public API and are left untouched by :func:`clear`.
+    """
+
+    def __init__(self, api: "Api"):
+        self._api = api
+
+    def get_list(
+        self,
+        team_id: Optional[int] = None,
+        include_datasets: bool = True,
+    ) -> List[TrashItem]:
+        """
+        List everything currently in the Trash Bin.
+
+        The instance is walked top-down: archived Teams, then archived Workspaces inside the
+        Teams that remain, then archived Projects, then archived Datasets that are still
+        sitting inside live Projects. Nested entities are not listed separately from an
+        archived parent that already contains them — removing the parent removes them too.
+
+        :param team_id: Restrict the walk to a single Team. ``None`` walks every Team.
+        :type team_id: int, optional
+        :param include_datasets: Also look for archived Datasets inside live Projects. This
+                                 costs one API call per live Project, so pass ``False`` on a
+                                 large instance when only whole Projects matter.
+        :type include_datasets: bool, optional
+        :returns: Archived entities, parents before children.
+        :rtype: List[:class:`~supervisely.api.trash_api.TrashItem`]
+
+        :Usage Example:
+
+            .. code-block:: python
+
+                import os
+                from dotenv import load_dotenv
+
+                import supervisely as sly
+
+                # Load secrets and create API object from .env file (recommended)
+                # Learn more here: https://developer.supervisely.com/getting-started/basics-of-authentication
+                if sly.is_development():
+                    load_dotenv(os.path.expanduser("~/supervisely.env"))
+
+                api = sly.Api.from_env()
+
+                for item in api.trash.get_list():
+                    print(item.type, item.id, item.name)
+        """
+        items: List[TrashItem] = []
+
+        archived_teams = [
+            team
+            for team in self._api.team.get_list(archived=True)
+            if team.id != 1 and (team_id is None or team.id == team_id)
+        ]
+        for team in archived_teams:
+            items.append(TrashItem(TEAM, team.id, team.name, team.id, None, None))
+
+        removed_team_ids = {team.id for team in archived_teams}
+        live_teams = [
+            team
+            for team in self._api.team.get_list()
+            if team.id not in removed_team_ids and (team_id is None or team.id == team_id)
+        ]
+
+        for team in live_teams:
+            archived_workspaces = self._api.workspace.get_list(team.id, archived=True)
+            for workspace in archived_workspaces:
+                items.append(
+                    TrashItem(WORKSPACE, workspace.id, workspace.name, team.id, workspace.id, None)
+                )
+
+            removed_workspace_ids = {workspace.id for workspace in archived_workspaces}
+            for workspace in self._api.workspace.get_list(team.id):
+                if workspace.id in removed_workspace_ids:
+                    continue
+
+                archived_projects = self._api.project.get_list(workspace.id, archived=True)
+                for project in archived_projects:
+                    items.append(
+                        TrashItem(PROJECT, project.id, project.name, team.id, workspace.id, None)
+                    )
+
+                if not include_datasets:
+                    continue
+
+                removed_project_ids = {project.id for project in archived_projects}
+                for project in self._api.project.get_list(workspace.id):
+                    if project.id in removed_project_ids:
+                        continue
+                    for dataset in self._api.dataset.get_list(
+                        project.id, recursive=True, archived=True
+                    ):
+                        items.append(
+                            TrashItem(
+                                DATASET, dataset.id, dataset.name, team.id, workspace.id, project.id
+                            )
+                        )
+
+        return items
+
+    def clear(
+        self,
+        team_id: Optional[int] = None,
+        include_datasets: bool = True,
+        cleanup_unused: bool = True,
+        progress_cb: Optional[Callable] = None,
+    ) -> Dict[str, int]:
+        """
+        !!! WARNING !!!
+        Be careful, this method deletes data from the database, recovery is not possible.
+
+        Permanently remove everything in the Trash Bin. Available only to the instance
+        administrator (root user); a regular user token is not enough. Call :func:`get_list`
+        first and read what it returns — there is no second Trash Bin behind this one.
+
+        Team and Workspace removal runs in the background, so this method waits for each of
+        those tasks to reach a terminal status before moving on to the entities nested below.
+
+        :param team_id: Restrict the removal to a single Team. ``None`` empties the whole
+                        instance Trash Bin.
+        :type team_id: int, optional
+        :param include_datasets: Also remove archived Datasets sitting inside live Projects.
+        :type include_datasets: bool, optional
+        :param cleanup_unused: Trigger ``instance.data.cleanup-unused`` afterwards. Image and
+                               video data is reference-counted, so removing an entity drops
+                               its references and the storage behind them is reclaimed by the
+                               garbage collector, which also runs daily on its own.
+        :type cleanup_unused: bool, optional
+        :param progress_cb: Function for tracking removal progress, called with the number of
+                            entities removed by each API call.
+        :type progress_cb: Callable, optional
+        :returns: Number of entities removed, keyed by kind.
+        :rtype: Dict[str, int]
+
+        :Usage Example:
+
+            .. code-block:: python
+
+                import os
+                from dotenv import load_dotenv
+
+                import supervisely as sly
+
+                # Load secrets and create API object from .env file (recommended)
+                # Learn more here: https://developer.supervisely.com/getting-started/basics-of-authentication
+                if sly.is_development():
+                    load_dotenv(os.path.expanduser("~/supervisely.env"))
+
+                api = sly.Api.from_env()
+
+                print(api.trash.clear())
+                # Output: {'team': 1, 'workspace': 0, 'project': 4, 'dataset': 2}
+        """
+        items = self.get_list(team_id=team_id, include_datasets=include_datasets)
+        removed = {TEAM: 0, WORKSPACE: 0, PROJECT: 0, DATASET: 0}
+
+        by_type: Dict[str, List[TrashItem]] = {TEAM: [], WORKSPACE: [], PROJECT: [], DATASET: []}
+        for item in items:
+            by_type[item.type].append(item)
+
+        # Teams and Workspaces take everything nested inside them, and drain in the background.
+        for kind, api_module in ((TEAM, self._api.team), (WORKSPACE, self._api.workspace)):
+            ids = [item.id for item in by_type[kind]]
+            if not ids:
+                continue
+            for response in api_module.remove_permanently(ids, progress_cb=progress_cb):
+                self._wait_for_task(response.get("taskId"))
+            removed[kind] = len(ids)
+
+        # `preserveProjectCard` defaults to True on the server, which keeps the project row in
+        # the Trash Bin and only drops its data. `ProjectApi.remove_permanently` sends False.
+        project_ids = [item.id for item in by_type[PROJECT]]
+        if project_ids:
+            self._api.project.remove_permanently(project_ids, progress_cb=progress_cb)
+            removed[PROJECT] = len(project_ids)
+
+        dataset_ids = [item.id for item in by_type[DATASET]]
+        if dataset_ids:
+            self._api.dataset.remove_permanently(dataset_ids, progress_cb=progress_cb)
+            removed[DATASET] = len(dataset_ids)
+
+        if cleanup_unused and any(removed.values()):
+            self.cleanup_unused()
+
+        return removed
+
+    def cleanup_unused(self) -> Optional[int]:
+        """
+        Trigger the instance-wide garbage collector for unreferenced data. Root only.
+
+        Storage is not released the moment a removal finishes: data is reference-counted by
+        content hash, and the collector applies a grace window before reclaiming an object.
+        Running this twice in a row does not shorten that window.
+
+        :returns: ID of the background task, or ``None`` if the instance does not expose the
+                  method (added in Supervisely 6.17.17).
+        :rtype: Optional[int]
+        """
+        try:
+            response = self._api.post("instance.data.cleanup-unused", {})
+        except Exception as e:
+            logger.warning(f"Could not trigger cleanup of unused data: {e}")
+            return None
+        return response.json().get("taskId")
+
+    def _wait_for_task(
+        self, task_id: Optional[int], poll_sec: int = 5, timeout_sec: int = 3600
+    ) -> None:
+        """Block until a background removal task reaches a terminal status."""
+        if task_id is None:
+            return
+        deadline = time.monotonic() + timeout_sec
+        while True:
+            status = self._api.task.get_status(task_id)
+            if status in (self._api.task.Status.FINISHED, self._api.task.Status.ERROR):
+                if status is self._api.task.Status.ERROR:
+                    logger.warning(f"Removal task {task_id} finished with status 'error'")
+                return
+            if time.monotonic() >= deadline:
+                logger.warning(
+                    f"Removal task {task_id} did not finish within {timeout_sec}s, "
+                    f"last status '{status}'. It keeps running on the server."
+                )
+                return
+            time.sleep(poll_sec)

--- a/supervisely/api/workspace_api.py
+++ b/supervisely/api/workspace_api.py
@@ -74,7 +74,10 @@ class WorkspaceApi(ModuleApi, UpdateableModule):
         return "WorkspaceInfo"
 
     def get_list(
-        self, team_id: int, filters: Optional[List[Dict[str, str]]] = None
+        self,
+        team_id: int,
+        filters: Optional[List[Dict[str, str]]] = None,
+        archived: Optional[Union[bool, str]] = None,
     ) -> List[WorkspaceInfo]:
         """
         List of Workspaces in the given Team on the Supervisely instance.
@@ -83,6 +86,13 @@ class WorkspaceApi(ModuleApi, UpdateableModule):
         :type team_id: int
         :param filters: List of params to sort output Workspaces.
         :type filters: List[Dict[str, str]], optional
+        :param archived: Which rows to return. ``None`` (default) omits the parameter
+                         entirely and keeps the server default of live entities only.
+                         ``True`` returns archived (Trash Bin) entities instead.
+                         ``'forever'`` also includes entities already queued for permanent
+                         removal, where the entity has that state; it is root only.
+                         Requires Supervisely instance 6.17.22 or newer.
+        :type archived: Optional[Union[bool, str]]
         :returns: List of all Workspaces with information for the given Team.
         :rtype: List[:class:`~supervisely.api.workspace_api.WorkspaceInfo`]
 
@@ -136,10 +146,10 @@ class WorkspaceApi(ModuleApi, UpdateableModule):
                 #                       updated_at='2020-05-20T15:01:54.172Z')
                 # ]
         """
-        return self.get_list_all_pages(
-            "workspaces.list",
-            {ApiField.TEAM_ID: team_id, ApiField.FILTER: filters or []},
-        )
+        data = {ApiField.TEAM_ID: team_id, ApiField.FILTER: filters or []}
+        if archived is not None:
+            data[ApiField.ARCHIVED] = archived
+        return self.get_list_all_pages("workspaces.list", data)
 
     def get_info_by_id(self, id: int, raise_error: Optional[bool] = False) -> WorkspaceInfo:
         """


### PR DESCRIPTION
## Why

The public API has had the two-step removal flow since 6.17.17 (`*.archive` then `*.remove.permanently`) and the `archived` flag on the v3 list methods since 6.17.22. The SDK exposed neither, so there was no way to enumerate what is actually in the Trash Bin — `remove_permanently` could only be pointed at IDs the caller already knew. Emptying the Trash Bin from Python meant hand-rolling `api.post` calls against four list methods.

## What changed

- `archived` parameter on `team`/`workspace`/`project`/`dataset` `get_list`. The key is omitted from the request body unless it is set, so nothing changes for existing callers or older instances.
- `api.trash.get_list()` — walks the instance top-down and returns archived Teams, Workspaces, Projects and Datasets as `TrashItem` tuples, skipping entities already covered by an archived parent.
- `api.trash.clear()` — permanently removes all of them, waits on the background Team and Workspace removal tasks before descending, then triggers `instance.data.cleanup-unused`. Root only, irreversible, documented as such.

Models, checkpoints, python notebooks and DTL archives also show on the Trash Bin page but have no public API, so `clear()` leaves them alone — called out in the class docstring.